### PR TITLE
fix + refactor: stream timeouts on agent loops; drop redundant block_config placeholders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,6 @@ serde_json = "1"
 getrandom = { version = "0.2", features = ["js"] }
 # uuid v4 needs a JS RNG source on wasm32
 uuid = { version = "1", features = ["v4", "js"] }
+# tokio time feature for per-frame stream timeouts in agent.rs.
+# The `time` feature compiles to wasm32 (uses JS timers under wasm-bindgen).
+tokio = { version = "1", features = ["time", "sync"], default-features = false }

--- a/src/blocks/agent.rs
+++ b/src/blocks/agent.rs
@@ -29,9 +29,11 @@
 //!    `event: done` with `reason: "stop"` and terminate.
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::{pin_mut, StreamExt};
+use tokio::time::timeout;
 use serde::Deserialize;
 use wafer_block::{
     block::Block,
@@ -52,6 +54,11 @@ use wafer_core::interfaces::llm::service::{
 
 /// Maximum agent-loop rounds before giving up.
 const MAX_ROUNDS: u32 = 5;
+
+/// Per-frame timeout for the LLM body stream. Matches the old sw-llm-bridge.js
+/// 5-minute budget. If no bytes arrive within this window the stream is
+/// considered stalled and the request is terminated with an error event.
+const STREAM_FRAME_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// The agent block's own chat endpoint.
 const AGENT_CHAT_PATH: &str = "/b/agent/chat";
@@ -229,19 +236,29 @@ async fn handle_load_model(ctx: &dyn Context, input: InputStream) -> OutputStrea
     pin_mut!(stream);
 
     let mut had_error: Option<String> = None;
-    while let Some(bytes) = stream.next().await {
-        match serde_json::from_slice::<Result<LoadProgress, LlmError>>(&bytes) {
-            Ok(Ok(progress)) => {
-                let data = serde_json::to_value(&progress).unwrap_or(serde_json::Value::Null);
-                sse_body.push_str(&encode_sse_event("load_progress", &data));
-            }
-            Ok(Err(e)) => {
-                had_error = Some(format!("{e}"));
+    loop {
+        match timeout(STREAM_FRAME_TIMEOUT, stream.next()).await {
+            Err(_elapsed) => {
+                had_error = Some("llm load timed out".to_string());
                 break;
             }
-            Err(e) => {
-                had_error = Some(format!("deserialize load progress: {e}"));
-                break;
+            Ok(None) => break,
+            Ok(Some(bytes)) => {
+                match serde_json::from_slice::<Result<LoadProgress, LlmError>>(&bytes) {
+                    Ok(Ok(progress)) => {
+                        let data =
+                            serde_json::to_value(&progress).unwrap_or(serde_json::Value::Null);
+                        sse_body.push_str(&encode_sse_event("load_progress", &data));
+                    }
+                    Ok(Err(e)) => {
+                        had_error = Some(format!("{e}"));
+                        break;
+                    }
+                    Err(e) => {
+                        had_error = Some(format!("deserialize load progress: {e}"));
+                        break;
+                    }
+                }
             }
         }
     }
@@ -366,11 +383,20 @@ async fn run_agent_loop(
         let mut finish_reason: Option<FinishReason> = None;
         let mut round_error: Option<String> = None;
 
-        'chunks: while let Some(bytes) = stream.next().await {
+        'chunks: loop {
+            let frame = match timeout(STREAM_FRAME_TIMEOUT, stream.next()).await {
+                Err(_elapsed) => {
+                    round_error = Some("llm stream timed out".to_string());
+                    break 'chunks;
+                }
+                Ok(None) => break 'chunks,
+                Ok(Some(bytes)) => bytes,
+            };
+
             let item = match serde_json::from_slice::<Result<
                 wafer_core::interfaces::llm::service::ChatChunk,
                 LlmError,
-            >>(&bytes)
+            >>(&frame)
             {
                 Ok(item) => item,
                 Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,35 +111,13 @@ pub async fn initialize() -> Result<(), JsValue> {
                 )
             }),
         )
-        // Placeholder config for the auth block. gizza-ai runs anonymously;
-        // OAuth sign-in is never exercised. The required-config validator
-        // rejects empty strings though, so feed non-empty placeholders.
-        // Plan C tightens this (make the auth block accept empty OAuth
-        // fields as "provider disabled").
         .block_config(
             "suppers-ai/auth",
             serde_json::json!({
                 "SUPPERS_AI__AUTH__JWT_SECRET": "gizza-mvp-dev-jwt-secret-not-for-production",
-                "SUPPERS_AI__AUTH__ALLOWED_EMAIL_DOMAINS": "*",
                 "SUPPERS_AI__AUTH__ADMIN_EMAIL": "admin@gizza.local",
                 "SUPPERS_AI__AUTH__ADMIN_PASSWORD": "admin",
                 "SUPPERS_AI__AUTH__INTERNAL_SECRET": "gizza-mvp-dev-internal-secret",
-                "SUPPERS_AI__AUTH__OAUTH_REDIRECT_URI": "http://localhost:8000/b/auth/oauth/callback",
-                "SUPPERS_AI__AUTH__OAUTH_GOOGLE_CLIENT_ID": "disabled",
-                "SUPPERS_AI__AUTH__OAUTH_GOOGLE_CLIENT_SECRET": "disabled",
-                "SUPPERS_AI__AUTH__OAUTH_GITHUB_CLIENT_ID": "disabled",
-                "SUPPERS_AI__AUTH__OAUTH_GITHUB_CLIENT_SECRET": "disabled",
-                "SUPPERS_AI__AUTH__OAUTH_MICROSOFT_CLIENT_ID": "disabled",
-                "SUPPERS_AI__AUTH__OAUTH_MICROSOFT_CLIENT_SECRET": "disabled",
-            }),
-        )
-        .block_config(
-            "suppers-ai/email",
-            serde_json::json!({
-                "SUPPERS_AI__EMAIL__MAILGUN_API_KEY": "disabled",
-                "SUPPERS_AI__EMAIL__MAILGUN_DOMAIN": "disabled",
-                "SUPPERS_AI__EMAIL__MAILGUN_FROM": "noreply@gizza.local",
-                "SUPPERS_AI__EMAIL__MAILGUN_REPLY_TO": "noreply@gizza.local",
             }),
         )
         .block_config(
@@ -147,13 +125,6 @@ pub async fn initialize() -> Result<(), JsValue> {
             serde_json::json!({
                 "SUPPERS_AI__LLM__DEFAULT_PROVIDER": "suppers-ai/local-llm",
                 "SUPPERS_AI__LLM__DEFAULT_MODEL": "Qwen2.5-1.5B-Instruct-q4f32_1-MLC",
-            }),
-        )
-        .block_config(
-            "suppers-ai/provider-llm",
-            serde_json::json!({
-                "SUPPERS_AI__PROVIDER_LLM__OPENAI_KEY": "disabled",
-                "SUPPERS_AI__PROVIDER_LLM__ANTHROPIC_KEY": "disabled",
             }),
         )
         .add_route("/", "gizza-ai/ui", RouteAccess::Public)
@@ -182,35 +153,6 @@ pub async fn initialize() -> Result<(), JsValue> {
             ],
         }),
     );
-
-    // 6a-bis. Override the site-main flow with inline step config for
-    // wafer-run/security-headers. That block reads its `csp` from the
-    // flow-step config, not from block_configs — the default CSP has
-    // only `'self' 'unsafe-inline'` which blocks WebLLM's jsdelivr import.
-    //
-    // SolobaseBuilder's `.block_config("wafer-run/security-headers", ...)`
-    // was silently ineffective for this reason. Plan C follow-up: make
-    // security-headers also consult block_configs, or expose a clean
-    // SolobaseBuilder::csp(...) helper.
-    wafer.add_flow_json(r##"{
-        "id": "site-main",
-        "name": "Site Main (gizza-ai)",
-        "version": "0.1.0",
-        "description": "Top-level HTTP dispatch with gizza-ai CSP.",
-        "steps": [
-            { "id": "security-headers", "block": "wafer-run/security-headers", "config": {
-                "csp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' https:; connect-src 'self' https://cdn.jsdelivr.net https://esm.run https://huggingface.co https://raw.githubusercontent.com https://*.huggingface.co https://*.hf.co https://*.xethub.hf.co; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
-            }},
-            { "id": "cors", "block": "wafer-run/cors" },
-            { "id": "readonly-guard", "block": "wafer-run/readonly-guard" },
-            { "id": "router", "block": "wafer-run/router" }
-        ],
-        "config": { "on_error": "stop" },
-        "config_map": {
-            "routes": { "target": "wafer-run/router", "key": "routes" }
-        }
-    }"##)
-    .map_err(|e| JsValue::from_str(&format!("register gizza site-main: {e}")))?;
 
     // 6b. Register the SW-side external-asset loader before start so any
     // block init that triggers an asset load sees the real loader (not


### PR DESCRIPTION
Two small followups now that solobase PR #15 is on main.

## 1. Agent-stream timeouts (\`src/blocks/agent.rs\`)

After PR #3 dropped \`sw-llm-bridge.js\` (which had an explicit 5-min \`setTimeout\` per stream), \`run_agent_loop\` and \`handle_load_model\` drove \`stream.next().await\` unbounded. If \`BrowserLlmService\` hangs mid-stream (WebGPU stall, etc.) the agent request holds the SSE connection open forever. Wrap each \`stream.next()\` in \`tokio::time::timeout(STREAM_FRAME_TIMEOUT, ...)\` with a 5-min budget — matches the old bridge timeout. On timeout emit a structured \`done\`/\`load_done\` error frame and break the loop. Added \`tokio = { version = \"1\", features = [\"time\", \"sync\"], default-features = false }\` under the wasm32 dep set.

Addresses the 75-scored finding from PR #3's code review (below the 80 auto-flag threshold but a real regression).

## 2. Drop redundant block_config placeholders (\`src/lib.rs\`)

Solobase PR #15 made admin-configurable vars \`.optional()\` (so empty = "disabled", no startup validation error) and wired \`wafer-block-security-headers\` to honour \`block_config.csp\` at \`lifecycle(Init)\`. Both made local workarounds unnecessary:

- Strip the \`suppers-ai/auth\` block_config to only the 4 vars gizza actually sets (\`JWT_SECRET\`, \`ADMIN_EMAIL\`, \`ADMIN_PASSWORD\`, \`INTERNAL_SECRET\`); drop every \`\"disabled\"\` OAuth placeholder + \`ALLOWED_EMAIL_DOMAINS\` + \`OAUTH_REDIRECT_URI\`.
- Drop the entire \`suppers-ai/email\` block_config (all Mailgun vars optional).
- Drop the entire \`suppers-ai/provider-llm\` block_config (OpenAI/Anthropic keys optional).
- Remove the \`wafer.add_flow_json(r##\"...site-main...\"##)\` override whose only purpose was inlining the CSP into the security-headers flow-step config. The existing \`.block_config(\"wafer-run/security-headers\", ...)\` earlier in the builder chain is now the sole CSP path.

Net: \`src/lib.rs\` loses 58 lines.

## Test plan
- [x] \`cargo check --target wasm32-unknown-unknown\` clean
- [ ] Manual: chat + model-load flows (not run — heavyweight WebGPU/model download)

🤖 Generated with [Claude Code](https://claude.ai/code)