### PR TITLE
chore: drop unused tokio sync feature; clarify timeout scope

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,4 +55,4 @@ getrandom = { version = "0.2", features = ["js"] }
 uuid = { version = "1", features = ["v4", "js"] }
 # tokio time feature for per-frame stream timeouts in agent.rs.
 # The `time` feature compiles to wasm32 (uses JS timers under wasm-bindgen).
-tokio = { version = "1", features = ["time", "sync"], default-features = false }
+tokio = { version = "1", features = ["time"], default-features = false }

--- a/src/blocks/agent.rs
+++ b/src/blocks/agent.rs
@@ -55,9 +55,13 @@ use wafer_core::interfaces::llm::service::{
 /// Maximum agent-loop rounds before giving up.
 const MAX_ROUNDS: u32 = 5;
 
-/// Per-frame timeout for the LLM body stream. Matches the old sw-llm-bridge.js
-/// 5-minute budget. If no bytes arrive within this window the stream is
-/// considered stalled and the request is terminated with an error event.
+/// Per-frame timeout for the LLM body stream.
+///
+/// Wraps each `stream.next()` — resets on every frame. That differs
+/// semantically from the old `sw-llm-bridge.js` `setTimeout(300_000)` which
+/// capped the entire request. In practice both catch the same failure mode
+/// (GPU stall produces zero frames); a healthy stream emits tokens every
+/// ~0–1s and never approaches the budget.
 const STREAM_FRAME_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// The agent block's own chat endpoint.


### PR DESCRIPTION
Two low-severity followups from PR #4's code review (both scored below the 80 auto-flag threshold but worth bundling).

- `Cargo.toml`: tokio wasm32 dep had `features = ["time", "sync"]`; `agent.rs` only imports `tokio::time::timeout`. Drop `sync` to slim the wasm bundle.
- `agent.rs`: `STREAM_FRAME_TIMEOUT` comment claimed equivalence with the old `sw-llm-bridge.js` 5-minute budget. The old bridge used a per-request timeout; the new code is per-frame (resets on each chunk). In practice both catch GPU stalls identically, but the comment should not claim semantic equivalence.

Test plan:
- [x] `cargo check --target wasm32-unknown-unknown` clean

🤖 Generated with [Claude Code](https://claude.ai/code)