### PR TITLE
migrate to solobase-cli (Phase E part 3)

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,52 +1,6 @@
 default:
     @just --list
 
-# Build WASM skill blocks.
-build-skills:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    for dir in blocks/*/; do
-        if [ -f "$dir/Cargo.toml" ]; then
-            echo "Building $dir"
-            (cd "$dir" && /home/joris/Programs/suppers-ai/workspace/wafer-run/target/release/wafer build)
-        fi
-    done
-
-# Build the main gizza-ai wasm.
-build-wasm: build-skills
-    wasm-pack build --target web --out-dir pkg
-
-# Assemble dist/ from site/ + pkg/ + solobase-browser framework assets.
-#
-# solobase-browser's `export-assets` bin vendors sql.js, writes the
-# parameterized sw.js/loader.js/index.html templates, content-hashes
-# the wasm-pack output, and renders the templates with the given
-# --app-name / --app-title / --boot-redirect placeholders. We then
-# overwrite the default index.html with gizza's branded one and add
-# gizza's UI scripts.
-build: build-wasm
-    #!/usr/bin/env bash
-    set -euo pipefail
-    rm -rf dist
-    mkdir -p dist
-    cp pkg/gizza_ai.js pkg/gizza_ai_bg.wasm dist/
-    # wasm-pack emits `snippets/` referenced from the wasm-bindgen output.
-    cp -r pkg/snippets dist/
-    cargo run --manifest-path ../solobase/Cargo.toml -p solobase-browser --release --bin export-assets -- dist/ \
-        --repo-dir "$(pwd)" \
-        --app-name gizza-ai \
-        --app-title "Gizza AI" \
-        --boot-redirect / \
-        --extra-bypass-prefix "/gizza-app.js,/gizza.css"
-    # Gizza-branded index.html + app JS overwrite the framework defaults.
-    # The page-side WebLLM engine ships with solobase-browser at
-    # /webllm-engine.js (bypassed by the framework's default SW list).
-    cp site/index.html site/gizza-app.js site/gizza.css dist/
-
-# Serve dist/ on localhost:8000.
-serve: build
-    python3 -m http.server --directory dist 8000
-
 # Run the e2e smoke test.
 test:
     cd tests && npx playwright test

--- a/solobase.toml
+++ b/solobase.toml
@@ -1,0 +1,19 @@
+[app]
+name = "gizza-ai"
+title = "Gizza AI"
+boot_redirect = "/"
+
+[assets]
+extra_bypass_prefix = ["/gizza-app.js", "/gizza.css"]
+
+[[assets.overlay]]
+from = "site/index.html"
+to = "index.html"
+
+[[assets.overlay]]
+from = "site/gizza-app.js"
+to = "gizza-app.js"
+
+[[assets.overlay]]
+from = "site/gizza.css"
+to = "gizza.css"

--- a/solobase.toml
+++ b/solobase.toml
@@ -3,6 +3,9 @@ name = "gizza-ai"
 title = "Gizza AI"
 boot_redirect = "/"
 
+[solobase]
+manifest_path = "../solobase"
+
 [assets]
 extra_bypass_prefix = ["/gizza-app.js", "/gizza.css"]
 

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -10,10 +10,10 @@ export default defineConfig({
     baseURL: 'http://localhost:8000',
     headless: true,
     // Service workers work most reliably in Chromium.
-    // The dist/ bundle is browser-WASM + SW-based.
+    // The pkg/ bundle is browser-WASM + SW-based.
   },
   webServer: {
-    command: 'python3 -m http.server --directory ../dist 8000',
+    command: 'python3 -m http.server --directory ../pkg 8000',
     port: 8000,
     timeout: 60_000,
     reuseExistingServer: true,


### PR DESCRIPTION
## Summary

- Add `solobase.toml` at repo root — drives `solobase build` / `solobase serve` via the new CLI (solobase PR #17)
- Remove the hand-rolled `build-skills`, `build-wasm`, `build`, `serve` targets from the justfile; keep only `test` (Playwright, not managed by the CLI)
- Update `tests/playwright.config.ts` webServer command: `../dist` → `../pkg` (the CLI's single `out_dir`; no more two-stage dist assembly)

## Out-dir decision

Old flow: wasm-pack → `pkg/`, then manually assemble → `dist/`. solobase-cli collapses this to one directory. Using the CLI default (`pkg/`) — simpler, consistent with solobase-web's convention.

## Test plan

- [ ] `solobase build` completes; `pkg/` contains `index.html` (gizza-branded), `gizza-app.js`, `gizza.css`, `loader.js`, `sw.js`, `gizza_ai.js`, `gizza_ai_bg.wasm`, `vendor/`, `webllm-engine.js`, `snippets/`
- [ ] `solobase serve` serves `pkg/` on port 8000 without errors
- [ ] `just test` (Playwright) passes against the `pkg/`-served build

🤖 Generated with [Claude Code](https://claude.com/claude-code)