### PR TITLE
refactor: depend on solobase-core only after upstream lib merge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ wafer-core = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
 wafer-block-config = { git = "https://github.com/wafer-run/wafer-run", branch = "main" }
 
 # Solobase — path deps (sibling checkout; can be switched to git later).
-solobase = { path = "../solobase/crates/solobase", default-features = false }
 solobase-core = { path = "../solobase/crates/solobase-core", default-features = false }
 solobase-browser = { path = "../solobase/crates/solobase-browser" }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 
 use std::sync::Arc;
 
-use solobase::builder::{self, SolobaseBuilder};
+use solobase_core::builder::{self, SolobaseBuilder};
 use solobase_core::RouteAccess;
 use wafer_core::interfaces::config::service::ConfigService;
 use wasm_bindgen::prelude::*;


### PR DESCRIPTION
Upstream solobase merged the solobase lib into solobase-core. Drop the direct solobase dep; solobase-core now provides everything we need. Imports updated from use solobase::* to use solobase_core::*.

Cannot land until upstream solobase PR (unified-cli) is merged.