### PR TITLE
chore: drop stale [patch] entries for deleted wafer-block crates

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,12 +16,10 @@ wafer-run = { path = "../wafer-run/crates/wafer-run" }
 wafer-block = { path = "../wafer-run/crates/wafer-block" }
 wafer-core = { path = "../wafer-run/crates/wafer-core" }
 wafer-sql-utils = { path = "../wafer-run/crates/wafer-sql-utils" }
-wafer-block-auth-validator = { path = "../wafer-run/crates/wafer-block-auth-validator" }
 wafer-block-config = { path = "../wafer-run/crates/wafer-block-config" }
 wafer-block-cors = { path = "../wafer-run/crates/wafer-block-cors" }
 wafer-block-crypto = { path = "../wafer-run/crates/wafer-block-crypto" }
 wafer-block-http-listener = { path = "../wafer-run/crates/wafer-block-http-listener" }
-wafer-block-iam-guard = { path = "../wafer-run/crates/wafer-block-iam-guard" }
 wafer-block-inspector = { path = "../wafer-run/crates/wafer-block-inspector" }
 wafer-block-local-storage = { path = "../wafer-run/crates/wafer-block-local-storage" }
 wafer-block-logger = { path = "../wafer-run/crates/wafer-block-logger" }


### PR DESCRIPTION
## Summary

`wafer-block-auth-validator` and `wafer-block-iam-guard` were deleted upstream as part of the wafer-run/solobase auth refactor. Their `[patch]` entries in `.cargo/config.toml` broke any `cargo build` in this repo with a `No such file or directory` error before any actual gizza-ai code compiled.

This PR drops the two stale entries. Other patched crates (still alive upstream) are unchanged.

## Scope

This PR only fixes the dependency-resolution layer. Subsequent gizza-ai compile errors (API drift against current `solobase-browser` / `solobase-core`) are out of scope and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)