### PR TITLE
feat(site): port chrome to suppers-ai/site-kit

### DIFF
--- a/site/gizza-app.js
+++ b/site/gizza-app.js
@@ -10,7 +10,7 @@ const $ = (id) => document.getElementById(id);
 // rebuild.
 document.title = 'gizza.ai';
 {
-    const wordmark = document.querySelector('.topbar h1');
+    const wordmark = document.querySelector('sa-header h1');
     if (wordmark) wordmark.textContent = 'gizza.ai';
 }
 

--- a/site/gizza.css
+++ b/site/gizza.css
@@ -1,101 +1,68 @@
 /* gizza.css — Cursor-inspired editorial chat UI.
  *
- * Warm cream canvas, ink (#26251e) text, Cursor Orange (#f54e00) reserved
- * for the primary CTA. Hairline-only depth — no shadows. Inter substitutes
- * the licensed CursorGothic at the editorial display weight (400). JetBrains
- * Mono on every code surface. AI-timeline pastels mark agent tool stages.
+ * Foundation tokens (colors, type, spacing) come from suppers-ai/site-kit
+ * via the design-system.css link in render_chat(). This file overrides
+ * --sa-accent for the gizza brand and aliases the legacy --color-*/--space-*
+ * names onto the kit's --sa-* tokens so the rest of this stylesheet did
+ * not need a search-and-replace pass. Gizza-specific tokens that have no
+ * kit equivalent (timeline pastels, soft canvas, ink-on-canvas hairlines,
+ * pill radius) are kept bespoke.
  */
 
-/* Self-hosted fonts. CSP blocks external stylesheets but allows /self/ files,
- * so we declare @font-face directly here and load the WOFF2 files from
- * /fonts/. Itim is the brand display+body face (matches solobase-site);
- * JetBrains Mono carries every code surface. */
-
-@font-face {
-  font-family: 'Itim';
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: url('/fonts/itim-latin.woff2') format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-@font-face {
-  font-family: 'Itim';
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: url('/fonts/itim-latin-ext.woff2') format('woff2');
-  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
-}
-@font-face {
-  font-family: 'JetBrains Mono';
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-  src: url('/fonts/jetbrains-mono-latin-400-normal.woff2') format('woff2');
-}
-@font-face {
-  font-family: 'JetBrains Mono';
-  font-weight: 500;
-  font-style: normal;
-  font-display: swap;
-  src: url('/fonts/jetbrains-mono-latin-500-normal.woff2') format('woff2');
-}
-
 :root {
-  /* Brand */
-  --color-primary: #f54e00;
-  --color-primary-active: #d04200;
+  /* Brand override — Cursor Orange instead of the kit's default navy. */
+  --sa-accent: #f54e00;
+  --sa-accent-hover: #d04200;
 
-  /* Surfaces */
-  --color-canvas: #f7f7f4;
-  --color-canvas-soft: #fafaf7;
-  --color-surface-card: #ffffff;
-  --color-surface-strong: #e6e5e0;
+  /* Aliases: gizza color names → site-kit --sa-* tokens. */
+  --color-primary:        var(--sa-accent);
+  --color-primary-active: var(--sa-accent-hover);
+  --color-canvas:         #f7f7f4; /* warm cream — kit ships gray-50, gizza wants warmer */
+  --color-surface-card:   var(--sa-bg-card);
+  --color-hairline:       var(--sa-border);
+  --color-ink:            var(--sa-text);
+  --color-body:           var(--sa-text-muted);
+  --color-muted:          var(--sa-text-muted);
+  --color-on-primary:     #ffffff;
 
-  /* Hairlines */
-  --color-hairline: #e6e5e0;
-  --color-hairline-soft: #efeee8;
+  /* Bespoke surfaces — no kit equivalent for gizza's warm-cream variants. */
+  --color-canvas-soft:     #fafaf7;
+  --color-surface-strong:  #e6e5e0;
+  --color-hairline-soft:   #efeee8;
   --color-hairline-strong: #cfcdc4;
+  --color-muted-soft:      #a09c92;
 
-  /* Ink */
-  --color-ink: rgb(31, 41, 55);
-  --color-body: #5a5852;
-  --color-muted: #807d72;
-  --color-muted-soft: #a09c92;
-  --color-on-primary: #ffffff;
-
-  /* Timeline pastels — agent stage signature */
+  /* Timeline pastels — gizza-specific agent-stage signature. */
   --color-timeline-thinking: #dfa88f;
   --color-timeline-grep:     #9fc9a2;
   --color-timeline-read:     #9fbbe0;
   --color-timeline-edit:     #c0a8dd;
   --color-timeline-done:     #c08532;
 
-  /* Semantic */
+  /* Semantic. */
   --color-success: #1f8a65;
   --color-error:   #cf2d56;
 
-  /* Type */
-  --font-display: 'Itim', system-ui, 'Comic Sans MS', cursive, sans-serif;
-  --font-mono:    'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  /* Type aliases — kit provides Itim and JetBrains Mono via design-system.css. */
+  --font-display: var(--sa-font-sans);
+  --font-mono:    var(--sa-font-mono);
 
-  /* Radius */
+  /* Radius aliases (pill is bespoke; kit has no full-pill token). */
   --radius-xs:   4px;
-  --radius-sm:   6px;
-  --radius-md:   8px;
-  --radius-lg:   12px;
+  --radius-sm:   var(--sa-radius-sm);
+  --radius-md:   var(--sa-radius-md);
+  --radius-lg:   var(--sa-radius-lg);
   --radius-pill: 9999px;
 
-  /* Spacing */
-  --space-xxs:  4px;
-  --space-xs:   8px;
-  --space-sm:   12px;
-  --space-base: 16px;
-  --space-md:   20px;
-  --space-lg:   24px;
-  --space-xl:   32px;
-  --space-xxl:  48px;
+  /* Spacing aliases — closest match to kit's 4px-base scale. */
+  --space-xxs:  var(--sa-space-1);
+  --space-xs:   var(--sa-space-2);
+  --space-sm:   var(--sa-space-3);
+  --space-base: var(--sa-space-4);
+  --space-md:   20px; /* no kit equivalent between sa-4 (16px) and sa-6 (24px) */
+  --space-lg:   var(--sa-space-6);
+  --space-xl:   var(--sa-space-8);
+  --space-xxl:  var(--sa-space-12);
 }
 
 * { box-sizing: border-box; }
@@ -137,66 +104,45 @@ main#app {
   text-transform: uppercase;
 }
 
-/* ─── Top nav ──────────────────────────────────────────────────────────── */
+/* ─── Brand (slotted into <sa-header>) ─────────────────────────────────── */
 
-.topbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  height: 64px;
-  padding: 0 var(--space-lg);
-  background: var(--color-canvas);
-  border-bottom: 1px solid var(--color-hairline);
-}
-
-/* Wordmark — the only place orange runs as text. Magazine voice (400). */
-.topbar h1 {
-  margin: 0;
+/* Wordmark + crab mascot. The kit's <sa-header> provides the chrome
+ * container, sticky behavior, and hairline divider. We just style the
+ * slotted contents — magazine voice (400), Cursor Orange wordmark, crab
+ * to the left. */
+sa-header .brand {
   display: inline-flex;
   align-items: center;
   gap: var(--space-xs);
+  text-decoration: none;
+  color: var(--color-primary);
+}
+sa-header .brand-logo {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+}
+sa-header .brand h1 {
+  margin: 0;
   font-family: var(--font-display);
   font-size: 24px;
   font-weight: 400;
-  color: var(--color-primary);
-}
-
-/* Crab mascot anchored beside the wordmark — pulled in via ::before so we
- * don't need to touch the maud HTML. */
-.topbar h1::before {
-  content: '';
-  display: inline-block;
-  width: 32px;
-  height: 32px;
-  background: url('/gis.png') no-repeat center / contain;
-  flex-shrink: 0;
+  color: inherit;
 }
 
 /* The settings cog renders inside the composer once gizza-app.js moves it
- * there at init. Hide it in its original topbar slot so there's no flash of
+ * there at init. Hide it in its original slot so there's no flash of
  * unstyled glyph during boot. */
-.topbar #open-settings { display: none; }
+sa-header #open-settings { display: none; }
 
 /* ─── Chat band ────────────────────────────────────────────────────────── */
-
-#chat {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  width: 100%;
-  max-width: 880px;
-  margin: 0 auto;
-  padding: var(--space-xl) var(--space-lg);
-}
+/* Layout (max-width, vertical sizing, padding) is owned by <sa-chat>.
+ * We just style the slotted #messages container. */
 
 #messages {
-  flex: 1;
-  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: var(--space-base);
-  padding-right: var(--space-xs);
 }
 
 .empty {
@@ -729,10 +675,8 @@ dialog button[value="close"] {
 /* ─── Mobile ───────────────────────────────────────────────────────────── */
 
 @media (max-width: 640px) {
-  .topbar { padding: 0 var(--space-base); }
-  .topbar h1 { font-size: 20px; }
-  .topbar h1::before { width: 28px; height: 28px; }
-  #chat { padding: var(--space-base); }
+  sa-header .brand h1 { font-size: 20px; }
+  sa-header .brand-logo { width: 28px; height: 28px; }
   #composer { width: calc(100% - var(--space-lg)); padding: var(--space-sm) var(--space-sm) var(--space-xs); }
   .bubble { max-width: 92%; }
   dialog { padding: var(--space-lg); }

--- a/site/index.html
+++ b/site/index.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="stylesheet" href="https://site-kit.suppers.ai/dist/design-system.css">
   <link rel="stylesheet" href="/gizza.css">
 </head>
 <body>

--- a/src/blocks/ui.rs
+++ b/src/blocks/ui.rs
@@ -94,21 +94,27 @@ fn render_chat() -> maud::Markup {
                 meta charset="utf-8";
                 meta name="viewport" content="width=device-width, initial-scale=1";
                 title { "gizza-ai" }
+                link rel="stylesheet" href="https://site-kit.suppers.ai/dist/design-system.css";
+                script type="module" src="https://site-kit.suppers.ai/dist/components/sa-header.js" {}
+                script type="module" src="https://site-kit.suppers.ai/dist/components/sa-chat.js" {}
                 link rel="stylesheet" href="/gizza.css";
             }
             body {
-                header class="topbar" {
-                    h1 { "gizza-ai" }
-                    button id="open-settings" type="button" aria-label="Settings" { "⚙" }
+                sa-header {
+                    a slot="brand" href="/" class="brand" {
+                        img src="/gis.png" alt="" class="brand-logo";
+                        h1 { "gizza-ai" }
+                    }
+                    button slot="actions" id="open-settings" type="button" aria-label="Settings" { "⚙" }
                 }
-                main id="chat" {
-                    div id="messages" {
+                sa-chat {
+                    div slot="messages" id="messages" {
                         div class="empty" { "Load a model in settings to start." }
                     }
-                }
-                form id="composer" autocomplete="off" {
-                    textarea id="user-input" name="user_message" placeholder="Ask anything…" rows="2" {}
-                    button id="send" type="submit" disabled { "Send" }
+                    form slot="composer" id="composer" autocomplete="off" {
+                        textarea id="user-input" name="user_message" placeholder="Ask anything…" rows="2" {}
+                        button id="send" type="submit" disabled { "Send" }
+                    }
                 }
                 dialog id="settings" {
                     form method="dialog" {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,8 +99,9 @@ pub async fn initialize() -> Result<(), JsValue> {
             serde_json::json!({
                 "csp": concat!(
                     "default-src 'self'; ",
-                    "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net; ",
-                    "style-src 'self' 'unsafe-inline'; ",
+                    "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' ",
+                        "https://cdn.jsdelivr.net https://site-kit.suppers.ai; ",
+                    "style-src 'self' 'unsafe-inline' https://site-kit.suppers.ai; ",
                     "img-src 'self' data: blob: https:; ",
                     "font-src 'self' https:; ",
                     "connect-src 'self' https://cdn.jsdelivr.net https://esm.run https://huggingface.co ",


### PR DESCRIPTION
## Summary

Adopt site-kit foundation + components across the gizza-ai surface, in line with workspace direction that all sites consume site-kit.

- **`src/blocks/ui.rs`** — replace bespoke `<header class="topbar">` with `<sa-header>` (brand slot = crab + `<h1>`, actions slot = settings cog). Wrap `#messages` and `#composer` in `<sa-chat>` (the new chat-shell component shipped in site-kit#5). Both slots stay in light DOM so `#messages`, `#user-input`, `#send` etc. remain queryable from gizza-app.js without piercing shadow DOM.
- **`site/index.html`** — load site-kit's `design-system.css` in the boot shell so the cream canvas + Itim/JetBrains-Mono fonts are correct during the brief pre-SW phase.
- **`src/lib.rs`** — extend `wafer-run/security-headers` CSP to allow `https://site-kit.suppers.ai` for `script-src` + `style-src` (mirrors wafer-site PR #3 commit `287a7b0`).
- **`site/gizza.css`** — drop now-redundant `@font-face` blocks (kit serves Itim and JetBrains Mono via `design-system.css`), add a legacy-name aliasing block at the top so existing `--color-*` and `--space-*` refs in this file map onto the kit's `--sa-*` tokens with no search-and-replace pass needed. Cursor-orange brand kept by overriding `--sa-accent: #f54e00`. Drop `.topbar` styles; slotted brand link gets a small ruleset preserving wordmark sizing + crab positioning. Drop `#chat` layout (owned by `<sa-chat>`) and simplify `#messages`. Gizza-bespoke tokens (timeline pastels, soft canvas/hairline surfaces, pill radius) kept — no kit equivalents.
- **`site/gizza-app.js`** — update the wordmark text-override selector from `.topbar h1` to `sa-header h1`. All other selectors unchanged.

Net diff: +86 / −134 (gizza.css drops the @font-face blocks and the topbar styles).

## Verified

- `cargo check --target wasm32-unknown-unknown` clean
- `wasm-pack build --target web --out-dir dist` succeeds
- Served `dist/` locally and confirmed the boot shell now loads `design-system.css` and the updated `gizza.css`/`gizza-app.js` reference the new selectors

## Follow-up (not in this PR)

- `site/fonts/*.woff2` is now redundant since the kit serves the same fonts. One-PR cleanup once we're confident the kit-served fonts are reliable in production.
- Same goes for the local `gis.png` — could move to a slot-able SVG if we ever reduce per-site assets further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)