### PR TITLE
chore(ui): drop ⚙ emoji from settings button

### DIFF
--- a/site/gizza-app.js
+++ b/site/gizza-app.js
@@ -14,14 +14,14 @@ document.title = 'gizza.ai';
     if (wordmark) wordmark.textContent = 'gizza.ai';
 }
 
-// Move the settings cog from the topbar into the composer's action row,
+// Move the settings cog from the header into the composer's action row,
 // just before the send button. The Lucide cog icon and ghost-button styling
-// are applied by gizza.css via #composer #open-settings.
+// are applied by gizza.css via #composer #open-settings (mask-image on
+// ::before — the button itself is empty in the maud HTML).
 {
     const cog = document.getElementById('open-settings');
     const send = document.getElementById('send');
     if (cog && send && cog.parentElement !== send.parentElement) {
-        cog.textContent = ''; // drop the ⚙ glyph; CSS draws the Lucide icon
         send.parentElement.insertBefore(cog, send);
     }
 }

--- a/src/blocks/ui.rs
+++ b/src/blocks/ui.rs
@@ -105,7 +105,10 @@ fn render_chat() -> maud::Markup {
                         img src="/gis.png" alt="" class="brand-logo";
                         h1 { "gizza-ai" }
                     }
-                    button slot="actions" id="open-settings" type="button" aria-label="Settings" { "⚙" }
+                    // Empty button — gizza.css draws the Lucide `settings` icon
+                    // via `::before { mask-image }` once the button lands in the
+                    // composer. No textContent needed (was an emoji placeholder).
+                    button slot="actions" id="open-settings" type="button" aria-label="Settings" {}
                 }
                 sa-chat {
                     div slot="messages" id="messages" {


### PR DESCRIPTION
## Summary

Cosmetic hygiene fix from a UX review (skill rule: no emoji as structural icons).

The emoji was never actually visible to users — hidden by `display: none` while in the header slot, and by `font-size: 0` once relocated into the composer (where the Lucide cog is drawn via `::before { mask-image }`). But it lived in the maud source as a placeholder, which the skill (and our own consistency goals) treats as a smell.

- `src/blocks/ui.rs`: emit an empty `<button>`
- `site/gizza-app.js`: drop the now-no-op `cog.textContent = ''` line; comment still describes the move

## Test plan

- [x] `cargo check --target wasm32-unknown-unknown` clean
- [ ] Browser smoke: cog still renders correctly inside composer

🤖 Generated with [Claude Code](https://claude.com/claude-code)