### PR TITLE
fix(deploy): build solobase-web wasm before solobase CLI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,12 @@ jobs:
             solobase
             wafer-run
 
+      - name: Build solobase-web wasm
+        # Required by solobase's build.rs (it include_bytes!s the wasm).
+        # Mirrors solobase/justfile's `build` recipe.
+        working-directory: solobase
+        run: wasm-pack build crates/solobase-web --target web --release --out-dir pkg
+
       - name: Build solobase CLI
         run: cargo install --path solobase/crates/solobase --locked
 


### PR DESCRIPTION
## Summary
solobase's build.rs include_bytes!s the solobase-web wasm. The CLI install in CI fails with \`solobase-web wasm not found\` if wasm-pack hasn't run first.

Adds the missing step ahead of \`cargo install solobase\`. Mirrors solobase/justfile's \`build\` recipe.

## Repro
Workflow run #25160492949 — first deploy attempt after PR #15 merged.

## Test plan
- [ ] Workflow re-runs on this PR / on next push to main and goes green.
- [ ] gh-pages branch is created with pkg/ contents.