### PR TITLE
test: LLM-free dispatch test for gizza-ai/web-fetch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,7 @@ uuid = { version = "1", features = ["v4", "js"] }
 # tokio time feature for per-frame stream timeouts in agent.rs.
 # The `time` feature compiles to wasm32 (uses JS timers under wasm-bindgen).
 tokio = { version = "1", features = ["time"], default-features = false }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }
+async-trait = "0.1"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,35 @@
+# gizza-ai tests
+
+Two test surfaces with very different runtime characteristics.
+
+## `cargo test`
+
+Native Rust integration tests. Run in CI, fast, deterministic, headless.
+
+- `tests/skills_embed.rs` — asserts every skill block under `blocks/*/` ends up embedded in `gizza_ai::skills::SKILLS` after `solobase build`. Catches "I forgot to add the new skill" and "wafer compiled to an empty file."
+- `tests/dispatch_skills.rs` — boots a `wafer-run::Wafer` runtime in-process, loads the produced `block.wasm` into the `wasmi` runtime, substitutes a `FakeNetworkBlock` at the network leaf, and verifies cross-block dispatch round-trips correctly. Same wasmi loader and `__wafer_host_call_block` ABI used in the browser SW.
+
+```bash
+# Prerequisite: blocks/*/target/block.wasm must exist (built via wafer build).
+solobase build       # builds every block under blocks/* + the gizza-ai bundle
+                     # equivalent: `wafer build blocks/<name>` per block
+
+cargo test
+```
+
+## `npx playwright test` — manual smoke test
+
+Drives the real chat UI (boot → load WebLLM model → send prompt → assert tool call result). Useful as a manual sanity check that the deployed site works end-to-end, but **not** runnable in CI today:
+
+- Requires headed Chromium with WebGPU (set in `playwright.config.ts` as `headless: false`). Linux headless Chromium has no WebGPU.
+- Downloads ~1.2 GB of model weights (Qwen2.5-1.5B) on each cold run, because Playwright's per-test browser context wipes IndexedDB. Persistent-context fixture work is tracked separately.
+
+```bash
+# Prerequisite: pkg/ built via 'solobase build'.
+cd tests
+npm install
+npx playwright install chromium    # first time only
+npx playwright test
+```
+
+If you need a deterministic, repeatable check that a skill works end-to-end, prefer `cargo test --test dispatch_skills` over the Playwright suite.

--- a/tests/dispatch_skills.rs
+++ b/tests/dispatch_skills.rs
@@ -1,0 +1,122 @@
+//! In-process integration test for gizza-ai/web-fetch.
+//!
+//! Boots a wafer-run runtime, substitutes a FakeNetworkBlock for
+//! wafer-run/network, loads blocks/web-fetch/target/block.wasm into the wasmi
+//! runtime, and asserts the cross-block dispatch path (web-fetch → call_block
+//! → fake network → response → web-fetch parses → ToolResp) round-trips
+//! correctly. No browser, no LLM, no Playwright.
+
+use std::sync::Arc;
+
+use serde_json::json;
+use wafer_block::{Block, Context, InputStream, Message, OutputStream, WaferError};
+use wafer_run::{ErrorCode, WasmiBlock, Wafer};
+
+/// A native test stub for `wafer-run/network`. Returns canned 200 responses for
+/// the URL the test uses, 404 for everything else. Lives inline because no
+/// other test consumer needs it yet — promote to `wafer-test-support` if a
+/// second skill grows a similar dispatch test.
+#[derive(Default)]
+struct FakeNetworkBlock;
+
+#[async_trait::async_trait]
+impl Block for FakeNetworkBlock {
+    fn info(&self) -> wafer_block::types::BlockInfo {
+        wafer_block::types::BlockInfo::new(
+            "wafer-run/network",
+            "0.1.0",
+            "network@v1",
+            "Test stub — returns canned HTTP responses",
+        )
+    }
+
+    async fn handle(
+        &self,
+        _ctx: &dyn Context,
+        msg: Message,
+        input: InputStream,
+    ) -> OutputStream {
+        let expected_kind = wafer_block::ServiceOp::NETWORK_DO_REQUEST;
+        if msg.kind != expected_kind {
+            return OutputStream::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                format!("FakeNetworkBlock: unexpected msg.kind {}", msg.kind),
+            ));
+        }
+        let body = input.collect_to_bytes().await;
+        let req: serde_json::Value = match serde_json::from_slice(&body) {
+            Ok(v) => v,
+            Err(e) => {
+                return OutputStream::error(WaferError::new(
+                    ErrorCode::INVALID_ARGUMENT,
+                    format!("FakeNetworkBlock: invalid request body: {e}"),
+                ));
+            }
+        };
+
+        let url = req["url"].as_str().unwrap_or("");
+        let (status, body_bytes): (u16, Vec<u8>) = match url {
+            "https://example.test/web-fetch.txt" => (200, b"WEBFETCH_OK_8f3a2".to_vec()),
+            _ => (404, Vec::new()),
+        };
+
+        OutputStream::respond(
+            serde_json::to_vec(&json!({
+                "status_code": status,
+                "headers": { "content-type": ["text/plain"] },
+                "body": body_bytes,
+            }))
+            .expect("serialize fake response"),
+        )
+    }
+}
+
+#[tokio::test]
+async fn web_fetch_round_trips_through_network_block() {
+    let mut wafer = Wafer::builder()
+        .disable_inventory()
+        .disable_lockfile()
+        .build()
+        .expect("Wafer::build");
+
+    wafer
+        .register_block("wafer-run/network", Arc::new(FakeNetworkBlock))
+        .expect("register fake network");
+
+    let wasm: &[u8] = include_bytes!("../blocks/web-fetch/target/block.wasm");
+    let block = WasmiBlock::load_from_bytes(wasm).expect("load web-fetch wasm");
+    wafer
+        .register_block("gizza-ai/web-fetch", Arc::new(block))
+        .expect("register web-fetch");
+
+    let wafer = wafer.start().await.expect("start runtime");
+
+    let req_body = serde_json::to_vec(&json!({
+        "url": "https://example.test/web-fetch.txt"
+    }))
+    .expect("serialize request body");
+
+    let output = wafer
+        .run_block(
+            "gizza-ai/web-fetch",
+            Message::new("invoke"),
+            InputStream::from_bytes(req_body),
+        )
+        .await;
+
+    let resp = output
+        .collect_buffered()
+        .await
+        .expect("web-fetch returned a non-success terminal");
+
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&resp.body).expect("web-fetch body is JSON");
+
+    assert_eq!(parsed["status"], 200, "status field");
+    assert_eq!(
+        parsed["url"], "https://example.test/web-fetch.txt",
+        "url echoed back"
+    );
+    assert_eq!(parsed["body"], "WEBFETCH_OK_8f3a2", "body marker");
+    assert_eq!(parsed["truncated"], false, "truncated flag");
+}


### PR DESCRIPTION
## Summary

Adds `tests/dispatch_skills.rs` — a deterministic, headless `cargo test` that loads `blocks/web-fetch/target/block.wasm` into a `wasmi` runtime, substitutes a `FakeNetworkBlock` for `wafer-run/network`, and asserts the cross-block dispatch round-trips correctly. Same wasmi loader, same `__wafer_host_call_block` ABI, same `Block` trait used by the browser SW — only the network leaf is faked.

Closes #19.

## Why

The existing `tests/e2e_smoke.spec.ts` Playwright suite is gated on a real Chromium with WebGPU plus a 1.2 GB WebLLM model download per cold run. The dispatch test gives us a fast, deterministic CI signal for skill-block correctness without any of that.

## Test plan

- [x] `cargo test --test dispatch_skills` — passes locally (`1 passed; 0 failed`, ~50 ms).
- [x] `cargo test --test skills_embed` — still passes (no regression).
- [x] `solobase build` — still produces a valid `pkg/` (no production code touched).

## Notes

- Uses `Wafer::builder().disable_inventory().disable_lockfile().build()` to start with a clean runtime — needed so the test can register its own `FakeNetworkBlock` at `wafer-run/network` without colliding with auto-registered middleware blocks.
- `tests/README.md` distinguishes the cargo (CI-friendly) and playwright (manual smoke) test surfaces.

## Out of scope (per spec)

- Persistent-context fixture for the LLM-driven Playwright test.
- Stub `LlmService` or any test-only routes/blocks in production code paths.
- Promoting `FakeNetworkBlock` to `wafer-test-support` (premature — wait for a second consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)