### PR TITLE
feat: gizza-ai/ffmpeg-runtime — browser-side ffmpeg invocation primitive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", default-features = false, features = ["serde", "std", "clock", "wasmbind"] }
+base64 = "0.22"
+thiserror = "1"
 
 # Async
 async-trait = "0.1"

--- a/js/ffmpeg.js
+++ b/js/ffmpeg.js
@@ -1,0 +1,87 @@
+//! gizza-ai ffmpeg JS bridge.
+//!
+//! Exports a single function `ffmpegExec(argsJson, inputsJson, outputName)`
+//! that the Rust BrowserFfmpegService calls via wasm-bindgen.
+//!
+//! @ffmpeg/ffmpeg + @ffmpeg/core are loaded lazily on first call from the
+//! jsdelivr CDN. Subsequent calls reuse the same FFmpeg instance.
+
+let ffmpegInstance = null;
+let ffmpegInstancePromise = null;
+
+const FFMPEG_VERSION = "0.12.15";
+const CORE_VERSION = "0.12.10";
+
+async function ensureFfmpeg() {
+    if (ffmpegInstance) return ffmpegInstance;
+    if (ffmpegInstancePromise) return ffmpegInstancePromise;
+
+    ffmpegInstancePromise = (async () => {
+        const mod = await import(
+            `https://cdn.jsdelivr.net/npm/@ffmpeg/ffmpeg@${FFMPEG_VERSION}/+esm`
+        );
+        const inst = new mod.FFmpeg();
+        await inst.load({
+            coreURL: `https://cdn.jsdelivr.net/npm/@ffmpeg/core@${CORE_VERSION}/dist/umd/ffmpeg-core.js`,
+            wasmURL: `https://cdn.jsdelivr.net/npm/@ffmpeg/core@${CORE_VERSION}/dist/umd/ffmpeg-core.wasm`,
+        });
+        ffmpegInstance = inst;
+        return inst;
+    })();
+
+    return ffmpegInstancePromise;
+}
+
+function b64ToUint8(b64) {
+    const bin = atob(b64);
+    const out = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+}
+
+function uint8ToB64(arr) {
+    let s = "";
+    const chunk = 0x8000;
+    for (let i = 0; i < arr.length; i += chunk) {
+        s += String.fromCharCode.apply(null, arr.subarray(i, i + chunk));
+    }
+    return btoa(s);
+}
+
+/**
+ * Run ffmpeg with the given CLI args.
+ *
+ * @param {string} argsJson    JSON-encoded array of strings, e.g. '["-i","in","out"]'
+ * @param {string} inputsJson  JSON-encoded array of {name, bytes_b64}
+ * @param {string} outputName  Filename to read back from ffmpeg's virtual FS
+ * @returns {Promise<{exit_code:number, output_b64:string, log:string}>}
+ */
+export async function ffmpegExec(argsJson, inputsJson, outputName) {
+    const args = JSON.parse(argsJson);
+    const inputs = JSON.parse(inputsJson);
+    const ffmpeg = await ensureFfmpeg();
+
+    let log = "";
+    const onLog = ({ message }) => { log += message + "\n"; };
+    ffmpeg.on("log", onLog);
+
+    try {
+        for (const { name, bytes_b64 } of inputs) {
+            await ffmpeg.writeFile(name, b64ToUint8(bytes_b64));
+        }
+        const exit_code = await ffmpeg.exec(args);
+
+        let output_b64 = "";
+        try {
+            const out = await ffmpeg.readFile(outputName);
+            const u8 = out instanceof Uint8Array ? out : new TextEncoder().encode(out);
+            output_b64 = uint8ToB64(u8);
+        } catch (_) {
+            // ffmpeg failed before producing output — leave output_b64 empty.
+        }
+
+        return { exit_code, output_b64, log };
+    } finally {
+        ffmpeg.off("log", onLog);
+    }
+}

--- a/src/blocks/ffmpeg.rs
+++ b/src/blocks/ffmpeg.rs
@@ -1,0 +1,79 @@
+//! gizza-ai/ffmpeg-runtime native block.
+//!
+//! Dispatches `msg.kind = "ffmpeg.exec"` to a configurable
+//! `FfmpegService` (e.g. `BrowserFfmpegService` in production,
+//! `FakeFfmpegService` in tests).
+
+use std::sync::Arc;
+
+use wafer_block::{
+    block::Block,
+    context::Context,
+    core_types::{ErrorCode, Message, WaferError},
+    streams::{input::InputStream, output::OutputStream},
+    types::BlockInfo,
+};
+
+use crate::ffmpeg::{ExecArgs, FfmpegService};
+
+pub struct FfmpegBlock {
+    service: Arc<dyn FfmpegService>,
+}
+
+impl FfmpegBlock {
+    pub fn new(service: Arc<dyn FfmpegService>) -> Self {
+        Self { service }
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl Block for FfmpegBlock {
+    fn info(&self) -> BlockInfo {
+        BlockInfo::new(
+            "gizza-ai/ffmpeg-runtime",
+            "0.1.0",
+            "ffmpeg@v1",
+            "Browser-side ffmpeg bridge: exec accepts CLI args + virtual-FS inputs",
+        )
+    }
+
+    async fn handle(
+        &self,
+        _ctx: &dyn Context,
+        msg: Message,
+        input: InputStream,
+    ) -> OutputStream {
+        if msg.kind != "ffmpeg.exec" {
+            return OutputStream::error(WaferError::new(
+                ErrorCode::InvalidArgument,
+                format!("FfmpegBlock: unknown msg.kind {}", msg.kind),
+            ));
+        }
+
+        let body = input.collect_to_bytes().await;
+        let args: ExecArgs = match serde_json::from_slice(&body) {
+            Ok(v) => v,
+            Err(e) => {
+                return OutputStream::error(WaferError::new(
+                    ErrorCode::InvalidArgument,
+                    format!("FfmpegBlock: invalid request body: {e}"),
+                ));
+            }
+        };
+
+        match self.service.exec(args).await {
+            Ok(result) => match serde_json::to_vec(&result) {
+                Ok(bytes) => OutputStream::respond(bytes),
+                Err(e) => OutputStream::error(WaferError::new(
+                    ErrorCode::Internal,
+                    format!("FfmpegBlock: serialize result: {e}"),
+                )),
+            },
+            Err(e) => OutputStream::error(WaferError::new(
+                ErrorCode::Unavailable,
+                format!("ffmpeg exec failed: {e}"),
+            )),
+        }
+    }
+}

--- a/src/blocks/mod.rs
+++ b/src/blocks/mod.rs
@@ -1,4 +1,7 @@
 //! Native gizza-ai blocks.
 
+#[cfg(target_arch = "wasm32")]
 pub mod agent;
+pub mod ffmpeg;
+#[cfg(target_arch = "wasm32")]
 pub mod ui;

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -1,0 +1,122 @@
+//! gizza-ai ffmpeg invocation primitive.
+//!
+//! Bridges `gizza-ai/ffmpeg-runtime` block requests into JS-side
+//! `@ffmpeg/ffmpeg`. Mirrors the `BrowserNetworkService` pattern from
+//! `solobase-browser/src/network.rs`.
+
+#[cfg(target_arch = "wasm32")]
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use serde::{Deserialize, Serialize};
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen(module = "/js/ffmpeg.js")]
+extern "C" {
+    #[wasm_bindgen(js_name = ffmpegExec)]
+    pub async fn ffmpeg_exec(
+        args_json: &str,
+        inputs_json: &str,
+        output_name: &str,
+    ) -> JsValue;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecArgs {
+    pub args: Vec<String>,
+    /// `(filename, bytes)` pairs — written to ffmpeg's virtual FS before exec.
+    pub inputs: Vec<(String, Vec<u8>)>,
+    /// Filename to read back after exec.
+    pub output: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecResult {
+    pub exit_code: i32,
+    pub output: Vec<u8>,
+    pub log: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum FfmpegError {
+    #[error("bridge serialization: {0}")]
+    Serialize(String),
+    #[error("bridge call returned malformed response: {0}")]
+    Bridge(String),
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+pub trait FfmpegService: wafer_block::MaybeSend + wafer_block::MaybeSync + 'static {
+    async fn exec(&self, args: ExecArgs) -> Result<ExecResult, FfmpegError>;
+}
+
+/// Browser-side ffmpeg service. Uses `@ffmpeg/ffmpeg` from jsdelivr via
+/// the wasm-bindgen module at `js/ffmpeg.js`. wasm32-only — native tests
+/// substitute their own `FfmpegService` impl.
+#[cfg(target_arch = "wasm32")]
+pub struct BrowserFfmpegService;
+
+// wasm32 is single-threaded; the service holds no JS state of its own
+// (the FFmpeg instance lives in the JS module). Mirrors BrowserNetworkService.
+#[cfg(target_arch = "wasm32")]
+unsafe impl Send for BrowserFfmpegService {}
+#[cfg(target_arch = "wasm32")]
+unsafe impl Sync for BrowserFfmpegService {}
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Serialize)]
+struct BridgeInput<'a> {
+    name: &'a str,
+    bytes_b64: String,
+}
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Deserialize)]
+struct BridgeResponse {
+    exit_code: i32,
+    output_b64: String,
+    log: String,
+}
+
+#[cfg(target_arch = "wasm32")]
+#[async_trait::async_trait(?Send)]
+impl FfmpegService for BrowserFfmpegService {
+    async fn exec(&self, args: ExecArgs) -> Result<ExecResult, FfmpegError> {
+        let args_json = serde_json::to_string(&args.args)
+            .map_err(|e| FfmpegError::Serialize(format!("args: {e}")))?;
+
+        let inputs_b64: Vec<BridgeInput> = args
+            .inputs
+            .iter()
+            .map(|(name, bytes)| BridgeInput {
+                name,
+                bytes_b64: B64.encode(bytes),
+            })
+            .collect();
+        let inputs_json = serde_json::to_string(&inputs_b64)
+            .map_err(|e| FfmpegError::Serialize(format!("inputs: {e}")))?;
+
+        let js_val = ffmpeg_exec(&args_json, &inputs_json, &args.output).await;
+
+        let json_str = js_sys::JSON::stringify(&js_val)
+            .map(|s| s.as_string().unwrap_or_default())
+            .unwrap_or_default();
+
+        let resp: BridgeResponse = serde_json::from_str(&json_str)
+            .map_err(|e| FfmpegError::Bridge(format!("parse response: {e}")))?;
+
+        let output = if resp.output_b64.is_empty() {
+            Vec::new()
+        } else {
+            B64.decode(&resp.output_b64)
+                .map_err(|e| FfmpegError::Bridge(format!("decode output_b64: {e}")))?
+        };
+
+        Ok(ExecResult {
+            exit_code: resp.exit_code,
+            output,
+            log: resp.log,
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,10 @@ use wafer_core::interfaces::config::service::ConfigService;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
-#[cfg(target_arch = "wasm32")]
 pub mod blocks;
 #[cfg(target_arch = "wasm32")]
 pub mod config;
+pub mod ffmpeg;
 pub mod skills;
 
 // ---------------------------------------------------------------------------
@@ -174,6 +174,14 @@ pub async fn initialize() -> Result<(), JsValue> {
     wafer
         .register_block("gizza-ai/ui", Arc::new(blocks::ui::UiBlock))
         .map_err(|e| JsValue::from_str(&format!("register gizza-ai/ui: {e}")))?;
+
+    let ffmpeg_svc: Arc<dyn ffmpeg::FfmpegService> = Arc::new(ffmpeg::BrowserFfmpegService);
+    wafer
+        .register_block(
+            "gizza-ai/ffmpeg-runtime",
+            Arc::new(blocks::ffmpeg::FfmpegBlock::new(ffmpeg_svc)),
+        )
+        .map_err(|e| JsValue::from_str(&format!("register gizza-ai/ffmpeg-runtime: {e}")))?;
 
     for (name, bytes) in skills::SKILLS {
         let wasmi = wafer_run::wasm::WasmiBlock::load_from_bytes(bytes)

--- a/tests/dispatch_skills.rs
+++ b/tests/dispatch_skills.rs
@@ -120,3 +120,75 @@ async fn web_fetch_round_trips_through_network_block() {
     assert_eq!(parsed["body"], "WEBFETCH_OK_8f3a2", "body marker");
     assert_eq!(parsed["truncated"], false, "truncated flag");
 }
+
+// -- ffmpeg-runtime dispatch test ----------------------------------------------
+
+/// Test stub: `FfmpegService` impl that returns canned bytes regardless of args.
+struct FakeFfmpegService {
+    canned_output: Vec<u8>,
+    canned_log: String,
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl gizza_ai::ffmpeg::FfmpegService for FakeFfmpegService {
+    async fn exec(
+        &self,
+        _args: gizza_ai::ffmpeg::ExecArgs,
+    ) -> Result<gizza_ai::ffmpeg::ExecResult, gizza_ai::ffmpeg::FfmpegError> {
+        Ok(gizza_ai::ffmpeg::ExecResult {
+            exit_code: 0,
+            output: self.canned_output.clone(),
+            log: self.canned_log.clone(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn ffmpeg_block_dispatches_to_service() {
+    let mut wafer = Wafer::builder()
+        .disable_inventory()
+        .disable_lockfile()
+        .build()
+        .expect("Wafer::builder().build()");
+
+    let svc: Arc<dyn gizza_ai::ffmpeg::FfmpegService> = Arc::new(FakeFfmpegService {
+        canned_output: b"FAKE_FFMPEG_OUT".to_vec(),
+        canned_log: "fake ok".into(),
+    });
+    wafer
+        .register_block(
+            "gizza-ai/ffmpeg-runtime",
+            Arc::new(gizza_ai::blocks::ffmpeg::FfmpegBlock::new(svc)),
+        )
+        .expect("register ffmpeg-runtime");
+
+    let wafer = wafer.start().await.expect("start runtime");
+
+    let body = serde_json::to_vec(&gizza_ai::ffmpeg::ExecArgs {
+        args: vec!["-i".into(), "in".into(), "out".into()],
+        inputs: vec![("in".into(), b"hello".to_vec())],
+        output: "out".into(),
+    })
+    .expect("serialize args");
+
+    let output = wafer
+        .run_block(
+            "gizza-ai/ffmpeg-runtime",
+            Message::new("ffmpeg.exec"),
+            InputStream::from_bytes(body),
+        )
+        .await;
+
+    let resp = output
+        .collect_buffered()
+        .await
+        .expect("ffmpeg-runtime non-success terminal");
+
+    let result: gizza_ai::ffmpeg::ExecResult =
+        serde_json::from_slice(&resp.body).expect("ffmpeg result is JSON");
+
+    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.output, b"FAKE_FFMPEG_OUT");
+    assert_eq!(result.log, "fake ok");
+}


### PR DESCRIPTION
## Summary

Adds the gizza-ai-local invocation primitive for ffmpeg. A native `FfmpegBlock` registered as `gizza-ai/ffmpeg-runtime` dispatches `msg.kind = "ffmpeg.exec"` to a configurable `FfmpegService`. In production the service is `BrowserFfmpegService`, which calls into `@ffmpeg/ffmpeg` (loaded lazily from jsdelivr) via a new wasm-bindgen module at `js/ffmpeg.js`. In tests the service is a `FakeFfmpegService` returning canned bytes.

This is sub-project 1 of the ffmpeg arc — the design crux. Sub-projects 2-4 (skill block, drag-drop UI, file preview) build on top.

## Why

The skill block (sub-project 2) needs a way to invoke ffmpeg ops from inside the wasmi runtime. ffmpeg itself runs in JS, so the primitive is a Rust ↔ JS bridge wrapped in the WAFER block dispatch protocol. Mirrors `wafer-run/network` ↔ `BrowserNetworkService`, but kept inside `gizza-ai/` (no upstream changes to solobase or wafer-run).

## Test plan

- [x] `cargo test --test dispatch_skills` — 2 tests pass (`web_fetch_round_trips_through_network_block`, `ffmpeg_block_dispatches_to_service`).
- [x] `cargo test --test skills_embed` — 2 tests pass (no regression).
- [x] `cargo build --target wasm32-unknown-unknown --release` — succeeds.
- [x] `solobase build` — succeeds; `pkg/snippets/gizza-ai-<hash>/js/ffmpeg.js` is bundled with our header comment.

## Out of scope (per spec)

- The skill block (`blocks/ffmpeg/`) — sub-project 2.
- UI drag-drop and file preview — sub-projects 3+.
- ExternalAsset / progress reporting — `@ffmpeg/ffmpeg` lazy-loads itself; the existing asset-loader is unused for now.
- Promotion to `solobase-browser` or `wafer-core`.

## Notes

- First time gizza-ai uses a wasm-bindgen module of its own (existing JS bridges came from `solobase-browser`). Path: `js/ffmpeg.js`, declared as `#[wasm_bindgen(module = "/js/ffmpeg.js")]`. wasm-pack bundles it as a snippet.
- `BrowserFfmpegService` is wasm32-only (cfg-gated), so the trait is the seam — `FakeFfmpegService` plugs into the same `Arc<dyn FfmpegService>` slot in tests.
- Bytes cross the Rust↔JS boundary as base64 strings to keep the wasm-bindgen call shape simple. The block's external wire format (Message body) still uses serde-default `Vec<u8>` (JSON int arrays) — same as `wafer-run/network`.
- `FfmpegService` trait uses `MaybeSend + MaybeSync + 'static` bounds (with `cfg_attr`-gated `async_trait` variant) to match `Block`'s requirements on both targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)