### PR TITLE
feat: gizza-ai/ffmpeg skill (ffprobe scope) — two-hop call_block

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -27,11 +27,12 @@ Right now there's only `gizza-ai/clock`. The flagship demo is ffmpeg image manip
 - [x] `gizza-ai/web-fetch` — fetch a URL and return its text body. Implemented via `call_block("wafer-run/network", …)` after wafer-run PR-H landed body-passing call_block.
 - [x] `gizza-ai/calculator` — eval simple arithmetic expressions in Rust. Zero deps.
 - [ ] `gizza-ai/search-messages` — calls `suppers-ai/messages` via `ctx.call_block` to search past conversation. Tests cross-skill dispatch.
-- [ ] `gizza-ai/ffmpeg` — the flagship. First skill to exercise the `externalAssets` declarative loader end-to-end. Needs:
-  - Skill block wrapping ffmpeg operations (resize, crop, trim, transcode) as a tool.
-  - `ai-bridge.js` registers an `ffmpeg.wasm` loader in `_loaderRegistry`, using `@ffmpeg/ffmpeg` from jsdelivr.
-  - File drag-drop in the UI so the user can supply an image/video.
-  - File preview in assistant replies (inline `<img>`/`<video>`/download button).
+- [~] `gizza-ai/ffmpeg` — flagship. Decomposed into 4 sub-projects (see specs). Status:
+  - [x] **Sub-project 1**: ffmpeg-runtime invocation primitive (PR #21).
+  - [x] **Sub-project 2**: ffprobe-scope skill (this PR). Returns media metadata as text.
+  - [ ] **Sub-project 3**: file drag-drop UI (deferred — needs design pass).
+  - [ ] **Sub-project 4**: file preview / inline `<img>`/`<video>` rendering (deferred — couples with markdown rendering).
+  - Resize/transcode/crop/trim ops on hold pending sub-projects 3+4 (binary output has nowhere usable to land in the current text-only chat UI).
 
 **Rough estimate:** ffmpeg alone is a session or two; the others are an afternoon each.
 

--- a/blocks/ffmpeg/Cargo.toml
+++ b/blocks/ffmpeg/Cargo.toml
@@ -1,0 +1,17 @@
+[workspace]
+resolver = "2"
+members = ["."]
+
+[package]
+name = "gizza-ai-ffmpeg-block"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wafer-sdk = { path = "../../../wafer-run/sdks/rust" }
+wafer-block = { path = "../../../wafer-run/crates/wafer-block" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/blocks/ffmpeg/manifest.json
+++ b/blocks/ffmpeg/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "gizza-ai/ffmpeg",
+  "version": "0.1.0",
+  "interface": "handler@v1",
+  "summary": "Inspect a media file's codec/duration/dimensions via ffmpeg.",
+  "role": "skill",
+  "tool": {
+    "description": "Fetch a media file at the given URL and return its metadata (codec, container, duration, dimensions, bitrate, etc.) as printed by ffmpeg. Use this to describe audio or video files to the user.",
+    "parameters": {
+      "type": "object",
+      "required": ["url"],
+      "properties": {
+        "url": { "type": "string", "description": "Absolute http(s) URL to a media file." }
+      }
+    }
+  }
+}

--- a/blocks/ffmpeg/src/lib.rs
+++ b/blocks/ffmpeg/src/lib.rs
@@ -1,0 +1,21 @@
+//! gizza-ai/ffmpeg — fetches a URL and returns ffmpeg's `-i` log.
+
+use wafer_sdk::*;
+
+struct FfmpegSkill;
+
+#[wafer_block(
+    name = "gizza-ai/ffmpeg",
+    version = "0.1.0",
+    interface = "handler@v1",
+    summary = "Inspect a media file via ffmpeg",
+    capabilities(callable_blocks = ["wafer-run/network", "gizza-ai/ffmpeg-runtime"]),
+)]
+impl FfmpegSkill {
+    fn handle(_msg: Message, _body: Vec<u8>) -> GuestResult {
+        GuestResult::error(WaferError::new(
+            ErrorCode::UNIMPLEMENTED,
+            "ffmpeg skill not yet implemented",
+        ))
+    }
+}

--- a/blocks/ffmpeg/src/lib.rs
+++ b/blocks/ffmpeg/src/lib.rs
@@ -1,6 +1,54 @@
-//! gizza-ai/ffmpeg — fetches a URL and returns ffmpeg's `-i` log.
+//! gizza-ai/ffmpeg — fetch a URL, run `ffmpeg -i input` on the bytes,
+//! return the log.
 
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
 use wafer_sdk::*;
+
+const MAX_BYTES: usize = 16 * 1024 * 1024; // 16 MiB
+
+#[derive(Deserialize)]
+struct Args {
+    url: String,
+}
+
+#[derive(Serialize)]
+struct NetReq<'a> {
+    method: &'a str,
+    url: &'a str,
+    headers: HashMap<String, String>,
+}
+
+#[derive(Deserialize)]
+struct NetResp {
+    status_code: u16,
+    #[allow(dead_code)]
+    headers: HashMap<String, Vec<String>>,
+    body: Vec<u8>,
+}
+
+#[derive(Serialize)]
+struct FfmpegReq {
+    args: Vec<String>,
+    inputs: Vec<(String, Vec<u8>)>,
+    output: String,
+}
+
+#[derive(Deserialize)]
+struct FfmpegResp {
+    #[allow(dead_code)]
+    exit_code: i32,
+    #[allow(dead_code)]
+    output: Vec<u8>,
+    log: String,
+}
+
+#[derive(Serialize)]
+struct ToolResp {
+    url: String,
+    info: String,
+}
 
 struct FfmpegSkill;
 
@@ -12,10 +60,118 @@ struct FfmpegSkill;
     capabilities(callable_blocks = ["wafer-run/network", "gizza-ai/ffmpeg-runtime"]),
 )]
 impl FfmpegSkill {
-    fn handle(_msg: Message, _body: Vec<u8>) -> GuestResult {
-        GuestResult::error(WaferError::new(
-            ErrorCode::UNIMPLEMENTED,
-            "ffmpeg skill not yet implemented",
-        ))
+    fn handle(_msg: Message, body: Vec<u8>) -> GuestResult {
+        let args: Args = match serde_json::from_slice(&body) {
+            Ok(a) => a,
+            Err(e) => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INVALID_ARGUMENT,
+                    format!("invalid ffmpeg args: {e}"),
+                ));
+            }
+        };
+
+        // 1. Fetch bytes via wafer-run/network.
+        let net_body = match serde_json::to_vec(&NetReq {
+            method: "GET",
+            url: &args.url,
+            headers: HashMap::new(),
+        }) {
+            Ok(v) => v,
+            Err(e) => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INTERNAL,
+                    format!("serialize network request: {e}"),
+                ));
+            }
+        };
+        let (_msg, net_resp_bytes) =
+            match call_block("wafer-run/network", Message::new("network.do"), &net_body) {
+                Ok(v) => v,
+                Err(CallBlockError::Error(e)) => return GuestResult::error(e),
+                Err(other) => {
+                    return GuestResult::error(WaferError::new(
+                        ErrorCode::UNAVAILABLE,
+                        format!("network call failed: {other:?}"),
+                    ));
+                }
+            };
+        let net: NetResp = match serde_json::from_slice(&net_resp_bytes) {
+            Ok(v) => v,
+            Err(e) => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INTERNAL,
+                    format!("malformed network response: {e}"),
+                ));
+            }
+        };
+        if net.status_code >= 400 {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::UNAVAILABLE,
+                format!("HTTP {} for {}", net.status_code, args.url),
+            ));
+        }
+        if net.body.len() > MAX_BYTES {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::OUT_OF_RANGE,
+                format!(
+                    "media file too large: {} bytes (cap {})",
+                    net.body.len(),
+                    MAX_BYTES
+                ),
+            ));
+        }
+
+        // 2. Hand bytes to ffmpeg-runtime.
+        let ffreq = match serde_json::to_vec(&FfmpegReq {
+            args: vec!["-i".into(), "input".into()],
+            inputs: vec![("input".into(), net.body)],
+            output: String::new(),
+        }) {
+            Ok(v) => v,
+            Err(e) => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INTERNAL,
+                    format!("serialize ffmpeg request: {e}"),
+                ));
+            }
+        };
+        let (_msg, ff_resp_bytes) = match call_block(
+            "gizza-ai/ffmpeg-runtime",
+            Message::new("ffmpeg.exec"),
+            &ffreq,
+        ) {
+            Ok(v) => v,
+            Err(CallBlockError::Error(e)) => return GuestResult::error(e),
+            Err(other) => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::UNAVAILABLE,
+                    format!("ffmpeg call failed: {other:?}"),
+                ));
+            }
+        };
+        let ff: FfmpegResp = match serde_json::from_slice(&ff_resp_bytes) {
+            Ok(v) => v,
+            Err(e) => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INTERNAL,
+                    format!("malformed ffmpeg response: {e}"),
+                ));
+            }
+        };
+        // ffmpeg's exit code is expected to be non-zero when no output file
+        // is produced; the log is what we want regardless.
+
+        let tool = ToolResp {
+            url: args.url,
+            info: ff.log,
+        };
+        match serde_json::to_vec(&tool) {
+            Ok(v) => GuestResult::respond(v),
+            Err(e) => GuestResult::error(WaferError::new(
+                ErrorCode::INTERNAL,
+                format!("serialize tool response: {e}"),
+            )),
+        }
     }
 }

--- a/tests/dispatch_skills.rs
+++ b/tests/dispatch_skills.rs
@@ -57,6 +57,7 @@ impl Block for FakeNetworkBlock {
         let url = req["url"].as_str().unwrap_or("");
         let (status, body_bytes): (u16, Vec<u8>) = match url {
             "https://example.test/web-fetch.txt" => (200, b"WEBFETCH_OK_8f3a2".to_vec()),
+            "https://example.test/sample.mp4" => (200, b"FAKE_MP4_BYTES".to_vec()),
             _ => (404, Vec::new()),
         };
 
@@ -191,4 +192,74 @@ async fn ffmpeg_block_dispatches_to_service() {
     assert_eq!(result.exit_code, 0);
     assert_eq!(result.output, b"FAKE_FFMPEG_OUT");
     assert_eq!(result.log, "fake ok");
+}
+
+// -- ffmpeg skill (two-hop) dispatch test ------------------------------------
+
+#[tokio::test]
+async fn ffmpeg_skill_two_hop_dispatch() {
+    let mut wafer = Wafer::builder()
+        .disable_inventory()
+        .disable_lockfile()
+        .build()
+        .expect("Wafer::builder().build()");
+
+    // Hop 1 target: fake network block returning canned bytes for the URL.
+    wafer
+        .register_block("wafer-run/network", Arc::new(FakeNetworkBlock))
+        .expect("register fake network");
+
+    // Hop 2 target: fake ffmpeg-runtime returning a canned log.
+    let ffmpeg_svc: Arc<dyn gizza_ai::ffmpeg::FfmpegService> = Arc::new(FakeFfmpegService {
+        canned_output: Vec::new(),
+        canned_log: "Stream #0:0: Video: h264, yuv420p, 1920x1080, 30 fps".into(),
+    });
+    wafer
+        .register_block(
+            "gizza-ai/ffmpeg-runtime",
+            Arc::new(gizza_ai::blocks::ffmpeg::FfmpegBlock::new(ffmpeg_svc)),
+        )
+        .expect("register ffmpeg-runtime");
+
+    // The skill itself.
+    let wasm: &[u8] = include_bytes!("../blocks/ffmpeg/target/block.wasm");
+    wafer
+        .register_block(
+            "gizza-ai/ffmpeg",
+            Arc::new(WasmiBlock::load_from_bytes(wasm).expect("load ffmpeg skill")),
+        )
+        .expect("register ffmpeg skill");
+
+    let wafer = wafer.start().await.expect("start runtime");
+
+    let body = serde_json::to_vec(&json!({
+        "url": "https://example.test/sample.mp4"
+    }))
+    .expect("serialize request body");
+
+    let output = wafer
+        .run_block(
+            "gizza-ai/ffmpeg",
+            Message::new("invoke"),
+            InputStream::from_bytes(body),
+        )
+        .await;
+
+    let resp = output
+        .collect_buffered()
+        .await
+        .expect("ffmpeg skill non-success terminal");
+
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&resp.body).expect("ffmpeg skill body is JSON");
+
+    assert_eq!(parsed["url"], "https://example.test/sample.mp4");
+    assert!(
+        parsed["info"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("h264"),
+        "info field should contain the canned ffmpeg log marker; got: {}",
+        parsed["info"]
+    );
 }

--- a/tests/skills_embed.rs
+++ b/tests/skills_embed.rs
@@ -26,3 +26,17 @@ fn web_fetch_skill_is_embedded() {
     assert!(!bytes.is_empty(), "web-fetch wasm bytes non-empty");
     assert_eq!(&bytes[..4], b"\0asm", "web-fetch bytes look like wasm");
 }
+
+#[test]
+fn ffmpeg_skill_is_embedded() {
+    assert!(
+        gizza_ai::skills::SKILLS.iter().any(|(n, _)| *n == "gizza-ai/ffmpeg"),
+        "gizza-ai/ffmpeg should be embedded — did you forget to build the block first?"
+    );
+    let (_, bytes) = gizza_ai::skills::SKILLS
+        .iter()
+        .find(|(n, _)| *n == "gizza-ai/ffmpeg")
+        .expect("ffmpeg");
+    assert!(!bytes.is_empty(), "ffmpeg wasm bytes non-empty");
+    assert_eq!(&bytes[..4], b"\0asm", "ffmpeg bytes look like wasm");
+}


### PR DESCRIPTION
## Summary

Adds `gizza-ai/ffmpeg` — a WASM skill block that fetches a URL, runs `ffmpeg -i input` on the bytes via `gizza-ai/ffmpeg-runtime` (#21), and returns the log to the LLM. The first skill in the project that performs a two-hop `call_block` chain (skill → `wafer-run/network` → skill → `gizza-ai/ffmpeg-runtime`).

This is sub-project 2 of the ffmpeg arc — restricted to ffprobe-style read-only operations because resize/transcode binary output has nowhere usable to land in the current text-only chat UI. Resize/transcode wait on sub-projects 3 (drag-drop) and 4 (file preview).

## Why

After PR #21 shipped the ffmpeg-runtime primitive, the obvious next move is the LLM-facing tool. ffprobe is the highest-value text-out operation: the LLM can describe arbitrary media files at a URL.

## Test plan

- [x] `cargo test --test skills_embed` — 3 tests pass (clock + web-fetch + ffmpeg).
- [x] `cargo test --test dispatch_skills` — 3 tests pass (web-fetch round-trip, ffmpeg-runtime, ffmpeg skill two-hop).
- [x] `cargo build --target wasm32-unknown-unknown --release` — succeeds.
- [x] `solobase build` — succeeds; ffmpeg skill bundled.

## Notes

- The skill caps fetched body at 16 MiB (in-block constant; not exposed in the tool surface). ffprobe only reads file headers, so this is plenty for any real media file.
- ffmpeg's exit code is non-zero when `-i` is invoked without an output file. The skill ignores the code and returns `result.log` regardless — that's where ffprobe metadata is printed.
- `FakeNetworkBlock`'s URL match is extended with a second arm (`/sample.mp4` → arbitrary bytes). The existing web-fetch test continues to use the original arm.

## Out of scope (per spec)

- Resize / transcode / crop / trim — sub-projects 3+ in the ffmpeg arc.
- A `max_bytes` arg in the tool surface — the LLM-facing interface stays minimal.
- Range-request fetches — future optimization.
- Storage-backed output URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)