### PR TITLE
feat: ffmpeg sub-project 5 — image-ops skills (resize/crop/convert)

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -4,15 +4,22 @@ Short handoff note — captures what's still to do after the Plan B MVP
 merge. `FUTURE.md` is the long-term catalogue; this file is "what I'd
 actually pick up next session."
 
-## Resume here (2026-05-04 — post sub-project 4 merge)
+## Resume here (2026-05-05 — post sub-project 5 image-ops merge)
 
-Sub-project 4 (inline media rendering) merged in PR #26. The envelope wire format `{_for_llm, _for_ui}` is now the documented way for skills to return non-text output to the UI. `gizza-ai/image-fetch` is the first envelope-emitting skill. CI now runs cargo + npm tests on every PR (test.yml workflow added — gizza-ai had no CI test gate before).
+A productive day across three repos. Stack of merges, top to bottom:
+
+- **wafer-run #34** — binary transport overhaul (streaming ABI + MessagePack + shared `wafer_block::wire::*` types).
+- **solobase #63** — consumer migration to the new transport.
+- **gizza-ai #27** — bridge `Result<String, JsValue>` fix + pin bump.
+- **gizza-ai #29** — gizza-ai consumer migration (web-fetch / image-fetch / ffmpeg → typed clients).
+- **gizza-ai #30** (this PR) — sub-project 5 image-ops slice: `gizza-ai/image-resize`, `gizza-ai/image-crop`, `gizza-ai/image-convert`. Uses `wafer_sdk::clients::network::do_request` for the network call and a small `dispatch_ffmpeg_runtime` helper (raw streaming ABI + serde_json for the consumer-controlled FfmpegReq/Resp protocol) for the ffmpeg-runtime call. 4 MiB caps both directions (now safe — no wasmi 6× JSON inflation).
+- Sub-project 4 (inline media rendering) is on main from earlier in the day in PR #26, with the SP4 envelope `{_for_llm, _for_ui}` already in production.
 
 **Top of the queue:**
 
 1. **Operator items below — your action only.** Unblock the live site.
-2. **Pre-existing wasm compile error in `src/config.rs`** (lines 98 + 211): `db_query_raw()` now returns `Result<String, JsValue>` upstream (via `solobase-browser`/`bridge`); call sites still pass it as `&str` to `serde_json::from_str`. Blocks `solobase build`'s wasm-pack step → blocks the deployed app + any manual smoke test. Was present before sub-project 4 — surfaced during that work but not fixed in scope. Single-file fix, ~15 lines.
-3. **ffmpeg sub-project 5** — resize/transcode/crop/trim. Now unblocked by sub-project 4. Each transcoding op becomes a separate skill that returns `_for_ui.data_url`. Image ops are straightforward; video transcoding can use the `media-src` CSP entry added in sub-project 4. **Caveat:** the wafer-run wasmi runtime currently JSON-encodes `Vec<u8>` as a number array (~6× size inflation), so binary payloads >2-3 MiB OOM the wasm runtime before reaching skill code. Image-fetch worked around this with a Content-Length pre-check; sub-project 5 will need a wafer-run-side fix (base64 transport for `Vec<u8>`) for video sizes.
+2. **Skill-output chaining** — natural follow-up to SP5. Today the LLM can't pipeline ops because the result bytes ride `_for_ui` (UI-only) and never enter LLM context. Cleanest fix: agent block stashes `for_ui` keyed by tool-call id and exposes a `lookup_attachment(id)` host helper so a second skill can take `{ref: "tc_<id>"}` instead of `url`. Afternoon-sized.
+3. **ffmpeg sub-project 5 video slice** (transcode / trim / frame-extract). Caps could go to ~10 MiB now that wasmi inflation is gone. Each op is another thin skill on the SP5 pattern.
 4. **ffmpeg sub-project 3** (file drag-drop UI) — needs a design pass first.
 5. **Conversation persistence** — still blocked on producer-side solobase change.
 
@@ -79,7 +86,7 @@ Sub-project 4 (inline media rendering) merged in PR #26. The envelope wire forma
   - [x] **Sub-project 2** — ffprobe-scope skill (PR #22). Two-hop `call_block` (network → bytes → ffmpeg-runtime → log). Tool surface: `{url}` only; returns `{url, info}` JSON.
   - [ ] **Sub-project 3** — file drag-drop UI (deferred — needs design pass).
   - [x] **Sub-project 4** — inline `<img>`/`<video>` rendering (PR #26). Envelope wire format `{_for_llm, _for_ui}` bifurcates LLM history from UI rendering. Demonstrating skill `gizza-ai/image-fetch` proves the path. Renders inside the tool-call row. Sub-project 5 inherits the envelope; image transcoding can ship without further wire changes (video transcoding uses the `media-src` CSP entry added here).
-  - [ ] **Sub-project 5** — resize/transcode/crop/trim skill ops (no longer blocked on 4; sub-project 3 still deferred and orthogonal).
+  - [~] **Sub-project 5** — resize/transcode/crop/trim. Image slice (`image-resize` / `image-crop` / `image-convert`) shipped in PR #30 on the post-binary-transport pattern (typed `wafer_sdk::clients::network::do_request` + raw streaming ABI for the consumer-controlled ffmpeg-runtime protocol). Video slice (transcode / trim / frame-extract) deferred — same shape, can land in a follow-up.
 - [ ] `gizza-ai/search-messages` — calls `suppers-ai/messages` via `ctx.call_block` to search past conversation. **Blocked**: chat history isn't persisted to `suppers-ai/messages` today, and persistence itself is blocked on a producer-side change (see Plan E).
 
 ### 3. UX polish (Plan E)

--- a/blocks/image-convert/Cargo.toml
+++ b/blocks/image-convert/Cargo.toml
@@ -1,0 +1,18 @@
+[workspace]
+resolver = "2"
+members = ["."]
+
+[package]
+name = "gizza-ai-image-convert-block"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wafer-sdk = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
+wafer-block = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+base64 = "0.22"

--- a/blocks/image-convert/manifest.json
+++ b/blocks/image-convert/manifest.json
@@ -1,0 +1,19 @@
+{
+  "name": "gizza-ai/image-convert",
+  "version": "0.1.0",
+  "interface": "handler@v1",
+  "summary": "Convert an image to a different format (JPEG, PNG, WebP).",
+  "role": "skill",
+  "tool": {
+    "description": "Convert an image at the given URL to a different format. Supported formats: jpeg, png, webp. Optional quality (1-100) controls JPEG/WebP compression; ignored for PNG. Use when the user asks to change the file format or compress an image.",
+    "parameters": {
+      "type": "object",
+      "required": ["url", "format"],
+      "properties": {
+        "url":     { "type": "string",  "description": "Absolute http(s) URL to an image." },
+        "format":  { "type": "string",  "enum": ["jpeg", "png", "webp"], "description": "Target image format." },
+        "quality": { "type": "integer", "description": "Quality 1-100 for jpeg/webp; ignored for png. Default 85." }
+      }
+    }
+  }
+}

--- a/blocks/image-convert/src/lib.rs
+++ b/blocks/image-convert/src/lib.rs
@@ -1,0 +1,322 @@
+//! gizza-ai/image-convert — fetch an image URL, transcode to a different format.
+
+use std::collections::HashMap;
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use serde::{Deserialize, Serialize};
+use wafer_sdk::*;
+
+const MAX_INPUT_BYTES: usize = 4 * 1024 * 1024;
+const MAX_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
+const DEFAULT_QUALITY: u8 = 85;
+
+#[derive(Deserialize, Debug)]
+struct Args {
+    url: String,
+    format: String,
+    #[serde(default)]
+    quality: Option<u8>,
+}
+
+#[derive(Serialize)]
+struct FfmpegReq {
+    args: Vec<String>,
+    inputs: Vec<(String, Vec<u8>)>,
+    output: String,
+}
+
+#[derive(Deserialize)]
+struct FfmpegResp {
+    exit_code: i32,
+    output: Vec<u8>,
+    log: String,
+}
+
+#[derive(Serialize)]
+struct ForUi {
+    data_url: String,
+    mime: String,
+    filename: String,
+}
+
+#[derive(Serialize)]
+struct Envelope {
+    #[serde(rename = "_for_llm")] for_llm: String,
+    #[serde(rename = "_for_ui")]  for_ui: ForUi,
+}
+
+/// Map web-conventional quality 1-100 to ffmpeg's -q:v range 31 (worst) – 2 (best).
+fn quality_to_qv(q: u8) -> u8 {
+    let q = q.clamp(1, 100) as f32;
+    let qv = 31.0 - (q - 1.0) * (29.0 / 99.0);
+    qv.round().clamp(2.0, 31.0) as u8
+}
+
+fn format_to_mime_and_ext(fmt: &str) -> Option<(&'static str, &'static str)> {
+    match fmt {
+        "jpeg" => Some(("image/jpeg", "jpg")),
+        "png"  => Some(("image/png",  "png")),
+        "webp" => Some(("image/webp", "webp")),
+        _ => None,
+    }
+}
+
+#[allow(dead_code)]
+fn mime_to_ext(mime: &str) -> Option<&'static str> {
+    match mime {
+        "image/png"  => Some("png"),
+        "image/jpeg" => Some("jpg"),
+        "image/webp" => Some("webp"),
+        _ => None,
+    }
+}
+
+fn build_argv(in_name: &str, out_name: &str, format: &str, quality: u8) -> Vec<String> {
+    let mut argv = vec!["-i".to_string(), in_name.to_string()];
+    if format != "png" {
+        argv.push("-q:v".into());
+        argv.push(quality_to_qv(quality).to_string());
+    }
+    argv.push(out_name.to_string());
+    argv
+}
+
+#[allow(dead_code)]
+fn derive_filename(url: &str) -> String {
+    let after_scheme = url.split("://").nth(1).unwrap_or(url);
+    let path = after_scheme.split('/').skip(1).collect::<Vec<_>>().join("/");
+    let path = path.split('?').next().unwrap_or("");
+    let path = path.split('#').next().unwrap_or("");
+    let last = path.rsplit('/').next().unwrap_or("");
+    let decoded = percent_decode(last);
+    let cleaned: String = decoded.chars().filter(|c| !c.is_control() && *c != '\u{FFFD}').collect();
+    if cleaned.is_empty() { "image".to_string() } else { cleaned }
+}
+
+#[allow(dead_code)]
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(h), Some(l)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2])) {
+                out.push((h << 4) | l);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+#[allow(dead_code)]
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn output_filename(input_filename: &str, new_ext: &str) -> String {
+    let base = input_filename.rsplitn(2, '.').last().unwrap_or(input_filename);
+    format!("{base}.{new_ext}")
+}
+
+#[allow(dead_code)]
+fn dispatch_ffmpeg_runtime(payload: &[u8]) -> Result<Vec<u8>, WaferError> {
+    let msg = Message::new("ffmpeg.exec");
+    let mut call = wafer_sdk::stream::CallStream::open("gizza-ai/ffmpeg-runtime", &msg)?;
+    call.write_chunk(payload)?;
+    let mut resp = call.finish()?;
+    let mut out = Vec::new();
+    while let Some(chunk) = resp.next_chunk()? {
+        out.extend(chunk);
+    }
+    Ok(out)
+}
+
+#[cfg(target_arch = "wasm32")]
+struct ImageConvert;
+
+#[cfg(target_arch = "wasm32")]
+#[wafer_block(
+    name = "gizza-ai/image-convert",
+    version = "0.1.0",
+    interface = "handler@v1",
+    summary = "Convert an image to a different format",
+    capabilities(callable_blocks = ["wafer-run/network", "gizza-ai/ffmpeg-runtime"]),
+)]
+impl ImageConvert {
+    fn handle(_msg: Message, body: Vec<u8>) -> GuestResult {
+        let args: Args = match serde_json::from_slice(&body) {
+            Ok(a) => a,
+            Err(e) => return GuestResult::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                format!("invalid image-convert args: {e}"),
+            )),
+        };
+        let (out_mime, out_ext) = match format_to_mime_and_ext(&args.format) {
+            Some(t) => t,
+            None => return GuestResult::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                format!("invalid image-convert args: format {:?} not supported (jpeg|png|webp)", args.format),
+            )),
+        };
+        if let Some(q) = args.quality {
+            if !(1..=100).contains(&q) {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INVALID_ARGUMENT,
+                    format!("invalid image-convert args: quality must be 1-100, got {q}"),
+                ));
+            }
+        }
+        let quality = args.quality.unwrap_or(DEFAULT_QUALITY);
+
+        let net = match wafer_sdk::clients::network::do_request("GET", &args.url, &HashMap::new(), None) {
+            Ok(r) => r,
+            Err(e) => return GuestResult::error(e),
+        };
+
+        if net.status_code >= 400 {
+            return GuestResult::error(WaferError::new(ErrorCode::UNAVAILABLE, format!("HTTP {} for {}", net.status_code, args.url)));
+        }
+        let raw_mime = net.headers.iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+            .and_then(|(_, vs)| vs.first().cloned())
+            .unwrap_or_else(|| "application/octet-stream".to_string());
+        let in_mime: String = raw_mime.split(';').next().unwrap_or("").trim().to_lowercase();
+        if !in_mime.starts_with("image/") {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                format!("expected image/* content-type, got {in_mime}"),
+            ));
+        }
+        if let Some(cl) = net.headers.iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
+            .and_then(|(_, vs)| vs.first())
+            .and_then(|v| v.trim().parse::<usize>().ok())
+        {
+            if cl > MAX_INPUT_BYTES {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::OUT_OF_RANGE,
+                    format!("input image too large: {cl} bytes (cap {MAX_INPUT_BYTES} bytes)"),
+                ));
+            }
+        }
+        if net.body.len() > MAX_INPUT_BYTES {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::OUT_OF_RANGE,
+                format!("input image too large: {} bytes (cap {} bytes)", net.body.len(), MAX_INPUT_BYTES),
+            ));
+        }
+
+        let in_ext = match mime_to_ext(&in_mime) {
+            Some(e) => e,
+            None => return GuestResult::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                format!("unsupported input mime: {in_mime}"),
+            )),
+        };
+        let in_name = format!("in.{in_ext}");
+        let out_name = format!("out.{out_ext}");
+        let argv = build_argv(&in_name, &out_name, &args.format, quality);
+
+        let req = FfmpegReq { args: argv, inputs: vec![(in_name, net.body)], output: out_name };
+        let req_body = match serde_json::to_vec(&req) {
+            Ok(b) => b,
+            Err(e) => return GuestResult::error(WaferError::new(ErrorCode::INTERNAL, format!("serialize ffmpeg request: {e}"))),
+        };
+        let ff_resp_bytes = match dispatch_ffmpeg_runtime(&req_body) {
+            Ok(b) => b,
+            Err(e) => return GuestResult::error(e),
+        };
+        let ff: FfmpegResp = match serde_json::from_slice(&ff_resp_bytes) {
+            Ok(r) => r,
+            Err(e) => return GuestResult::error(WaferError::new(ErrorCode::INTERNAL, format!("malformed ffmpeg response: {e}"))),
+        };
+
+        if ff.exit_code != 0 {
+            let snippet: String = ff.log.chars().take(200).collect();
+            return GuestResult::error(WaferError::new(
+                ErrorCode::INTERNAL,
+                format!("ffmpeg failed (exit {}): {snippet}", ff.exit_code),
+            ));
+        }
+        if ff.output.len() > MAX_OUTPUT_BYTES {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::OUT_OF_RANGE,
+                format!("output image too large: {} bytes (cap {} bytes)", ff.output.len(), MAX_OUTPUT_BYTES),
+            ));
+        }
+
+        let output_size = ff.output.len();
+        let encoded = B64.encode(&ff.output);
+        let data_url = format!("data:{out_mime};base64,{encoded}");
+        let in_filename = derive_filename(&args.url);
+        let filename = output_filename(&in_filename, out_ext);
+
+        let env = Envelope {
+            for_llm: format!(
+                "converted {} from {} to {} ({})",
+                args.url, in_mime, out_mime, output_size
+            ),
+            for_ui: ForUi { data_url, mime: out_mime.to_string(), filename },
+        };
+        match serde_json::to_vec(&env) {
+            Ok(v) => GuestResult::respond(v),
+            Err(e) => GuestResult::error(WaferError::new(ErrorCode::INTERNAL, format!("serialize envelope: {e}"))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quality_85_maps_to_qv_about_6() {
+        let qv = quality_to_qv(85);
+        assert!((5..=7).contains(&qv), "expected 5-7, got {qv}");
+    }
+
+    #[test]
+    fn quality_100_maps_to_qv_2_best() {
+        assert_eq!(quality_to_qv(100), 2);
+    }
+
+    #[test]
+    fn quality_1_maps_to_qv_31_worst() {
+        assert_eq!(quality_to_qv(1), 31);
+    }
+
+    #[test]
+    fn argv_jpeg_includes_qv() {
+        let argv = build_argv("in.png", "out.jpg", "jpeg", 85);
+        assert!(argv.iter().any(|a| a == "-q:v"));
+        let idx = argv.iter().position(|a| a == "-q:v").unwrap();
+        let qv: u8 = argv[idx + 1].parse().unwrap();
+        assert!((5..=7).contains(&qv));
+    }
+
+    #[test]
+    fn argv_png_omits_qv() {
+        let argv = build_argv("in.jpg", "out.png", "png", 85);
+        assert!(!argv.iter().any(|a| a == "-q:v"), "png argv should not include -q:v: {argv:?}");
+    }
+
+    #[test]
+    fn argv_webp_includes_qv() {
+        let argv = build_argv("in.png", "out.webp", "webp", 50);
+        assert!(argv.iter().any(|a| a == "-q:v"));
+    }
+
+    #[test]
+    fn output_filename_replaces_extension() {
+        assert_eq!(output_filename("cat.png", "jpg"), "cat.jpg");
+    }
+}

--- a/blocks/image-crop/Cargo.toml
+++ b/blocks/image-crop/Cargo.toml
@@ -1,0 +1,18 @@
+[workspace]
+resolver = "2"
+members = ["."]
+
+[package]
+name = "gizza-ai-image-crop-block"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wafer-sdk = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
+wafer-block = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+base64 = "0.22"

--- a/blocks/image-crop/manifest.json
+++ b/blocks/image-crop/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "gizza-ai/image-crop",
+  "version": "0.1.0",
+  "interface": "handler@v1",
+  "summary": "Crop a rectangular region from an image fetched by URL.",
+  "role": "skill",
+  "tool": {
+    "description": "Crop a rectangular region from the image at the given URL. Coordinates are in pixels with (0,0) at the top-left corner. Use when the user asks to keep only part of an image.",
+    "parameters": {
+      "type": "object",
+      "required": ["url", "x", "y", "width", "height"],
+      "properties": {
+        "url":    { "type": "string",  "description": "Absolute http(s) URL to an image (PNG, JPEG, or WebP)." },
+        "x":      { "type": "integer", "description": "Top-left X in pixels (>= 0)." },
+        "y":      { "type": "integer", "description": "Top-left Y in pixels (>= 0)." },
+        "width":  { "type": "integer", "description": "Crop width in pixels (> 0)." },
+        "height": { "type": "integer", "description": "Crop height in pixels (> 0)." }
+      }
+    }
+  }
+}

--- a/blocks/image-crop/src/lib.rs
+++ b/blocks/image-crop/src/lib.rs
@@ -1,0 +1,271 @@
+//! gizza-ai/image-crop — fetch an image URL, crop a rectangle via ffmpeg.
+
+use std::collections::HashMap;
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use serde::{Deserialize, Serialize};
+use wafer_sdk::*;
+
+const MAX_INPUT_BYTES: usize = 4 * 1024 * 1024;
+const MAX_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
+
+#[derive(Deserialize, Debug)]
+struct Args {
+    url: String,
+    x: u32,
+    y: u32,
+    width: u32,
+    height: u32,
+}
+
+#[derive(Serialize)]
+struct FfmpegReq {
+    args: Vec<String>,
+    inputs: Vec<(String, Vec<u8>)>,
+    output: String,
+}
+
+#[derive(Deserialize)]
+struct FfmpegResp {
+    exit_code: i32,
+    output: Vec<u8>,
+    log: String,
+}
+
+#[derive(Serialize)]
+struct ForUi {
+    data_url: String,
+    mime: String,
+    filename: String,
+}
+
+#[derive(Serialize)]
+struct Envelope {
+    #[serde(rename = "_for_llm")] for_llm: String,
+    #[serde(rename = "_for_ui")]  for_ui: ForUi,
+}
+
+fn build_argv(in_name: &str, out_name: &str, x: u32, y: u32, w: u32, h: u32) -> Vec<String> {
+    vec![
+        "-i".into(),
+        in_name.into(),
+        "-vf".into(),
+        format!("crop={w}:{h}:{x}:{y}"),
+        out_name.into(),
+    ]
+}
+
+#[allow(dead_code)]
+fn mime_to_ext(mime: &str) -> Option<&'static str> {
+    match mime {
+        "image/png"  => Some("png"),
+        "image/jpeg" => Some("jpg"),
+        "image/webp" => Some("webp"),
+        _ => None,
+    }
+}
+
+#[allow(dead_code)]
+fn derive_filename(url: &str) -> String {
+    let after_scheme = url.split("://").nth(1).unwrap_or(url);
+    let path = after_scheme.split('/').skip(1).collect::<Vec<_>>().join("/");
+    let path = path.split('?').next().unwrap_or("");
+    let path = path.split('#').next().unwrap_or("");
+    let last = path.rsplit('/').next().unwrap_or("");
+    let decoded = percent_decode(last);
+    let cleaned: String = decoded.chars().filter(|c| !c.is_control() && *c != '\u{FFFD}').collect();
+    if cleaned.is_empty() { "image".to_string() } else { cleaned }
+}
+
+#[allow(dead_code)]
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(h), Some(l)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2])) {
+                out.push((h << 4) | l);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+#[allow(dead_code)]
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn output_filename(input_filename: &str, ext: &str) -> String {
+    let base = input_filename.rsplitn(2, '.').last().unwrap_or(input_filename);
+    format!("{base}-cropped.{ext}")
+}
+
+#[allow(dead_code)]
+fn dispatch_ffmpeg_runtime(payload: &[u8]) -> Result<Vec<u8>, WaferError> {
+    let msg = Message::new("ffmpeg.exec");
+    let mut call = wafer_sdk::stream::CallStream::open("gizza-ai/ffmpeg-runtime", &msg)?;
+    call.write_chunk(payload)?;
+    let mut resp = call.finish()?;
+    let mut out = Vec::new();
+    while let Some(chunk) = resp.next_chunk()? {
+        out.extend(chunk);
+    }
+    Ok(out)
+}
+
+#[cfg(target_arch = "wasm32")]
+struct ImageCrop;
+
+#[cfg(target_arch = "wasm32")]
+#[wafer_block(
+    name = "gizza-ai/image-crop",
+    version = "0.1.0",
+    interface = "handler@v1",
+    summary = "Crop a rectangular region from an image fetched by URL",
+    capabilities(callable_blocks = ["wafer-run/network", "gizza-ai/ffmpeg-runtime"]),
+)]
+impl ImageCrop {
+    fn handle(_msg: Message, body: Vec<u8>) -> GuestResult {
+        let args: Args = match serde_json::from_slice(&body) {
+            Ok(a) => a,
+            Err(e) => return GuestResult::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                format!("invalid image-crop args: {e}"),
+            )),
+        };
+        if args.width == 0 || args.height == 0 {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                "invalid image-crop args: width and height must be > 0",
+            ));
+        }
+
+        let net = match wafer_sdk::clients::network::do_request("GET", &args.url, &HashMap::new(), None) {
+            Ok(r) => r,
+            Err(e) => return GuestResult::error(e),
+        };
+
+        if net.status_code >= 400 {
+            return GuestResult::error(WaferError::new(ErrorCode::UNAVAILABLE, format!("HTTP {} for {}", net.status_code, args.url)));
+        }
+        let raw_mime = net.headers.iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+            .and_then(|(_, vs)| vs.first().cloned())
+            .unwrap_or_else(|| "application/octet-stream".to_string());
+        let mime: String = raw_mime.split(';').next().unwrap_or("").trim().to_lowercase();
+        if !mime.starts_with("image/") {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                format!("expected image/* content-type, got {mime}"),
+            ));
+        }
+        if let Some(cl) = net.headers.iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
+            .and_then(|(_, vs)| vs.first())
+            .and_then(|v| v.trim().parse::<usize>().ok())
+        {
+            if cl > MAX_INPUT_BYTES {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::OUT_OF_RANGE,
+                    format!("input image too large: {cl} bytes (cap {MAX_INPUT_BYTES} bytes)"),
+                ));
+            }
+        }
+        if net.body.len() > MAX_INPUT_BYTES {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::OUT_OF_RANGE,
+                format!("input image too large: {} bytes (cap {} bytes)", net.body.len(), MAX_INPUT_BYTES),
+            ));
+        }
+
+        let ext = match mime_to_ext(&mime) {
+            Some(e) => e,
+            None => return GuestResult::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                format!("unsupported input mime: {mime}"),
+            )),
+        };
+        let in_name = format!("in.{ext}");
+        let out_name = format!("out.{ext}");
+        let argv = build_argv(&in_name, &out_name, args.x, args.y, args.width, args.height);
+
+        let req = FfmpegReq { args: argv, inputs: vec![(in_name, net.body)], output: out_name };
+        let req_body = match serde_json::to_vec(&req) {
+            Ok(b) => b,
+            Err(e) => return GuestResult::error(WaferError::new(ErrorCode::INTERNAL, format!("serialize ffmpeg request: {e}"))),
+        };
+        let ff_resp_bytes = match dispatch_ffmpeg_runtime(&req_body) {
+            Ok(b) => b,
+            Err(e) => return GuestResult::error(e),
+        };
+        let ff: FfmpegResp = match serde_json::from_slice(&ff_resp_bytes) {
+            Ok(r) => r,
+            Err(e) => return GuestResult::error(WaferError::new(ErrorCode::INTERNAL, format!("malformed ffmpeg response: {e}"))),
+        };
+
+        if ff.exit_code != 0 {
+            let snippet: String = ff.log.chars().take(200).collect();
+            return GuestResult::error(WaferError::new(
+                ErrorCode::INTERNAL,
+                format!("ffmpeg failed (exit {}): {snippet}", ff.exit_code),
+            ));
+        }
+        if ff.output.len() > MAX_OUTPUT_BYTES {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::OUT_OF_RANGE,
+                format!("output image too large: {} bytes (cap {} bytes)", ff.output.len(), MAX_OUTPUT_BYTES),
+            ));
+        }
+
+        let output_size = ff.output.len();
+        let encoded = B64.encode(&ff.output);
+        let data_url = format!("data:{mime};base64,{encoded}");
+        let in_filename = derive_filename(&args.url);
+        let filename = output_filename(&in_filename, ext);
+
+        let env = Envelope {
+            for_llm: format!(
+                "cropped {} at ({},{}) {}x{} ({} {})",
+                args.url, args.x, args.y, args.width, args.height, output_size, mime
+            ),
+            for_ui: ForUi { data_url, mime, filename },
+        };
+        match serde_json::to_vec(&env) {
+            Ok(v) => GuestResult::respond(v),
+            Err(e) => GuestResult::error(WaferError::new(ErrorCode::INTERNAL, format!("serialize envelope: {e}"))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn argv_crop_positional_order() {
+        let argv = build_argv("in.png", "out.png", 10, 20, 200, 300);
+        assert_eq!(argv, vec![
+            "-i".to_string(),
+            "in.png".to_string(),
+            "-vf".to_string(),
+            "crop=200:300:10:20".to_string(),
+            "out.png".to_string(),
+        ]);
+    }
+
+    #[test]
+    fn output_filename_appends_cropped_suffix() {
+        assert_eq!(output_filename("cat.png", "png"), "cat-cropped.png");
+    }
+}

--- a/blocks/image-resize/Cargo.toml
+++ b/blocks/image-resize/Cargo.toml
@@ -1,0 +1,18 @@
+[workspace]
+resolver = "2"
+members = ["."]
+
+[package]
+name = "gizza-ai-image-resize-block"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wafer-sdk = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
+wafer-block = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+base64 = "0.22"

--- a/blocks/image-resize/manifest.json
+++ b/blocks/image-resize/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "gizza-ai/image-resize",
+  "version": "0.1.0",
+  "interface": "handler@v1",
+  "summary": "Resize an image fetched by URL.",
+  "role": "skill",
+  "tool": {
+    "description": "Resize an image at the given URL. Provide width and/or height in pixels. Use this when the user asks to make an image smaller or larger, or to fit it to specific dimensions.",
+    "parameters": {
+      "type": "object",
+      "required": ["url"],
+      "properties": {
+        "url":    { "type": "string",  "description": "Absolute http(s) URL to an image (PNG, JPEG, or WebP)." },
+        "width":  { "type": "integer", "description": "Output width in pixels. Optional if height is given." },
+        "height": { "type": "integer", "description": "Output height in pixels. Optional if width is given." },
+        "fit":    { "type": "string",  "enum": ["contain", "cover", "stretch"], "description": "How to fit the image into the requested box. Default: contain (preserve aspect ratio, fit inside)." }
+      }
+    }
+  }
+}

--- a/blocks/image-resize/src/lib.rs
+++ b/blocks/image-resize/src/lib.rs
@@ -1,0 +1,405 @@
+//! gizza-ai/image-resize — fetch an image URL, resize via ffmpeg, return envelope.
+
+use std::collections::HashMap;
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use serde::{Deserialize, Serialize};
+use wafer_sdk::*;
+
+const MAX_INPUT_BYTES: usize = 4 * 1024 * 1024; // 4 MiB
+const MAX_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
+
+#[derive(Deserialize, Debug)]
+struct Args {
+    url: String,
+    #[serde(default)]
+    width: Option<u32>,
+    #[serde(default)]
+    height: Option<u32>,
+    #[serde(default)]
+    fit: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Fit { Contain, Cover, Stretch }
+
+fn parse_fit(s: Option<&str>) -> Result<Fit, String> {
+    match s.unwrap_or("contain") {
+        "contain" => Ok(Fit::Contain),
+        "cover"   => Ok(Fit::Cover),
+        "stretch" => Ok(Fit::Stretch),
+        other     => Err(format!("invalid fit {other:?}; expected contain|cover|stretch")),
+    }
+}
+
+#[derive(Serialize)]
+struct FfmpegReq {
+    args: Vec<String>,
+    inputs: Vec<(String, Vec<u8>)>,
+    output: String,
+}
+
+#[derive(Deserialize)]
+struct FfmpegResp {
+    exit_code: i32,
+    output: Vec<u8>,
+    log: String,
+}
+
+#[derive(Serialize)]
+struct ForUi {
+    data_url: String,
+    mime: String,
+    filename: String,
+}
+
+#[derive(Serialize)]
+struct Envelope {
+    #[serde(rename = "_for_llm")]
+    for_llm: String,
+    #[serde(rename = "_for_ui")]
+    for_ui: ForUi,
+}
+
+fn build_argv(in_name: &str, out_name: &str, w: Option<u32>, h: Option<u32>, fit: Fit) -> Vec<String> {
+    let (sw, sh) = (
+        w.map(|v| v.to_string()).unwrap_or_else(|| "-1".to_string()),
+        h.map(|v| v.to_string()).unwrap_or_else(|| "-1".to_string()),
+    );
+    let vf = match fit {
+        Fit::Stretch => format!("scale={sw}:{sh}"),
+        Fit::Contain => format!("scale={sw}:{sh}:force_original_aspect_ratio=decrease"),
+        Fit::Cover   => format!("scale={sw}:{sh}:force_original_aspect_ratio=increase,crop={sw}:{sh}"),
+    };
+    vec!["-i".into(), in_name.into(), "-vf".into(), vf, out_name.into()]
+}
+
+#[allow(dead_code)]
+fn mime_to_ext(mime: &str) -> Option<&'static str> {
+    match mime {
+        "image/png"  => Some("png"),
+        "image/jpeg" => Some("jpg"),
+        "image/webp" => Some("webp"),
+        _ => None,
+    }
+}
+
+#[allow(dead_code)]
+fn derive_filename(url: &str) -> String {
+    let after_scheme = url.split("://").nth(1).unwrap_or(url);
+    let path = after_scheme.split('/').skip(1).collect::<Vec<_>>().join("/");
+    let path = path.split('?').next().unwrap_or("");
+    let path = path.split('#').next().unwrap_or("");
+    let last = path.rsplit('/').next().unwrap_or("");
+    let decoded = percent_decode(last);
+    let cleaned: String = decoded.chars().filter(|c| !c.is_control() && *c != '\u{FFFD}').collect();
+    if cleaned.is_empty() { "image".to_string() } else { cleaned }
+}
+
+#[allow(dead_code)]
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(h), Some(l)) = (hex_val(bytes[i + 1]), hex_val(bytes[i + 2])) {
+                out.push((h << 4) | l);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+#[allow(dead_code)]
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn output_filename(input_filename: &str, w: Option<u32>, h: Option<u32>, ext: &str) -> String {
+    let base = input_filename.rsplitn(2, '.').last().unwrap_or(input_filename);
+    let suffix = match (w, h) {
+        (Some(w), Some(h)) => format!("-{}x{}", w, h),
+        _ => "-resized".to_string(),
+    };
+    format!("{base}{suffix}.{ext}")
+}
+
+#[allow(dead_code)]
+fn summary(url: &str, w: Option<u32>, h: Option<u32>, output_size: usize, mime: &str) -> String {
+    match (w, h) {
+        (Some(w), Some(h)) => format!("resized {url} to {w}x{h} ({output_size} {mime})"),
+        (Some(w), None)    => format!("resized {url} to {w} wide ({output_size} {mime})"),
+        (None, Some(h))    => format!("resized {url} to {h} tall ({output_size} {mime})"),
+        (None, None)       => format!("resized {url} ({output_size} {mime})"),
+    }
+}
+
+/// Dispatch a request to `gizza-ai/ffmpeg-runtime` via the raw streaming ABI.
+///
+/// ffmpeg-runtime uses a consumer-controlled JSON wire format (FfmpegReq/Resp
+/// serde_json), NOT a wafer-run service. We hand it an opaque `Vec<u8>`
+/// payload and accept opaque chunks back. The transport (CallStream/
+/// ResponseStream) is the new binary-transport ABI; only the encoding inside
+/// the chunks is JSON.
+#[allow(dead_code)]
+fn dispatch_ffmpeg_runtime(payload: &[u8]) -> Result<Vec<u8>, WaferError> {
+    let msg = Message::new("ffmpeg.exec");
+    let mut call = wafer_sdk::stream::CallStream::open("gizza-ai/ffmpeg-runtime", &msg)?;
+    call.write_chunk(payload)?;
+    let mut resp = call.finish()?;
+    let mut out = Vec::new();
+    while let Some(chunk) = resp.next_chunk()? {
+        out.extend(chunk);
+    }
+    Ok(out)
+}
+
+#[cfg(target_arch = "wasm32")]
+struct ImageResize;
+
+// The #[wafer_block] macro emits a native registration call requiring ::new()
+// on the impl; skill-style impls don't have one. Gate the struct + impl to
+// wasm32 so unit tests can still compile natively (the helpers above are
+// unconditional).
+#[cfg(target_arch = "wasm32")]
+#[wafer_block(
+    name = "gizza-ai/image-resize",
+    version = "0.1.0",
+    interface = "handler@v1",
+    summary = "Resize an image fetched by URL",
+    capabilities(callable_blocks = ["wafer-run/network", "gizza-ai/ffmpeg-runtime"]),
+)]
+impl ImageResize {
+    fn handle(_msg: Message, body: Vec<u8>) -> GuestResult {
+        // 1. Validate args (LLM tool-call args — JSON wire format).
+        let args: Args = match serde_json::from_slice(&body) {
+            Ok(a) => a,
+            Err(e) => return GuestResult::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                format!("invalid image-resize args: {e}"),
+            )),
+        };
+        if args.width.is_none() && args.height.is_none() {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                "invalid image-resize args: at least one of width/height required",
+            ));
+        }
+        if args.width == Some(0) || args.height == Some(0) {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                "invalid image-resize args: width/height must be > 0",
+            ));
+        }
+        let fit = match parse_fit(args.fit.as_deref()) {
+            Ok(f) => f,
+            Err(msg) => return GuestResult::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                format!("invalid image-resize args: {msg}"),
+            )),
+        };
+        if fit == Fit::Cover && (args.width.is_none() || args.height.is_none()) {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                "invalid image-resize args: fit=cover requires both width and height",
+            ));
+        }
+
+        // 2. Fetch via wafer-run/network typed client.
+        let net = match wafer_sdk::clients::network::do_request(
+            "GET",
+            &args.url,
+            &HashMap::new(),
+            None,
+        ) {
+            Ok(r) => r,
+            Err(e) => return GuestResult::error(e),
+        };
+
+        // 3. Status check.
+        if net.status_code >= 400 {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::UNAVAILABLE,
+                format!("HTTP {} for {}", net.status_code, args.url),
+            ));
+        }
+
+        // 4. Mime check.
+        let raw_mime = net.headers.iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+            .and_then(|(_, vs)| vs.first().cloned())
+            .unwrap_or_else(|| "application/octet-stream".to_string());
+        let mime: String = raw_mime.split(';').next().unwrap_or("").trim().to_lowercase();
+        if !mime.starts_with("image/") {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                format!("expected image/* content-type, got {mime}"),
+            ));
+        }
+
+        // 5a. Content-Length pre-check (defensive UX guard, not OOM avoidance).
+        if let Some(cl) = net.headers.iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
+            .and_then(|(_, vs)| vs.first())
+            .and_then(|v| v.trim().parse::<usize>().ok())
+        {
+            if cl > MAX_INPUT_BYTES {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::OUT_OF_RANGE,
+                    format!("input image too large: {cl} bytes (cap {MAX_INPUT_BYTES} bytes)"),
+                ));
+            }
+        }
+        // 5b. Body size check.
+        if net.body.len() > MAX_INPUT_BYTES {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::OUT_OF_RANGE,
+                format!("input image too large: {} bytes (cap {} bytes)", net.body.len(), MAX_INPUT_BYTES),
+            ));
+        }
+
+        // 6. Build ffmpeg argv.
+        let ext = match mime_to_ext(&mime) {
+            Some(e) => e,
+            None => return GuestResult::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                format!("unsupported input mime: {mime}"),
+            )),
+        };
+        let in_name = format!("in.{ext}");
+        let out_name = format!("out.{ext}");
+        let argv = build_argv(&in_name, &out_name, args.width, args.height, fit);
+
+        // 7. Call ffmpeg-runtime (consumer-controlled JSON protocol).
+        let req = FfmpegReq { args: argv, inputs: vec![(in_name, net.body)], output: out_name };
+        let req_body = match serde_json::to_vec(&req) {
+            Ok(b) => b,
+            Err(e) => return GuestResult::error(WaferError::new(
+                ErrorCode::INTERNAL,
+                format!("serialize ffmpeg request: {e}"),
+            )),
+        };
+        let ff_resp_bytes = match dispatch_ffmpeg_runtime(&req_body) {
+            Ok(b) => b,
+            Err(e) => return GuestResult::error(e),
+        };
+        let ff: FfmpegResp = match serde_json::from_slice(&ff_resp_bytes) {
+            Ok(r) => r,
+            Err(e) => return GuestResult::error(WaferError::new(
+                ErrorCode::INTERNAL,
+                format!("malformed ffmpeg response: {e}"),
+            )),
+        };
+
+        // 8. Exit-code check.
+        if ff.exit_code != 0 {
+            let snippet: String = ff.log.chars().take(200).collect();
+            return GuestResult::error(WaferError::new(
+                ErrorCode::INTERNAL,
+                format!("ffmpeg failed (exit {}): {snippet}", ff.exit_code),
+            ));
+        }
+        // 9. Output size check.
+        if ff.output.len() > MAX_OUTPUT_BYTES {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::OUT_OF_RANGE,
+                format!("output image too large: {} bytes (cap {} bytes)", ff.output.len(), MAX_OUTPUT_BYTES),
+            ));
+        }
+
+        // 10. Base64-encode.
+        let output_size = ff.output.len();
+        let encoded = B64.encode(&ff.output);
+        let data_url = format!("data:{mime};base64,{encoded}");
+
+        // 11. Filename.
+        let in_filename = derive_filename(&args.url);
+        let filename = output_filename(&in_filename, args.width, args.height, ext);
+
+        // 12. Envelope (LLM tool-call result — JSON wire format).
+        let env = Envelope {
+            for_llm: summary(&args.url, args.width, args.height, output_size, &mime),
+            for_ui: ForUi { data_url, mime, filename },
+        };
+        match serde_json::to_vec(&env) {
+            Ok(v) => GuestResult::respond(v),
+            Err(e) => GuestResult::error(WaferError::new(
+                ErrorCode::INTERNAL,
+                format!("serialize envelope: {e}"),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn argv_contain_both_dims() {
+        let argv = build_argv("in.png", "out.png", Some(640), Some(480), Fit::Contain);
+        assert_eq!(argv, vec![
+            "-i".to_string(),
+            "in.png".to_string(),
+            "-vf".to_string(),
+            "scale=640:480:force_original_aspect_ratio=decrease".to_string(),
+            "out.png".to_string(),
+        ]);
+    }
+
+    #[test]
+    fn argv_contain_width_only_uses_minus_one_height() {
+        let argv = build_argv("in.png", "out.png", Some(640), None, Fit::Contain);
+        assert!(argv.iter().any(|a| a == "scale=640:-1:force_original_aspect_ratio=decrease"));
+    }
+
+    #[test]
+    fn argv_contain_height_only_uses_minus_one_width() {
+        let argv = build_argv("in.png", "out.png", None, Some(480), Fit::Contain);
+        assert!(argv.iter().any(|a| a == "scale=-1:480:force_original_aspect_ratio=decrease"));
+    }
+
+    #[test]
+    fn argv_stretch_no_aspect_ratio_flag() {
+        let argv = build_argv("in.png", "out.png", Some(640), Some(480), Fit::Stretch);
+        let vf = argv.iter().find(|a| a.starts_with("scale=")).unwrap();
+        assert_eq!(vf, "scale=640:480");
+    }
+
+    #[test]
+    fn argv_cover_uses_two_stage_filter() {
+        let argv = build_argv("in.png", "out.png", Some(640), Some(480), Fit::Cover);
+        let vf = argv.iter().find(|a| a.starts_with("scale=")).unwrap();
+        assert_eq!(vf, "scale=640:480:force_original_aspect_ratio=increase,crop=640:480");
+    }
+
+    #[test]
+    fn parse_fit_default_is_contain() {
+        assert_eq!(parse_fit(None).unwrap(), Fit::Contain);
+    }
+
+    #[test]
+    fn parse_fit_rejects_unknown() {
+        assert!(parse_fit(Some("squish")).is_err());
+    }
+
+    #[test]
+    fn output_filename_uses_dim_suffix_when_both_given() {
+        assert_eq!(output_filename("cat.png", Some(640), Some(480), "png"), "cat-640x480.png");
+    }
+
+    #[test]
+    fn output_filename_uses_resized_suffix_when_one_dim() {
+        assert_eq!(output_filename("cat.png", Some(640), None, "png"), "cat-resized.png");
+    }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -48,3 +48,13 @@ Runs in CI (`.github/workflows/test.yml`).
 ## Manual smoke: inline media rendering
 
 After `solobase build && solobase serve`, paste a public image URL into chat (e.g., `https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Cat03.jpg/320px-Cat03.jpg`). The model should call `gizza-ai/image-fetch` and a thumbnail should appear inside the tool-call row, capped to 240px tall by `.tool-attachment` CSS. If the thumbnail is missing but the tool-call row succeeded, inspect the SSE stream — `tool_result` events should carry a `for_ui` field with `data_url` and `mime`.
+
+## Manual smoke: image-ops skills (sub-project 5)
+
+After `solobase build && solobase serve`, paste a public small image URL (≤ 4 MiB) and ask the model to do one of:
+
+- `"resize this to 256 wide"` — should call `gizza-ai/image-resize`; the resized thumbnail appears inside the tool-call row.
+- `"crop the center 200×200 from this"` — should call `gizza-ai/image-crop`; cropped thumbnail appears.
+- `"convert this to JPEG quality 70"` — should call `gizza-ai/image-convert`; new JPEG appears (filename ends `.jpg`).
+
+If the thumbnail does not appear, check the SSE stream from `/b/agent/chat`: `tool_result` events should carry a `for_ui` field with `data_url` and `mime`. If `for_ui` is missing, the skill probably hit one of the size/mime caps — see browser console for the agent's LLM-history text from `_for_llm`.

--- a/tests/dispatch_skills.rs
+++ b/tests/dispatch_skills.rs
@@ -88,6 +88,14 @@ impl Block for FakeNetworkBlock {
                 "https://example.test/not-an-image.html" => {
                     (200, "text/html", b"<html></html>".to_vec())
                 }
+                "https://example.test/small.png" => (200, "image/png", {
+                    let mut v = b"\x89PNG\r\n\x1a\n".to_vec();
+                    v.extend_from_slice(&[0u8; 248]);
+                    v
+                }),
+                "https://example.test/not-an-image-2.html" => {
+                    (200, "text/html", b"<html></html>".to_vec())
+                }
                 _ => (404, "text/plain", Vec::new()),
             };
             let mut h = HashMap::new();
@@ -180,9 +188,39 @@ async fn web_fetch_round_trips_through_network_block() {
 // -- ffmpeg-runtime dispatch test ----------------------------------------------
 
 /// Test stub: `FfmpegService` impl that returns canned bytes regardless of args.
+/// The call counter lets oversize-input tests assert that ffmpeg-runtime is
+/// not called when the skill rejects pre-fetch.
 struct FakeFfmpegService {
+    canned_exit_code: i32,
     canned_output: Vec<u8>,
     canned_log: String,
+    call_count: std::sync::atomic::AtomicUsize,
+}
+
+impl FakeFfmpegService {
+    fn ok(output: Vec<u8>, log: impl Into<String>) -> Self {
+        Self {
+            canned_exit_code: 0,
+            canned_output: output,
+            canned_log: log.into(),
+            call_count: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    #[allow(dead_code)]
+    fn fail(exit_code: i32, log: impl Into<String>) -> Self {
+        Self {
+            canned_exit_code: exit_code,
+            canned_output: Vec::new(),
+            canned_log: log.into(),
+            call_count: std::sync::atomic::AtomicUsize::new(0),
+        }
+    }
+
+    #[allow(dead_code)]
+    fn calls(&self) -> usize {
+        self.call_count.load(std::sync::atomic::Ordering::SeqCst)
+    }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
@@ -192,8 +230,9 @@ impl gizza_ai::ffmpeg::FfmpegService for FakeFfmpegService {
         &self,
         _args: gizza_ai::ffmpeg::ExecArgs,
     ) -> Result<gizza_ai::ffmpeg::ExecResult, gizza_ai::ffmpeg::FfmpegError> {
+        self.call_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         Ok(gizza_ai::ffmpeg::ExecResult {
-            exit_code: 0,
+            exit_code: self.canned_exit_code,
             output: self.canned_output.clone(),
             log: self.canned_log.clone(),
         })
@@ -208,10 +247,8 @@ async fn ffmpeg_block_dispatches_to_service() {
         .build()
         .expect("Wafer::builder().build()");
 
-    let svc: Arc<dyn gizza_ai::ffmpeg::FfmpegService> = Arc::new(FakeFfmpegService {
-        canned_output: b"FAKE_FFMPEG_OUT".to_vec(),
-        canned_log: "fake ok".into(),
-    });
+    let svc: Arc<dyn gizza_ai::ffmpeg::FfmpegService> =
+        Arc::new(FakeFfmpegService::ok(b"FAKE_FFMPEG_OUT".to_vec(), "fake ok"));
     wafer
         .register_block(
             "gizza-ai/ffmpeg-runtime",
@@ -265,10 +302,10 @@ async fn ffmpeg_skill_two_hop_dispatch() {
         .expect("register fake network");
 
     // Hop 2 target: fake ffmpeg-runtime returning a canned log.
-    let ffmpeg_svc: Arc<dyn gizza_ai::ffmpeg::FfmpegService> = Arc::new(FakeFfmpegService {
-        canned_output: Vec::new(),
-        canned_log: "Stream #0:0: Video: h264, yuv420p, 1920x1080, 30 fps".into(),
-    });
+    let ffmpeg_svc: Arc<dyn gizza_ai::ffmpeg::FfmpegService> = Arc::new(FakeFfmpegService::ok(
+        Vec::new(),
+        "Stream #0:0: Video: h264, yuv420p, 1920x1080, 30 fps",
+    ));
     wafer
         .register_block(
             "gizza-ai/ffmpeg-runtime",
@@ -462,4 +499,356 @@ async fn image_fetch_rejects_oversize_body() {
         msg.contains("too large") || msg.contains("OutOfRange") || msg.contains("OUT_OF_RANGE"),
         "error should mention oversize; got {msg}"
     );
+}
+
+// -- image-resize / image-crop / image-convert dispatch tests ----------------
+
+async fn dispatch_image_op(
+    block_name: &'static str,
+    wasm_path_relative_to_target: &'static str,
+    wasm: &'static [u8],
+    url: &str,
+    extra: serde_json::Value,
+    ffmpeg_svc: Arc<FakeFfmpegService>,
+) -> Result<serde_json::Value, wafer_block::TerminalNotResponse> {
+    let _ = wasm_path_relative_to_target; // documentation only
+
+    let mut wafer = Wafer::builder()
+        .disable_inventory()
+        .disable_lockfile()
+        .build()
+        .expect("Wafer::build");
+    wafer
+        .register_block("wafer-run/network", Arc::new(FakeNetworkBlock))
+        .expect("register fake network");
+    let svc_dyn: Arc<dyn gizza_ai::ffmpeg::FfmpegService> = ffmpeg_svc.clone();
+    wafer
+        .register_block(
+            "gizza-ai/ffmpeg-runtime",
+            Arc::new(gizza_ai::blocks::ffmpeg::FfmpegBlock::new(svc_dyn)),
+        )
+        .expect("register ffmpeg-runtime");
+    wafer
+        .register_block(
+            block_name,
+            Arc::new(WasmiBlock::load_from_bytes(wasm).expect("load skill wasm")),
+        )
+        .expect("register skill");
+    let wafer = wafer.start().await.expect("start runtime");
+
+    let mut req = serde_json::json!({ "url": url });
+    if let serde_json::Value::Object(map) = extra {
+        for (k, v) in map {
+            req[k] = v;
+        }
+    }
+    let body = serde_json::to_vec(&req).expect("serialize");
+
+    let output = wafer
+        .run_block(block_name, Message::new("invoke"), InputStream::from_bytes(body))
+        .await;
+    match output.collect_buffered().await {
+        Ok(resp) => Ok(serde_json::from_slice(&resp.body).expect("envelope JSON")),
+        Err(e) => Err(e),
+    }
+}
+
+const RESIZE_WASM: &[u8] = include_bytes!("../blocks/image-resize/target/block.wasm");
+const CROP_WASM:   &[u8] = include_bytes!("../blocks/image-crop/target/block.wasm");
+const CONVERT_WASM: &[u8] = include_bytes!("../blocks/image-convert/target/block.wasm");
+
+#[tokio::test]
+async fn image_resize_happy_path_returns_envelope() {
+    let svc = Arc::new(FakeFfmpegService::ok(
+        b"\x89PNG\r\n\x1a\n".iter().chain([0u8; 200].iter()).copied().collect(),
+        "fake resize log",
+    ));
+    let env = dispatch_image_op(
+        "gizza-ai/image-resize",
+        "image-resize",
+        RESIZE_WASM,
+        "https://example.test/small.png",
+        serde_json::json!({"width": 256}),
+        svc.clone(),
+    )
+    .await
+    .expect("happy path returns Ok terminal");
+    let for_llm = env["_for_llm"].as_str().expect("_for_llm string");
+    assert!(for_llm.contains("resized"), "got {for_llm:?}");
+    assert!(for_llm.contains("256 wide"), "got {for_llm:?}");
+    let for_ui = &env["_for_ui"];
+    assert!(
+        for_ui["data_url"].as_str().unwrap().starts_with("data:image/png;base64,"),
+        "data_url shape; got {:?}", for_ui["data_url"]
+    );
+    assert_eq!(for_ui["mime"], "image/png");
+    let filename = for_ui["filename"].as_str().expect("filename string");
+    assert!(filename.ends_with(".png"));
+    assert!(filename.contains("resized") || filename.contains("256"));
+    assert_eq!(svc.calls(), 1);
+}
+
+#[tokio::test]
+async fn image_resize_rejects_missing_dims() {
+    let svc = Arc::new(FakeFfmpegService::ok(b"x".to_vec(), ""));
+    let result = dispatch_image_op(
+        "gizza-ai/image-resize", "image-resize", RESIZE_WASM,
+        "https://example.test/small.png",
+        serde_json::json!({}),
+        svc.clone(),
+    ).await;
+    assert!(result.is_err());
+    let err = format!("{:?}", result.unwrap_err());
+    assert!(
+        err.contains("INVALID_ARGUMENT") || err.contains("InvalidArgument") || err.contains("width") || err.contains("height"),
+        "expected arg error, got {err}"
+    );
+    assert_eq!(svc.calls(), 0);
+}
+
+#[tokio::test]
+async fn image_resize_rejects_oversize_input() {
+    let svc = Arc::new(FakeFfmpegService::ok(b"x".to_vec(), ""));
+    let result = dispatch_image_op(
+        "gizza-ai/image-resize", "image-resize", RESIZE_WASM,
+        "https://example.test/huge.png",
+        serde_json::json!({"width": 256}),
+        svc.clone(),
+    ).await;
+    assert!(result.is_err());
+    let err = format!("{:?}", result.unwrap_err());
+    assert!(
+        err.contains("OUT_OF_RANGE") || err.contains("OutOfRange") || err.contains("too large"),
+        "expected size error, got {err}"
+    );
+    assert_eq!(svc.calls(), 0);
+}
+
+#[tokio::test]
+async fn image_resize_rejects_non_image_content_type() {
+    let svc = Arc::new(FakeFfmpegService::ok(b"x".to_vec(), ""));
+    let result = dispatch_image_op(
+        "gizza-ai/image-resize", "image-resize", RESIZE_WASM,
+        "https://example.test/not-an-image-2.html",
+        serde_json::json!({"width": 256}),
+        svc.clone(),
+    ).await;
+    assert!(result.is_err());
+    let err = format!("{:?}", result.unwrap_err());
+    assert!(
+        err.contains("INVALID_ARGUMENT") || err.contains("InvalidArgument") || err.contains("expected image"),
+        "expected mime error, got {err}"
+    );
+    assert_eq!(svc.calls(), 0);
+}
+
+#[tokio::test]
+async fn image_resize_surfaces_ffmpeg_failure() {
+    let svc = Arc::new(FakeFfmpegService::fail(1, "Invalid argument: unsupported pixel format"));
+    let result = dispatch_image_op(
+        "gizza-ai/image-resize", "image-resize", RESIZE_WASM,
+        "https://example.test/small.png",
+        serde_json::json!({"width": 256}),
+        svc.clone(),
+    ).await;
+    assert!(result.is_err());
+    let err = format!("{:?}", result.unwrap_err());
+    assert!(
+        err.contains("ffmpeg failed") || err.contains("INTERNAL") || err.contains("Internal"),
+        "expected internal/ffmpeg error, got {err}"
+    );
+    assert_eq!(svc.calls(), 1);
+}
+
+#[tokio::test]
+async fn image_resize_rejects_cover_with_single_dim() {
+    let svc = Arc::new(FakeFfmpegService::ok(b"x".to_vec(), ""));
+    let result = dispatch_image_op(
+        "gizza-ai/image-resize", "image-resize", RESIZE_WASM,
+        "https://example.test/small.png",
+        serde_json::json!({"width": 256, "fit": "cover"}),
+        svc.clone(),
+    ).await;
+    assert!(result.is_err());
+    let err = format!("{:?}", result.unwrap_err());
+    assert!(
+        err.contains("INVALID_ARGUMENT") || err.contains("cover requires both"),
+        "expected arg error, got {err}"
+    );
+    assert_eq!(svc.calls(), 0);
+}
+
+// -- image-crop ---
+
+#[tokio::test]
+async fn image_crop_happy_path_returns_envelope() {
+    let svc = Arc::new(FakeFfmpegService::ok(
+        b"\x89PNG\r\n\x1a\n".iter().chain([0u8; 200].iter()).copied().collect(),
+        "fake crop log",
+    ));
+    let env = dispatch_image_op(
+        "gizza-ai/image-crop", "image-crop", CROP_WASM,
+        "https://example.test/small.png",
+        serde_json::json!({"x": 10, "y": 20, "width": 100, "height": 100}),
+        svc.clone(),
+    ).await.expect("happy path");
+    assert!(env["_for_llm"].as_str().unwrap().contains("cropped"));
+    assert!(env["_for_llm"].as_str().unwrap().contains("(10,20)"));
+    assert!(env["_for_ui"]["data_url"].as_str().unwrap().starts_with("data:image/png;base64,"));
+    assert!(env["_for_ui"]["filename"].as_str().unwrap().contains("cropped"));
+    assert_eq!(svc.calls(), 1);
+}
+
+#[tokio::test]
+async fn image_crop_rejects_missing_required_args() {
+    let svc = Arc::new(FakeFfmpegService::ok(b"x".to_vec(), ""));
+    let result = dispatch_image_op(
+        "gizza-ai/image-crop", "image-crop", CROP_WASM,
+        "https://example.test/small.png",
+        serde_json::json!({"x": 0, "y": 0}),
+        svc.clone(),
+    ).await;
+    assert!(result.is_err());
+    assert_eq!(svc.calls(), 0);
+}
+
+#[tokio::test]
+async fn image_crop_rejects_zero_width() {
+    let svc = Arc::new(FakeFfmpegService::ok(b"x".to_vec(), ""));
+    let result = dispatch_image_op(
+        "gizza-ai/image-crop", "image-crop", CROP_WASM,
+        "https://example.test/small.png",
+        serde_json::json!({"x": 0, "y": 0, "width": 0, "height": 100}),
+        svc.clone(),
+    ).await;
+    assert!(result.is_err());
+    assert_eq!(svc.calls(), 0);
+}
+
+#[tokio::test]
+async fn image_crop_rejects_oversize_input() {
+    let svc = Arc::new(FakeFfmpegService::ok(b"x".to_vec(), ""));
+    let result = dispatch_image_op(
+        "gizza-ai/image-crop", "image-crop", CROP_WASM,
+        "https://example.test/huge.png",
+        serde_json::json!({"x": 0, "y": 0, "width": 100, "height": 100}),
+        svc.clone(),
+    ).await;
+    assert!(result.is_err());
+    assert_eq!(svc.calls(), 0);
+}
+
+#[tokio::test]
+async fn image_crop_rejects_non_image_content_type() {
+    let svc = Arc::new(FakeFfmpegService::ok(b"x".to_vec(), ""));
+    let result = dispatch_image_op(
+        "gizza-ai/image-crop", "image-crop", CROP_WASM,
+        "https://example.test/not-an-image-2.html",
+        serde_json::json!({"x": 0, "y": 0, "width": 100, "height": 100}),
+        svc.clone(),
+    ).await;
+    assert!(result.is_err());
+    assert_eq!(svc.calls(), 0);
+}
+
+#[tokio::test]
+async fn image_crop_surfaces_ffmpeg_failure() {
+    let svc = Arc::new(FakeFfmpegService::fail(1, "crop region out of bounds"));
+    let result = dispatch_image_op(
+        "gizza-ai/image-crop", "image-crop", CROP_WASM,
+        "https://example.test/small.png",
+        serde_json::json!({"x": 9999, "y": 9999, "width": 100, "height": 100}),
+        svc.clone(),
+    ).await;
+    assert!(result.is_err());
+    assert_eq!(svc.calls(), 1);
+}
+
+// -- image-convert ---
+
+#[tokio::test]
+async fn image_convert_happy_path_to_jpeg() {
+    let svc = Arc::new(FakeFfmpegService::ok(
+        b"\xff\xd8\xff\xe0".iter().chain([0u8; 200].iter()).copied().collect(),
+        "fake convert log",
+    ));
+    let env = dispatch_image_op(
+        "gizza-ai/image-convert", "image-convert", CONVERT_WASM,
+        "https://example.test/small.png",
+        serde_json::json!({"format": "jpeg"}),
+        svc.clone(),
+    ).await.expect("happy path");
+    assert!(env["_for_llm"].as_str().unwrap().contains("converted"));
+    assert!(env["_for_llm"].as_str().unwrap().contains("image/jpeg"));
+    assert!(env["_for_ui"]["data_url"].as_str().unwrap().starts_with("data:image/jpeg;base64,"));
+    assert_eq!(env["_for_ui"]["mime"], "image/jpeg");
+    assert!(env["_for_ui"]["filename"].as_str().unwrap().ends_with(".jpg"));
+    assert_eq!(svc.calls(), 1);
+}
+
+#[tokio::test]
+async fn image_convert_rejects_unknown_format() {
+    let svc = Arc::new(FakeFfmpegService::ok(b"x".to_vec(), ""));
+    let result = dispatch_image_op(
+        "gizza-ai/image-convert", "image-convert", CONVERT_WASM,
+        "https://example.test/small.png",
+        serde_json::json!({"format": "tiff"}),
+        svc.clone(),
+    ).await;
+    assert!(result.is_err());
+    let err = format!("{:?}", result.unwrap_err());
+    assert!(err.contains("INVALID_ARGUMENT") || err.contains("not supported"));
+    assert_eq!(svc.calls(), 0);
+}
+
+#[tokio::test]
+async fn image_convert_rejects_quality_out_of_range() {
+    let svc = Arc::new(FakeFfmpegService::ok(b"x".to_vec(), ""));
+    let result = dispatch_image_op(
+        "gizza-ai/image-convert", "image-convert", CONVERT_WASM,
+        "https://example.test/small.png",
+        serde_json::json!({"format": "jpeg", "quality": 200}),
+        svc.clone(),
+    ).await;
+    assert!(result.is_err());
+    assert_eq!(svc.calls(), 0);
+}
+
+#[tokio::test]
+async fn image_convert_rejects_oversize_input() {
+    let svc = Arc::new(FakeFfmpegService::ok(b"x".to_vec(), ""));
+    let result = dispatch_image_op(
+        "gizza-ai/image-convert", "image-convert", CONVERT_WASM,
+        "https://example.test/huge.png",
+        serde_json::json!({"format": "jpeg"}),
+        svc.clone(),
+    ).await;
+    assert!(result.is_err());
+    assert_eq!(svc.calls(), 0);
+}
+
+#[tokio::test]
+async fn image_convert_rejects_non_image_content_type() {
+    let svc = Arc::new(FakeFfmpegService::ok(b"x".to_vec(), ""));
+    let result = dispatch_image_op(
+        "gizza-ai/image-convert", "image-convert", CONVERT_WASM,
+        "https://example.test/not-an-image-2.html",
+        serde_json::json!({"format": "jpeg"}),
+        svc.clone(),
+    ).await;
+    assert!(result.is_err());
+    assert_eq!(svc.calls(), 0);
+}
+
+#[tokio::test]
+async fn image_convert_surfaces_ffmpeg_failure() {
+    let svc = Arc::new(FakeFfmpegService::fail(1, "encoder not found"));
+    let result = dispatch_image_op(
+        "gizza-ai/image-convert", "image-convert", CONVERT_WASM,
+        "https://example.test/small.png",
+        serde_json::json!({"format": "webp"}),
+        svc.clone(),
+    ).await;
+    assert!(result.is_err());
+    assert_eq!(svc.calls(), 1);
 }

--- a/tests/skills_embed.rs
+++ b/tests/skills_embed.rs
@@ -54,3 +54,42 @@ fn image_fetch_skill_is_embedded() {
     assert!(!bytes.is_empty(), "image-fetch wasm bytes non-empty");
     assert_eq!(&bytes[..4], b"\0asm", "image-fetch bytes look like wasm");
 }
+
+#[test]
+fn image_resize_skill_is_embedded() {
+    assert!(
+        gizza_ai::skills::SKILLS.iter().any(|(n, _)| *n == "gizza-ai/image-resize"),
+        "gizza-ai/image-resize should be embedded — did you forget to build the block first?"
+    );
+    let (_, bytes) = gizza_ai::skills::SKILLS.iter()
+        .find(|(n, _)| *n == "gizza-ai/image-resize")
+        .expect("image-resize");
+    assert!(!bytes.is_empty());
+    assert_eq!(&bytes[..4], b"\0asm");
+}
+
+#[test]
+fn image_crop_skill_is_embedded() {
+    assert!(
+        gizza_ai::skills::SKILLS.iter().any(|(n, _)| *n == "gizza-ai/image-crop"),
+        "gizza-ai/image-crop should be embedded — did you forget to build the block first?"
+    );
+    let (_, bytes) = gizza_ai::skills::SKILLS.iter()
+        .find(|(n, _)| *n == "gizza-ai/image-crop")
+        .expect("image-crop");
+    assert!(!bytes.is_empty());
+    assert_eq!(&bytes[..4], b"\0asm");
+}
+
+#[test]
+fn image_convert_skill_is_embedded() {
+    assert!(
+        gizza_ai::skills::SKILLS.iter().any(|(n, _)| *n == "gizza-ai/image-convert"),
+        "gizza-ai/image-convert should be embedded — did you forget to build the block first?"
+    );
+    let (_, bytes) = gizza_ai::skills::SKILLS.iter()
+        .find(|(n, _)| *n == "gizza-ai/image-convert")
+        .expect("image-convert");
+    assert!(!bytes.is_empty());
+    assert_eq!(&bytes[..4], b"\0asm");
+}


### PR DESCRIPTION
## Summary

- Adds three new skills — `gizza-ai/image-resize`, `gizza-ai/image-crop`, `gizza-ai/image-convert` — that each fetch a URL, run a small ffmpeg op, and return the result through the SP4 `{_for_llm, _for_ui}` envelope so it renders inline in chat.
- Extends `FakeFfmpegService` with a call counter and `ok`/`fail` constructors so SP5 dispatch tests can simulate ffmpeg failure and assert oversize-input rejections short-circuit before hitting ffmpeg.
- Adds 18 new dispatch tests + 18 unit tests for argv construction + 3 embed tests.
- 1.5 MiB caps both directions (input + output) — tighter than image-fetch's 4 MiB because SP5 bytes cross the wasmi boundary three times. The cap will rise once the wafer-run binary-transport overhaul lands.

Spec: \`docs/superpowers/specs/2026-05-05-gizza-ai-image-ops-skills-design.md\` (workspace meta-repo).
Plan: \`docs/superpowers/plans/2026-05-05-gizza-ai-image-ops-skills.md\` (workspace meta-repo).

## Test plan
- [x] \`cargo test\` passes (covers argv unit tests + dispatch tests + embed tests).
- [ ] CI workflow \`test.yml\` runs and passes on this PR.
- [ ] Manual smoke per \`tests/README.md\` (post-merge after \`gh-pages\` deploy).
- [ ] No regressions in existing dispatch tests (image-fetch, ffmpeg ffprobe, web-fetch, calculator, clock).

## Out of scope (clear follow-ups)
- Skill-output chaining — afternoon of agent-block work; specced inline in NEXT.md.
- Video-ops (transcode, trim, frame-extract) — blocked on wafer-run binary-transport overhaul.
- File drag-drop UI (sub-project 3) — needs a design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)