### PR TITLE
feat: SP5 video-ops slice (transcode/trim/frame-extract)

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -9,6 +9,7 @@ actually pick up next session."
 A productive day across three repos. Stack of merges, top to bottom:
 
 - **wafer-run #36 / #37 / #38** — attachment ABI (per-call host helpers `__wafer_host_stream_attach` + `__wafer_host_lookup_attachment` + `Context::lookup_attachment` + `Attachment` type), `#[wafer_block(skill(...))]` macro attribute for LLM tool schemas, and wafer-cli validator stubs for the new imports.
+- **gizza-ai #32** (this PR) — SP5 video slice. Three new skills: `gizza-ai/video-transcode` (mp4/webm with quality knob), `gizza-ai/video-trim` (stream-copy to mp4), `gizza-ai/video-frame-extract` (single-frame PNG, naturally chainable into image-* skills via the SP4 envelope). 10 MiB symmetric caps. All accept `{url|ref}`. The `dispatch_chains_video_frame_extract_then_image_resize_via_ref` test proves the cross-modality chain.
 - **gizza-ai #31** (this PR) — skill-output chaining. Agent block stashes `_for_ui` attachments per request and appends a ref hint to `_for_llm`; image-resize / image-crop / image-convert accept `{ref: "<call-id>"}` as an alternative to `{url}`. **Also fixes a pre-existing gap:** every gizza-ai skill block (clock, calculator, web-fetch, image-fetch, ffmpeg, image-resize, image-crop, image-convert) now uses the new `skill(...)` macro attribute, so the LLM finally sees them in the tool list. Before this PR, `Context::registered_blocks()` had `role: None` and `tool: None` on every wasmi-built skill; the agent's `build_tools()` returned an empty `Vec<ToolDefinition>` on every chat request.
 - **wafer-run #34** — binary transport overhaul (streaming ABI + MessagePack + shared `wafer_block::wire::*` types).
 - **solobase #63** — consumer migration to the new transport.
@@ -20,9 +21,8 @@ A productive day across three repos. Stack of merges, top to bottom:
 **Top of the queue:**
 
 1. **Operator items below — your action only.** Unblock the live site.
-2. **ffmpeg sub-project 5 video slice** (transcode / trim / frame-extract). Caps could go to ~10 MiB now that wasmi inflation is gone. Each op is another thin skill on the SP5 pattern.
-3. **ffmpeg sub-project 3** (file drag-drop UI) — needs a design pass first.
-4. **Conversation persistence** — still blocked on producer-side solobase change.
+2. **ffmpeg sub-project 3** (file drag-drop UI) — needs a design pass first.
+3. **Conversation persistence** — still blocked on producer-side solobase change.
 
 **Cross-repo news from the 2026-05-03 session:**
 
@@ -88,7 +88,7 @@ A productive day across three repos. Stack of merges, top to bottom:
   - [x] **Sub-project 2** — ffprobe-scope skill (PR #22). Two-hop `call_block` (network → bytes → ffmpeg-runtime → log). Tool surface: `{url}` only; returns `{url, info}` JSON.
   - [ ] **Sub-project 3** — file drag-drop UI (deferred — needs design pass).
   - [x] **Sub-project 4** — inline `<img>`/`<video>` rendering (PR #26). Envelope wire format `{_for_llm, _for_ui}` bifurcates LLM history from UI rendering. Demonstrating skill `gizza-ai/image-fetch` proves the path. Renders inside the tool-call row. Sub-project 5 inherits the envelope; image transcoding can ship without further wire changes (video transcoding uses the `media-src` CSP entry added here).
-  - [~] **Sub-project 5** — resize/transcode/crop/trim. Image slice (`image-resize` / `image-crop` / `image-convert`) shipped in PR #30 on the post-binary-transport pattern (typed `wafer_sdk::clients::network::do_request` + raw streaming ABI for the consumer-controlled ffmpeg-runtime protocol). Video slice (transcode / trim / frame-extract) deferred — same shape, can land in a follow-up.
+  - [x] **Sub-project 5** — resize/transcode/crop/trim. Image slice (image-resize/crop/convert) shipped in PR #30. Video slice (video-transcode/trim/frame-extract) shipped in PR #32 — same SP5 template, 10 MiB caps, chainable via {url|ref}.
 - [ ] `gizza-ai/search-messages` — calls `suppers-ai/messages` via `ctx.call_block` to search past conversation. **Blocked**: chat history isn't persisted to `suppers-ai/messages` today, and persistence itself is blocked on a producer-side change (see Plan E).
 
 ### 3. UX polish (Plan E)

--- a/blocks/video-frame-extract/Cargo.toml
+++ b/blocks/video-frame-extract/Cargo.toml
@@ -1,0 +1,18 @@
+[workspace]
+resolver = "2"
+members = ["."]
+
+[package]
+name = "gizza-ai-video-frame-extract-block"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wafer-sdk = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
+wafer-block = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+base64 = "0.22"

--- a/blocks/video-frame-extract/manifest.json
+++ b/blocks/video-frame-extract/manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "gizza-ai/video-frame-extract",
+  "version": "0.1.0",
+  "interface": "handler@v1",
+  "summary": "Extract a single frame from a video at a given timestamp."
+}

--- a/blocks/video-frame-extract/src/lib.rs
+++ b/blocks/video-frame-extract/src/lib.rs
@@ -1,0 +1,436 @@
+//! gizza-ai/video-frame-extract — fetch a video URL or attachment ref, extract a single frame as PNG.
+
+use std::collections::HashMap;
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use serde::{Deserialize, Serialize};
+use wafer_sdk::*;
+
+const MAX_INPUT_BYTES: usize = 10 * 1024 * 1024;
+const MAX_OUTPUT_BYTES: usize = 10 * 1024 * 1024;
+
+#[derive(Deserialize, Debug)]
+struct Args {
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    r#ref: Option<String>,
+    timestamp: f64,
+}
+
+enum Source {
+    Url(String),
+    Ref(String),
+}
+
+impl Args {
+    fn source(&self) -> Result<Source, String> {
+        match (&self.url, &self.r#ref) {
+            (Some(u), None) => Ok(Source::Url(u.clone())),
+            (None, Some(r)) => Ok(Source::Ref(r.clone())),
+            (Some(_), Some(_)) => Err("provide exactly one of `url` or `ref`".into()),
+            (None, None) => Err("`url` or `ref` is required".into()),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct FfmpegReq {
+    args: Vec<String>,
+    inputs: Vec<(String, Vec<u8>)>,
+    output: String,
+}
+
+#[derive(Deserialize)]
+struct FfmpegResp {
+    exit_code: i32,
+    output: Vec<u8>,
+    log: String,
+}
+
+#[derive(Serialize)]
+struct ForUi {
+    data_url: String,
+    mime: String,
+    filename: String,
+}
+
+#[derive(Serialize)]
+struct Envelope {
+    #[serde(rename = "_for_llm")]
+    for_llm: String,
+    #[serde(rename = "_for_ui")]
+    for_ui: ForUi,
+}
+
+#[allow(dead_code)]
+fn mime_to_ext(mime: &str) -> Option<&'static str> {
+    match mime {
+        "video/mp4" => Some("mp4"),
+        "video/webm" => Some("webm"),
+        "video/quicktime" => Some("mov"),
+        "video/x-matroska" => Some("mkv"),
+        _ => None,
+    }
+}
+
+#[allow(dead_code)]
+fn derive_filename(url: &str) -> String {
+    let after_scheme = url.split("://").nth(1).unwrap_or(url);
+    let path = after_scheme.split('/').skip(1).collect::<Vec<_>>().join("/");
+    let path = path.split('?').next().unwrap_or("");
+    let path = path.split('#').next().unwrap_or("");
+    let last = path.rsplit('/').next().unwrap_or("");
+    let decoded = percent_decode(last);
+    if decoded.is_empty() {
+        "video".into()
+    } else {
+        decoded
+    }
+}
+
+#[allow(dead_code)]
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(s.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(h), Some(l)) = (hi, lo) {
+                out.push((h * 16 + l) as u8);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(out).unwrap_or_else(|_| s.to_string())
+}
+
+#[allow(dead_code)]
+fn output_filename(in_filename: &str, out_ext: &str) -> String {
+    let stem = in_filename.rsplit_once('.').map(|(s, _)| s).unwrap_or(in_filename);
+    format!("{stem}.{out_ext}")
+}
+
+#[allow(dead_code)]
+fn dispatch_ffmpeg_runtime(payload: &[u8]) -> Result<Vec<u8>, WaferError> {
+    let msg = Message::new("ffmpeg.exec");
+    let mut call = wafer_sdk::stream::CallStream::open("gizza-ai/ffmpeg-runtime", &msg)?;
+    call.write_chunk(payload)?;
+    let mut resp = call.finish()?;
+    let mut out = Vec::new();
+    while let Some(chunk) = resp.next_chunk()? {
+        out.extend(chunk);
+    }
+    Ok(out)
+}
+
+#[allow(dead_code)]
+fn in_filename_stem(name: &str) -> &str {
+    name.rsplit_once('.').map(|(s, _)| s).unwrap_or(name)
+}
+
+fn build_argv(in_name: &str, out_name: &str, timestamp: f64) -> Vec<String> {
+    vec![
+        "-ss".into(),
+        format!("{timestamp}"),
+        "-i".into(),
+        in_name.into(),
+        "-frames:v".into(),
+        "1".into(),
+        "-update".into(),
+        "1".into(),
+        "-y".into(),
+        out_name.into(),
+    ]
+}
+
+#[cfg(target_arch = "wasm32")]
+struct VideoFrameExtract;
+
+#[cfg(target_arch = "wasm32")]
+#[wafer_block(
+    name = "gizza-ai/video-frame-extract",
+    version = "0.1.0",
+    interface = "handler@v1",
+    summary = "Extract a single frame from a video at a given timestamp",
+    capabilities(callable_blocks = ["wafer-run/network", "gizza-ai/ffmpeg-runtime"]),
+    skill(
+        description = "Extract a single frame from a video at the given timestamp (seconds), output as PNG. The PNG is naturally chainable into image-resize, image-crop, or image-convert via ref. Provide either url (HTTP/HTTPS) or ref (id from a prior tool call).",
+        parameters = r#"{
+            "type": "object",
+            "properties": {
+                "url":       { "type": "string" },
+                "ref":       { "type": "string" },
+                "timestamp": { "type": "number", "minimum": 0, "description": "Timestamp in seconds." }
+            },
+            "required": ["timestamp"],
+            "oneOf": [
+                { "required": ["url"] },
+                { "required": ["ref"] }
+            ]
+        }"#
+    ),
+)]
+impl VideoFrameExtract {
+    fn handle(_msg: Message, body: Vec<u8>) -> GuestResult {
+        let args: Args = match serde_json::from_slice(&body) {
+            Ok(a) => a,
+            Err(e) => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INVALID_ARGUMENT,
+                    format!("invalid video-frame-extract args: {e}"),
+                ))
+            }
+        };
+        if args.timestamp < 0.0 || !args.timestamp.is_finite() {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                format!("invalid video-frame-extract args: timestamp must be >= 0 and finite, got {}", args.timestamp),
+            ));
+        }
+
+        let (input_bytes, in_mime, in_filename) = match args.source() {
+            Err(e) => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INVALID_ARGUMENT,
+                    format!("invalid video-frame-extract args: {e}"),
+                ))
+            }
+            Ok(Source::Url(u)) => {
+                let net = match wafer_sdk::clients::network::do_request("GET", &u, &HashMap::new(), None) {
+                    Ok(r) => r,
+                    Err(e) => return GuestResult::error(e),
+                };
+                if net.status_code >= 400 {
+                    return GuestResult::error(WaferError::new(
+                        ErrorCode::UNAVAILABLE,
+                        format!("HTTP {} for {}", net.status_code, u),
+                    ));
+                }
+                let raw_mime = net
+                    .headers
+                    .iter()
+                    .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+                    .and_then(|(_, vs)| vs.first().cloned())
+                    .unwrap_or_else(|| "application/octet-stream".to_string());
+                let in_mime: String = raw_mime
+                    .split(';')
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_lowercase();
+                if !in_mime.starts_with("video/") {
+                    return GuestResult::error(WaferError::new(
+                        ErrorCode::INVALID_ARGUMENT,
+                        format!("expected video/* content-type, got {in_mime}"),
+                    ));
+                }
+                if let Some(cl) = net
+                    .headers
+                    .iter()
+                    .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
+                    .and_then(|(_, vs)| vs.first())
+                    .and_then(|v| v.trim().parse::<usize>().ok())
+                {
+                    if cl > MAX_INPUT_BYTES {
+                        return GuestResult::error(WaferError::new(
+                            ErrorCode::OUT_OF_RANGE,
+                            format!("input video too large: {cl} bytes (cap {MAX_INPUT_BYTES} bytes)"),
+                        ));
+                    }
+                }
+                if net.body.len() > MAX_INPUT_BYTES {
+                    return GuestResult::error(WaferError::new(
+                        ErrorCode::OUT_OF_RANGE,
+                        format!(
+                            "input video too large: {} bytes (cap {} bytes)",
+                            net.body.len(),
+                            MAX_INPUT_BYTES
+                        ),
+                    ));
+                }
+                let filename = derive_filename(&u);
+                (net.body, in_mime, filename)
+            }
+            Ok(Source::Ref(id)) => {
+                let att = match wafer_sdk::lookup_attachment(&id) {
+                    Ok(Some(a)) => a,
+                    Ok(None) => {
+                        return GuestResult::error(WaferError::new(
+                            ErrorCode::NOT_FOUND,
+                            format!("no attachment found for ref {:?}", id),
+                        ))
+                    }
+                    Err(e) => {
+                        return GuestResult::error(WaferError::new(
+                            ErrorCode::INTERNAL,
+                            e.to_string(),
+                        ))
+                    }
+                };
+                if !att.mime.starts_with("video/") {
+                    return GuestResult::error(WaferError::new(
+                        ErrorCode::INVALID_ARGUMENT,
+                        format!("expected video/* attachment, got {}", att.mime),
+                    ));
+                }
+                if att.bytes.len() > MAX_INPUT_BYTES {
+                    return GuestResult::error(WaferError::new(
+                        ErrorCode::OUT_OF_RANGE,
+                        format!(
+                            "input video too large: {} bytes (cap {} bytes)",
+                            att.bytes.len(),
+                            MAX_INPUT_BYTES
+                        ),
+                    ));
+                }
+                let filename = att.filename.unwrap_or_else(|| "video".into());
+                (att.bytes, att.mime, filename)
+            }
+        };
+
+        let in_ext = mime_to_ext(&in_mime).unwrap_or("bin");
+        let ffmpeg_in = format!("in.{in_ext}");
+        let ffmpeg_out = "out.png".to_string();
+        let argv = build_argv(&ffmpeg_in, &ffmpeg_out, args.timestamp);
+
+        let req = FfmpegReq {
+            args: argv,
+            inputs: vec![(ffmpeg_in, input_bytes)],
+            output: ffmpeg_out,
+        };
+        let req_body = match serde_json::to_vec(&req) {
+            Ok(b) => b,
+            Err(e) => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INTERNAL,
+                    format!("serialize ffmpeg request: {e}"),
+                ))
+            }
+        };
+        let ff_resp_bytes = match dispatch_ffmpeg_runtime(&req_body) {
+            Ok(b) => b,
+            Err(e) => return GuestResult::error(e),
+        };
+        let ff: FfmpegResp = match serde_json::from_slice(&ff_resp_bytes) {
+            Ok(r) => r,
+            Err(e) => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INTERNAL,
+                    format!("malformed ffmpeg response: {e}"),
+                ))
+            }
+        };
+
+        if ff.exit_code != 0 {
+            let snippet: String = ff.log.chars().take(200).collect();
+            return GuestResult::error(WaferError::new(
+                ErrorCode::INTERNAL,
+                format!("ffmpeg failed (exit {}): {snippet}", ff.exit_code),
+            ));
+        }
+        if ff.output.len() > MAX_OUTPUT_BYTES {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::OUT_OF_RANGE,
+                format!(
+                    "output frame too large: {} bytes (cap {} bytes)",
+                    ff.output.len(),
+                    MAX_OUTPUT_BYTES
+                ),
+            ));
+        }
+
+        let output_size = ff.output.len();
+        let encoded = B64.encode(&ff.output);
+        let data_url = format!("data:image/png;base64,{encoded}");
+        let stem = in_filename_stem(&in_filename);
+        let filename = format!("{stem}-frame-{}.png", args.timestamp);
+
+        let env = Envelope {
+            for_llm: format!(
+                "extracted frame at {}s from {} (PNG, {} bytes)",
+                args.timestamp, in_filename, output_size
+            ),
+            for_ui: ForUi {
+                data_url,
+                mime: "image/png".to_string(),
+                filename,
+            },
+        };
+        match serde_json::to_vec(&env) {
+            Ok(v) => GuestResult::respond(v),
+            Err(e) => GuestResult::error(WaferError::new(
+                ErrorCode::INTERNAL,
+                format!("serialize envelope: {e}"),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn argv_default() {
+        let argv = build_argv("in.mp4", "out.png", 5.0);
+        assert_eq!(argv[0], "-ss");
+        assert_eq!(argv[1], "5");
+        assert_eq!(argv[2], "-i");
+        assert_eq!(argv[3], "in.mp4");
+        assert!(argv.iter().any(|a| a == "-frames:v"));
+        assert!(argv.iter().any(|a| a == "1"));
+        assert_eq!(argv.last().map(String::as_str), Some("out.png"));
+    }
+
+    #[test]
+    fn args_url_only_ok() {
+        let a = Args {
+            url: Some("u".into()),
+            r#ref: None,
+            timestamp: 0.0,
+        };
+        match a.source().expect("ok") {
+            Source::Url(u) => assert_eq!(u, "u"),
+            _ => panic!("expected Url"),
+        }
+    }
+
+    #[test]
+    fn args_ref_only_ok() {
+        let a = Args {
+            url: None,
+            r#ref: Some("call_1".into()),
+            timestamp: 0.0,
+        };
+        match a.source().expect("ok") {
+            Source::Ref(r) => assert_eq!(r, "call_1"),
+            _ => panic!("expected Ref"),
+        }
+    }
+
+    #[test]
+    fn args_both_url_and_ref_errors() {
+        let a = Args {
+            url: Some("u".into()),
+            r#ref: Some("r".into()),
+            timestamp: 0.0,
+        };
+        assert!(a.source().is_err());
+    }
+
+    #[test]
+    fn args_neither_errors() {
+        let a = Args {
+            url: None,
+            r#ref: None,
+            timestamp: 0.0,
+        };
+        assert!(a.source().is_err());
+    }
+}

--- a/blocks/video-transcode/Cargo.toml
+++ b/blocks/video-transcode/Cargo.toml
@@ -1,0 +1,18 @@
+[workspace]
+resolver = "2"
+members = ["."]
+
+[package]
+name = "gizza-ai-video-transcode-block"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wafer-sdk = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
+wafer-block = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+base64 = "0.22"

--- a/blocks/video-transcode/manifest.json
+++ b/blocks/video-transcode/manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "gizza-ai/video-transcode",
+  "version": "0.1.0",
+  "interface": "handler@v1",
+  "summary": "Transcode a video to mp4 or webm."
+}

--- a/blocks/video-transcode/src/lib.rs
+++ b/blocks/video-transcode/src/lib.rs
@@ -1,0 +1,503 @@
+//! gizza-ai/video-transcode — fetch a video URL or attachment ref, transcode to a target container.
+
+use std::collections::HashMap;
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use serde::{Deserialize, Serialize};
+use wafer_sdk::*;
+
+const MAX_INPUT_BYTES: usize = 10 * 1024 * 1024;
+const MAX_OUTPUT_BYTES: usize = 10 * 1024 * 1024;
+const DEFAULT_QUALITY: u8 = 75;
+
+#[derive(Deserialize, Debug)]
+struct Args {
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    r#ref: Option<String>,
+    format: String,
+    #[serde(default)]
+    quality: Option<u8>,
+}
+
+enum Source {
+    Url(String),
+    Ref(String),
+}
+
+impl Args {
+    fn source(&self) -> Result<Source, String> {
+        match (&self.url, &self.r#ref) {
+            (Some(u), None) => Ok(Source::Url(u.clone())),
+            (None, Some(r)) => Ok(Source::Ref(r.clone())),
+            (Some(_), Some(_)) => Err("provide exactly one of `url` or `ref`".into()),
+            (None, None) => Err("`url` or `ref` is required".into()),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct FfmpegReq {
+    args: Vec<String>,
+    inputs: Vec<(String, Vec<u8>)>,
+    output: String,
+}
+
+#[derive(Deserialize)]
+struct FfmpegResp {
+    exit_code: i32,
+    output: Vec<u8>,
+    log: String,
+}
+
+#[derive(Serialize)]
+struct ForUi {
+    data_url: String,
+    mime: String,
+    filename: String,
+}
+
+#[derive(Serialize)]
+struct Envelope {
+    #[serde(rename = "_for_llm")]
+    for_llm: String,
+    #[serde(rename = "_for_ui")]
+    for_ui: ForUi,
+}
+
+/// Map web-conventional quality 1-100 to ffmpeg's CRF range 0 (best) – 51 (worst).
+fn quality_to_crf(q: u8) -> u8 {
+    let q = q.clamp(1, 100) as f32;
+    let crf = 51.0 - (q - 1.0) * (51.0 / 99.0);
+    crf.round().clamp(0.0, 51.0) as u8
+}
+
+fn format_to_mime_and_ext(fmt: &str) -> Option<(&'static str, &'static str)> {
+    match fmt {
+        "mp4" => Some(("video/mp4", "mp4")),
+        "webm" => Some(("video/webm", "webm")),
+        _ => None,
+    }
+}
+
+#[allow(dead_code)]
+fn mime_to_ext(mime: &str) -> Option<&'static str> {
+    match mime {
+        "video/mp4" => Some("mp4"),
+        "video/webm" => Some("webm"),
+        "video/quicktime" => Some("mov"),
+        "video/x-matroska" => Some("mkv"),
+        _ => None,
+    }
+}
+
+fn build_argv(in_name: &str, out_name: &str, format: &str, crf: u8) -> Vec<String> {
+    match format {
+        "mp4" => vec![
+            "-i".into(),
+            in_name.into(),
+            "-c:v".into(),
+            "libx264".into(),
+            "-c:a".into(),
+            "aac".into(),
+            "-crf".into(),
+            crf.to_string(),
+            "-movflags".into(),
+            "+faststart".into(),
+            out_name.into(),
+        ],
+        "webm" => vec![
+            "-i".into(),
+            in_name.into(),
+            "-c:v".into(),
+            "libvpx-vp9".into(),
+            "-c:a".into(),
+            "libopus".into(),
+            "-crf".into(),
+            crf.to_string(),
+            "-b:v".into(),
+            "0".into(),
+            out_name.into(),
+        ],
+        _ => Vec::new(),
+    }
+}
+
+#[allow(dead_code)]
+fn derive_filename(url: &str) -> String {
+    let after_scheme = url.split("://").nth(1).unwrap_or(url);
+    let path = after_scheme.split('/').skip(1).collect::<Vec<_>>().join("/");
+    let path = path.split('?').next().unwrap_or("");
+    let path = path.split('#').next().unwrap_or("");
+    let last = path.rsplit('/').next().unwrap_or("");
+    let decoded = percent_decode(last);
+    if decoded.is_empty() {
+        "video".into()
+    } else {
+        decoded
+    }
+}
+
+#[allow(dead_code)]
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(s.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(h), Some(l)) = (hi, lo) {
+                out.push((h * 16 + l) as u8);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(out).unwrap_or_else(|_| s.to_string())
+}
+
+#[allow(dead_code)]
+fn output_filename(in_filename: &str, out_ext: &str) -> String {
+    let stem = in_filename.rsplit_once('.').map(|(s, _)| s).unwrap_or(in_filename);
+    format!("{stem}.{out_ext}")
+}
+
+#[allow(dead_code)]
+fn dispatch_ffmpeg_runtime(payload: &[u8]) -> Result<Vec<u8>, WaferError> {
+    let msg = Message::new("ffmpeg.exec");
+    let mut call = wafer_sdk::stream::CallStream::open("gizza-ai/ffmpeg-runtime", &msg)?;
+    call.write_chunk(payload)?;
+    let mut resp = call.finish()?;
+    let mut out = Vec::new();
+    while let Some(chunk) = resp.next_chunk()? {
+        out.extend(chunk);
+    }
+    Ok(out)
+}
+
+#[cfg(target_arch = "wasm32")]
+struct VideoTranscode;
+
+#[cfg(target_arch = "wasm32")]
+#[wafer_block(
+    name = "gizza-ai/video-transcode",
+    version = "0.1.0",
+    interface = "handler@v1",
+    summary = "Transcode a video to a different container format",
+    capabilities(callable_blocks = ["wafer-run/network", "gizza-ai/ffmpeg-runtime"]),
+    skill(
+        description = "Transcode a video to a different format (mp4 or webm). Provide either url (HTTP/HTTPS) or ref (id from a prior tool call). Quality 1-100 maps to ffmpeg CRF (default 75).",
+        parameters = r#"{
+            "type": "object",
+            "properties": {
+                "url":     { "type": "string", "description": "Video URL (HTTP/HTTPS)." },
+                "ref":     { "type": "string", "description": "Reference id from a prior tool call (e.g. \"call_42\"). Use either url or ref." },
+                "format":  { "type": "string", "enum": ["mp4", "webm"], "description": "Output container format." },
+                "quality": { "type": "integer", "minimum": 1, "maximum": 100, "description": "Quality 1-100 (default 75). Lower = smaller file, lower quality." }
+            },
+            "required": ["format"],
+            "oneOf": [
+                { "required": ["url"] },
+                { "required": ["ref"] }
+            ]
+        }"#
+    ),
+)]
+impl VideoTranscode {
+    fn handle(_msg: Message, body: Vec<u8>) -> GuestResult {
+        let args: Args = match serde_json::from_slice(&body) {
+            Ok(a) => a,
+            Err(e) => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INVALID_ARGUMENT,
+                    format!("invalid video-transcode args: {e}"),
+                ))
+            }
+        };
+        let (out_mime, out_ext) = match format_to_mime_and_ext(&args.format) {
+            Some(t) => t,
+            None => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INVALID_ARGUMENT,
+                    format!(
+                        "invalid video-transcode args: format {:?} not supported (mp4|webm)",
+                        args.format
+                    ),
+                ))
+            }
+        };
+        if let Some(q) = args.quality {
+            if !(1..=100).contains(&q) {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INVALID_ARGUMENT,
+                    format!("invalid video-transcode args: quality must be 1-100, got {q}"),
+                ));
+            }
+        }
+        let crf = quality_to_crf(args.quality.unwrap_or(DEFAULT_QUALITY));
+
+        let (input_bytes, in_mime, in_filename) = match args.source() {
+            Err(e) => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INVALID_ARGUMENT,
+                    format!("invalid video-transcode args: {e}"),
+                ))
+            }
+            Ok(Source::Url(u)) => {
+                let net = match wafer_sdk::clients::network::do_request("GET", &u, &HashMap::new(), None) {
+                    Ok(r) => r,
+                    Err(e) => return GuestResult::error(e),
+                };
+                if net.status_code >= 400 {
+                    return GuestResult::error(WaferError::new(
+                        ErrorCode::UNAVAILABLE,
+                        format!("HTTP {} for {}", net.status_code, u),
+                    ));
+                }
+                let raw_mime = net
+                    .headers
+                    .iter()
+                    .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+                    .and_then(|(_, vs)| vs.first().cloned())
+                    .unwrap_or_else(|| "application/octet-stream".to_string());
+                let in_mime: String = raw_mime
+                    .split(';')
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_lowercase();
+                if !in_mime.starts_with("video/") {
+                    return GuestResult::error(WaferError::new(
+                        ErrorCode::INVALID_ARGUMENT,
+                        format!("expected video/* content-type, got {in_mime}"),
+                    ));
+                }
+                if let Some(cl) = net
+                    .headers
+                    .iter()
+                    .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
+                    .and_then(|(_, vs)| vs.first())
+                    .and_then(|v| v.trim().parse::<usize>().ok())
+                {
+                    if cl > MAX_INPUT_BYTES {
+                        return GuestResult::error(WaferError::new(
+                            ErrorCode::OUT_OF_RANGE,
+                            format!("input video too large: {cl} bytes (cap {MAX_INPUT_BYTES} bytes)"),
+                        ));
+                    }
+                }
+                if net.body.len() > MAX_INPUT_BYTES {
+                    return GuestResult::error(WaferError::new(
+                        ErrorCode::OUT_OF_RANGE,
+                        format!(
+                            "input video too large: {} bytes (cap {} bytes)",
+                            net.body.len(),
+                            MAX_INPUT_BYTES
+                        ),
+                    ));
+                }
+                let filename = derive_filename(&u);
+                (net.body, in_mime, filename)
+            }
+            Ok(Source::Ref(id)) => {
+                let att = match wafer_sdk::lookup_attachment(&id) {
+                    Ok(Some(a)) => a,
+                    Ok(None) => {
+                        return GuestResult::error(WaferError::new(
+                            ErrorCode::NOT_FOUND,
+                            format!("no attachment found for ref {:?}", id),
+                        ))
+                    }
+                    Err(e) => {
+                        return GuestResult::error(WaferError::new(
+                            ErrorCode::INTERNAL,
+                            e.to_string(),
+                        ))
+                    }
+                };
+                if !att.mime.starts_with("video/") {
+                    return GuestResult::error(WaferError::new(
+                        ErrorCode::INVALID_ARGUMENT,
+                        format!("expected video/* attachment, got {}", att.mime),
+                    ));
+                }
+                if att.bytes.len() > MAX_INPUT_BYTES {
+                    return GuestResult::error(WaferError::new(
+                        ErrorCode::OUT_OF_RANGE,
+                        format!(
+                            "input video too large: {} bytes (cap {} bytes)",
+                            att.bytes.len(),
+                            MAX_INPUT_BYTES
+                        ),
+                    ));
+                }
+                let filename = att.filename.unwrap_or_else(|| "video".into());
+                (att.bytes, att.mime, filename)
+            }
+        };
+
+        let in_ext = mime_to_ext(&in_mime).unwrap_or("bin");
+        let ffmpeg_in = format!("in.{in_ext}");
+        let ffmpeg_out = format!("out.{out_ext}");
+        let argv = build_argv(&ffmpeg_in, &ffmpeg_out, &args.format, crf);
+
+        let req = FfmpegReq {
+            args: argv,
+            inputs: vec![(ffmpeg_in, input_bytes)],
+            output: ffmpeg_out,
+        };
+        let req_body = match serde_json::to_vec(&req) {
+            Ok(b) => b,
+            Err(e) => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INTERNAL,
+                    format!("serialize ffmpeg request: {e}"),
+                ))
+            }
+        };
+        let ff_resp_bytes = match dispatch_ffmpeg_runtime(&req_body) {
+            Ok(b) => b,
+            Err(e) => return GuestResult::error(e),
+        };
+        let ff: FfmpegResp = match serde_json::from_slice(&ff_resp_bytes) {
+            Ok(r) => r,
+            Err(e) => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INTERNAL,
+                    format!("malformed ffmpeg response: {e}"),
+                ))
+            }
+        };
+
+        if ff.exit_code != 0 {
+            let snippet: String = ff.log.chars().take(200).collect();
+            return GuestResult::error(WaferError::new(
+                ErrorCode::INTERNAL,
+                format!("ffmpeg failed (exit {}): {snippet}", ff.exit_code),
+            ));
+        }
+        if ff.output.len() > MAX_OUTPUT_BYTES {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::OUT_OF_RANGE,
+                format!(
+                    "output video too large: {} bytes (cap {} bytes)",
+                    ff.output.len(),
+                    MAX_OUTPUT_BYTES
+                ),
+            ));
+        }
+
+        let output_size = ff.output.len();
+        let encoded = B64.encode(&ff.output);
+        let data_url = format!("data:{out_mime};base64,{encoded}");
+        let filename = output_filename(&in_filename, out_ext);
+
+        let env = Envelope {
+            for_llm: format!(
+                "transcoded {} from {} to {} ({} bytes)",
+                in_filename, in_mime, out_mime, output_size
+            ),
+            for_ui: ForUi {
+                data_url,
+                mime: out_mime.to_string(),
+                filename,
+            },
+        };
+        match serde_json::to_vec(&env) {
+            Ok(v) => GuestResult::respond(v),
+            Err(e) => GuestResult::error(WaferError::new(
+                ErrorCode::INTERNAL,
+                format!("serialize envelope: {e}"),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quality_to_crf_endpoints() {
+        assert_eq!(quality_to_crf(100), 0);
+        assert_eq!(quality_to_crf(1), 51);
+        let mid = quality_to_crf(75);
+        assert!((12..=14).contains(&mid), "expected 12-14, got {mid}");
+    }
+
+    #[test]
+    fn argv_mp4_default() {
+        let argv = build_argv("in.mp4", "out.mp4", "mp4", 13);
+        assert_eq!(argv[0], "-i");
+        assert_eq!(argv[1], "in.mp4");
+        assert!(argv.iter().any(|a| a == "libx264"));
+        assert!(argv.iter().any(|a| a == "aac"));
+        assert!(argv.iter().any(|a| a == "13"));
+        assert!(argv.iter().any(|a| a == "+faststart"));
+        assert_eq!(argv.last().map(String::as_str), Some("out.mp4"));
+    }
+
+    #[test]
+    fn argv_webm_default() {
+        let argv = build_argv("in.mp4", "out.webm", "webm", 13);
+        assert!(argv.iter().any(|a| a == "libvpx-vp9"));
+        assert!(argv.iter().any(|a| a == "libopus"));
+        assert!(argv.iter().any(|a| a == "13"));
+        assert!(argv.iter().any(|a| a == "0")); // -b:v 0
+        assert_eq!(argv.last().map(String::as_str), Some("out.webm"));
+    }
+
+    #[test]
+    fn args_url_only_ok() {
+        let a = Args {
+            url: Some("u".into()),
+            r#ref: None,
+            format: "mp4".into(),
+            quality: None,
+        };
+        match a.source().expect("ok") {
+            Source::Url(u) => assert_eq!(u, "u"),
+            _ => panic!("expected Url"),
+        }
+    }
+
+    #[test]
+    fn args_ref_only_ok() {
+        let a = Args {
+            url: None,
+            r#ref: Some("call_1".into()),
+            format: "mp4".into(),
+            quality: None,
+        };
+        match a.source().expect("ok") {
+            Source::Ref(r) => assert_eq!(r, "call_1"),
+            _ => panic!("expected Ref"),
+        }
+    }
+
+    #[test]
+    fn args_both_url_and_ref_errors() {
+        let a = Args {
+            url: Some("u".into()),
+            r#ref: Some("r".into()),
+            format: "mp4".into(),
+            quality: None,
+        };
+        assert!(a.source().is_err());
+    }
+
+    #[test]
+    fn args_neither_errors() {
+        let a = Args {
+            url: None,
+            r#ref: None,
+            format: "mp4".into(),
+            quality: None,
+        };
+        assert!(a.source().is_err());
+    }
+}

--- a/blocks/video-trim/Cargo.toml
+++ b/blocks/video-trim/Cargo.toml
@@ -1,0 +1,18 @@
+[workspace]
+resolver = "2"
+members = ["."]
+
+[package]
+name = "gizza-ai-video-trim-block"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wafer-sdk = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
+wafer-block = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+base64 = "0.22"

--- a/blocks/video-trim/manifest.json
+++ b/blocks/video-trim/manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "gizza-ai/video-trim",
+  "version": "0.1.0",
+  "interface": "handler@v1",
+  "summary": "Trim a video to a [start, start+duration] window."
+}

--- a/blocks/video-trim/src/lib.rs
+++ b/blocks/video-trim/src/lib.rs
@@ -1,0 +1,442 @@
+//! gizza-ai/video-trim — fetch a video URL or attachment ref, trim to [start, start+duration], stream-copy to mp4.
+
+use std::collections::HashMap;
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use serde::{Deserialize, Serialize};
+use wafer_sdk::*;
+
+const MAX_INPUT_BYTES: usize = 10 * 1024 * 1024;
+const MAX_OUTPUT_BYTES: usize = 10 * 1024 * 1024;
+
+#[derive(Deserialize, Debug)]
+struct Args {
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    r#ref: Option<String>,
+    start: f64,
+    duration: f64,
+}
+
+enum Source {
+    Url(String),
+    Ref(String),
+}
+
+impl Args {
+    fn source(&self) -> Result<Source, String> {
+        match (&self.url, &self.r#ref) {
+            (Some(u), None) => Ok(Source::Url(u.clone())),
+            (None, Some(r)) => Ok(Source::Ref(r.clone())),
+            (Some(_), Some(_)) => Err("provide exactly one of `url` or `ref`".into()),
+            (None, None) => Err("`url` or `ref` is required".into()),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct FfmpegReq {
+    args: Vec<String>,
+    inputs: Vec<(String, Vec<u8>)>,
+    output: String,
+}
+
+#[derive(Deserialize)]
+struct FfmpegResp {
+    exit_code: i32,
+    output: Vec<u8>,
+    log: String,
+}
+
+#[derive(Serialize)]
+struct ForUi {
+    data_url: String,
+    mime: String,
+    filename: String,
+}
+
+#[derive(Serialize)]
+struct Envelope {
+    #[serde(rename = "_for_llm")]
+    for_llm: String,
+    #[serde(rename = "_for_ui")]
+    for_ui: ForUi,
+}
+
+#[allow(dead_code)]
+fn mime_to_ext(mime: &str) -> Option<&'static str> {
+    match mime {
+        "video/mp4" => Some("mp4"),
+        "video/webm" => Some("webm"),
+        "video/quicktime" => Some("mov"),
+        "video/x-matroska" => Some("mkv"),
+        _ => None,
+    }
+}
+
+fn build_argv(in_name: &str, out_name: &str, start: f64, duration: f64) -> Vec<String> {
+    vec![
+        "-ss".into(),
+        format!("{start}"),
+        "-i".into(),
+        in_name.into(),
+        "-t".into(),
+        format!("{duration}"),
+        "-c".into(),
+        "copy".into(),
+        out_name.into(),
+    ]
+}
+
+#[allow(dead_code)]
+fn derive_filename(url: &str) -> String {
+    let after_scheme = url.split("://").nth(1).unwrap_or(url);
+    let path = after_scheme.split('/').skip(1).collect::<Vec<_>>().join("/");
+    let path = path.split('?').next().unwrap_or("");
+    let path = path.split('#').next().unwrap_or("");
+    let last = path.rsplit('/').next().unwrap_or("");
+    let decoded = percent_decode(last);
+    if decoded.is_empty() {
+        "video".into()
+    } else {
+        decoded
+    }
+}
+
+#[allow(dead_code)]
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(s.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(h), Some(l)) = (hi, lo) {
+                out.push((h * 16 + l) as u8);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(out).unwrap_or_else(|_| s.to_string())
+}
+
+#[allow(dead_code)]
+fn output_filename(in_filename: &str, out_ext: &str) -> String {
+    let stem = in_filename.rsplit_once('.').map(|(s, _)| s).unwrap_or(in_filename);
+    format!("{stem}.{out_ext}")
+}
+
+#[allow(dead_code)]
+fn dispatch_ffmpeg_runtime(payload: &[u8]) -> Result<Vec<u8>, WaferError> {
+    let msg = Message::new("ffmpeg.exec");
+    let mut call = wafer_sdk::stream::CallStream::open("gizza-ai/ffmpeg-runtime", &msg)?;
+    call.write_chunk(payload)?;
+    let mut resp = call.finish()?;
+    let mut out = Vec::new();
+    while let Some(chunk) = resp.next_chunk()? {
+        out.extend(chunk);
+    }
+    Ok(out)
+}
+
+#[cfg(target_arch = "wasm32")]
+struct VideoTrim;
+
+#[cfg(target_arch = "wasm32")]
+#[wafer_block(
+    name = "gizza-ai/video-trim",
+    version = "0.1.0",
+    interface = "handler@v1",
+    summary = "Trim a video to a [start, start+duration] window",
+    capabilities(callable_blocks = ["wafer-run/network", "gizza-ai/ffmpeg-runtime"]),
+    skill(
+        description = "Trim a video to a [start, start+duration] window using stream-copy (no re-encode). Provide either url (HTTP/HTTPS) or ref (id from a prior tool call). Output is mp4. Stream-copy preserves the source codecs and is fast — but requires the source streams be mp4-compatible (h264/aac); otherwise ffmpeg will fail with a clear error.",
+        parameters = r#"{
+            "type": "object",
+            "properties": {
+                "url":      { "type": "string" },
+                "ref":      { "type": "string" },
+                "start":    { "type": "number", "minimum": 0, "description": "Start time in seconds." },
+                "duration": { "type": "number", "exclusiveMinimum": 0, "description": "Duration in seconds." }
+            },
+            "required": ["start", "duration"],
+            "oneOf": [
+                { "required": ["url"] },
+                { "required": ["ref"] }
+            ]
+        }"#
+    ),
+)]
+impl VideoTrim {
+    fn handle(_msg: Message, body: Vec<u8>) -> GuestResult {
+        let args: Args = match serde_json::from_slice(&body) {
+            Ok(a) => a,
+            Err(e) => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INVALID_ARGUMENT,
+                    format!("invalid video-trim args: {e}"),
+                ))
+            }
+        };
+        if args.start < 0.0 || !args.start.is_finite() {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                format!("invalid video-trim args: start must be >= 0 and finite, got {}", args.start),
+            ));
+        }
+        if args.duration <= 0.0 || !args.duration.is_finite() {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::INVALID_ARGUMENT,
+                format!("invalid video-trim args: duration must be > 0 and finite, got {}", args.duration),
+            ));
+        }
+
+        let (input_bytes, in_mime, in_filename) = match args.source() {
+            Err(e) => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INVALID_ARGUMENT,
+                    format!("invalid video-trim args: {e}"),
+                ))
+            }
+            Ok(Source::Url(u)) => {
+                let net = match wafer_sdk::clients::network::do_request("GET", &u, &HashMap::new(), None) {
+                    Ok(r) => r,
+                    Err(e) => return GuestResult::error(e),
+                };
+                if net.status_code >= 400 {
+                    return GuestResult::error(WaferError::new(
+                        ErrorCode::UNAVAILABLE,
+                        format!("HTTP {} for {}", net.status_code, u),
+                    ));
+                }
+                let raw_mime = net
+                    .headers
+                    .iter()
+                    .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+                    .and_then(|(_, vs)| vs.first().cloned())
+                    .unwrap_or_else(|| "application/octet-stream".to_string());
+                let in_mime: String = raw_mime
+                    .split(';')
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_lowercase();
+                if !in_mime.starts_with("video/") {
+                    return GuestResult::error(WaferError::new(
+                        ErrorCode::INVALID_ARGUMENT,
+                        format!("expected video/* content-type, got {in_mime}"),
+                    ));
+                }
+                if let Some(cl) = net
+                    .headers
+                    .iter()
+                    .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
+                    .and_then(|(_, vs)| vs.first())
+                    .and_then(|v| v.trim().parse::<usize>().ok())
+                {
+                    if cl > MAX_INPUT_BYTES {
+                        return GuestResult::error(WaferError::new(
+                            ErrorCode::OUT_OF_RANGE,
+                            format!("input video too large: {cl} bytes (cap {MAX_INPUT_BYTES} bytes)"),
+                        ));
+                    }
+                }
+                if net.body.len() > MAX_INPUT_BYTES {
+                    return GuestResult::error(WaferError::new(
+                        ErrorCode::OUT_OF_RANGE,
+                        format!(
+                            "input video too large: {} bytes (cap {} bytes)",
+                            net.body.len(),
+                            MAX_INPUT_BYTES
+                        ),
+                    ));
+                }
+                let filename = derive_filename(&u);
+                (net.body, in_mime, filename)
+            }
+            Ok(Source::Ref(id)) => {
+                let att = match wafer_sdk::lookup_attachment(&id) {
+                    Ok(Some(a)) => a,
+                    Ok(None) => {
+                        return GuestResult::error(WaferError::new(
+                            ErrorCode::NOT_FOUND,
+                            format!("no attachment found for ref {:?}", id),
+                        ))
+                    }
+                    Err(e) => {
+                        return GuestResult::error(WaferError::new(
+                            ErrorCode::INTERNAL,
+                            e.to_string(),
+                        ))
+                    }
+                };
+                if !att.mime.starts_with("video/") {
+                    return GuestResult::error(WaferError::new(
+                        ErrorCode::INVALID_ARGUMENT,
+                        format!("expected video/* attachment, got {}", att.mime),
+                    ));
+                }
+                if att.bytes.len() > MAX_INPUT_BYTES {
+                    return GuestResult::error(WaferError::new(
+                        ErrorCode::OUT_OF_RANGE,
+                        format!(
+                            "input video too large: {} bytes (cap {} bytes)",
+                            att.bytes.len(),
+                            MAX_INPUT_BYTES
+                        ),
+                    ));
+                }
+                let filename = att.filename.unwrap_or_else(|| "video".into());
+                (att.bytes, att.mime, filename)
+            }
+        };
+
+        let in_ext = mime_to_ext(&in_mime).unwrap_or("bin");
+        let ffmpeg_in = format!("in.{in_ext}");
+        let ffmpeg_out = "out.mp4".to_string();
+        let argv = build_argv(&ffmpeg_in, &ffmpeg_out, args.start, args.duration);
+
+        let req = FfmpegReq {
+            args: argv,
+            inputs: vec![(ffmpeg_in, input_bytes)],
+            output: ffmpeg_out,
+        };
+        let req_body = match serde_json::to_vec(&req) {
+            Ok(b) => b,
+            Err(e) => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INTERNAL,
+                    format!("serialize ffmpeg request: {e}"),
+                ))
+            }
+        };
+        let ff_resp_bytes = match dispatch_ffmpeg_runtime(&req_body) {
+            Ok(b) => b,
+            Err(e) => return GuestResult::error(e),
+        };
+        let ff: FfmpegResp = match serde_json::from_slice(&ff_resp_bytes) {
+            Ok(r) => r,
+            Err(e) => {
+                return GuestResult::error(WaferError::new(
+                    ErrorCode::INTERNAL,
+                    format!("malformed ffmpeg response: {e}"),
+                ))
+            }
+        };
+
+        if ff.exit_code != 0 {
+            let snippet: String = ff.log.chars().take(200).collect();
+            return GuestResult::error(WaferError::new(
+                ErrorCode::INTERNAL,
+                format!("ffmpeg failed (exit {}): {snippet}", ff.exit_code),
+            ));
+        }
+        if ff.output.len() > MAX_OUTPUT_BYTES {
+            return GuestResult::error(WaferError::new(
+                ErrorCode::OUT_OF_RANGE,
+                format!(
+                    "output video too large: {} bytes (cap {} bytes)",
+                    ff.output.len(),
+                    MAX_OUTPUT_BYTES
+                ),
+            ));
+        }
+
+        let output_size = ff.output.len();
+        let encoded = B64.encode(&ff.output);
+        let data_url = format!("data:video/mp4;base64,{encoded}");
+        let filename = output_filename(&in_filename, "mp4");
+
+        let env = Envelope {
+            for_llm: format!(
+                "trimmed {} to [{}s, {}s+{}s] ({} bytes mp4)",
+                in_filename, args.start, args.start, args.duration, output_size
+            ),
+            for_ui: ForUi {
+                data_url,
+                mime: "video/mp4".to_string(),
+                filename,
+            },
+        };
+        match serde_json::to_vec(&env) {
+            Ok(v) => GuestResult::respond(v),
+            Err(e) => GuestResult::error(WaferError::new(
+                ErrorCode::INTERNAL,
+                format!("serialize envelope: {e}"),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn argv_default() {
+        let argv = build_argv("in.mp4", "out.mp4", 1.5, 3.0);
+        assert_eq!(argv[0], "-ss");
+        assert_eq!(argv[1], "1.5");
+        assert_eq!(argv[2], "-i");
+        assert_eq!(argv[3], "in.mp4");
+        assert_eq!(argv[4], "-t");
+        assert_eq!(argv[5], "3");
+        assert!(argv.iter().any(|a| a == "copy"));
+        assert_eq!(argv.last().map(String::as_str), Some("out.mp4"));
+    }
+
+    #[test]
+    fn args_url_only_ok() {
+        let a = Args {
+            url: Some("u".into()),
+            r#ref: None,
+            start: 0.0,
+            duration: 1.0,
+        };
+        match a.source().expect("ok") {
+            Source::Url(u) => assert_eq!(u, "u"),
+            _ => panic!("expected Url"),
+        }
+    }
+
+    #[test]
+    fn args_ref_only_ok() {
+        let a = Args {
+            url: None,
+            r#ref: Some("call_1".into()),
+            start: 0.0,
+            duration: 1.0,
+        };
+        match a.source().expect("ok") {
+            Source::Ref(r) => assert_eq!(r, "call_1"),
+            _ => panic!("expected Ref"),
+        }
+    }
+
+    #[test]
+    fn args_both_url_and_ref_errors() {
+        let a = Args {
+            url: Some("u".into()),
+            r#ref: Some("r".into()),
+            start: 0.0,
+            duration: 1.0,
+        };
+        assert!(a.source().is_err());
+    }
+
+    #[test]
+    fn args_neither_errors() {
+        let a = Args {
+            url: None,
+            r#ref: None,
+            start: 0.0,
+            duration: 1.0,
+        };
+        assert!(a.source().is_err());
+    }
+}

--- a/tests/dispatch_skills.rs
+++ b/tests/dispatch_skills.rs
@@ -1112,8 +1112,7 @@ async fn dispatch_chains_resize_then_crop_via_ref() {
 
 const TRANSCODE_WASM: &[u8] = include_bytes!("../blocks/video-transcode/target/block.wasm");
 const TRIM_WASM: &[u8] = include_bytes!("../blocks/video-trim/target/block.wasm");
-const FRAME_EXTRACT_WASM: &[u8] =
-    include_bytes!("../blocks/video-frame-extract/target/block.wasm");
+const FRAME_EXTRACT_WASM: &[u8] = include_bytes!("../blocks/video-frame-extract/target/block.wasm");
 
 #[tokio::test]
 async fn video_transcode_happy_path_returns_envelope() {
@@ -1155,7 +1154,11 @@ async fn video_transcode_rejects_oversize_input() {
     )
     .await;
     assert!(result.is_err(), "oversize must error");
-    assert_eq!(svc.calls(), 0, "ffmpeg-runtime must not be called when input rejected");
+    assert_eq!(
+        svc.calls(),
+        0,
+        "ffmpeg-runtime must not be called when input rejected"
+    );
 }
 
 #[tokio::test]
@@ -1341,16 +1344,16 @@ async fn video_frame_extract_surfaces_ffmpeg_failure() {
 
 #[tokio::test]
 async fn dispatch_chains_video_frame_extract_then_image_resize_via_ref() {
-    use std::collections::BTreeMap;
-    use wafer_block::Attachment;
-
     // Step 1: extract a frame from a fake video to obtain real PNG bytes.
     let png_bytes: Vec<u8> = b"\x89PNG\r\n\x1a\n"
         .iter()
         .chain([0u8; 200].iter())
         .copied()
         .collect();
-    let extract_svc = Arc::new(FakeFfmpegService::ok(png_bytes.clone(), "fake frame extract log"));
+    let extract_svc = Arc::new(FakeFfmpegService::ok(
+        png_bytes.clone(),
+        "fake frame extract log",
+    ));
 
     let extract_envelope = dispatch_image_op(
         "gizza-ai/video-frame-extract",
@@ -1385,7 +1388,11 @@ async fn dispatch_chains_video_frame_extract_then_image_resize_via_ref() {
         .register_block("wafer-run/network", Arc::new(FakeNetworkBlock))
         .expect("register fake network");
     let resize_svc: Arc<dyn gizza_ai::ffmpeg::FfmpegService> = Arc::new(FakeFfmpegService::ok(
-        b"\x89PNG\r\n\x1a\n".iter().chain([0u8; 88].iter()).copied().collect(),
+        b"\x89PNG\r\n\x1a\n"
+            .iter()
+            .chain([0u8; 88].iter())
+            .copied()
+            .collect(),
         "fake resize log",
     ));
     wafer

--- a/tests/dispatch_skills.rs
+++ b/tests/dispatch_skills.rs
@@ -956,13 +956,14 @@ async fn image_convert_surfaces_ffmpeg_failure() {
 
 // -- Skill-output chaining: image-resize → image-crop via ref attachment ----
 
-/// Native caller block: dispatches image-crop with a single attachment under
+/// Native caller block: dispatches a target block with a single attachment under
 /// the id "call_1". The bytes come from the caller's input stream; the args
-/// passed to the test fixture choose crop region. The crop block sees
+/// passed to the test fixture are forwarded verbatim. The target block sees
 /// `{ref: "call_1"}` in args and pulls bytes via `wafer_sdk::lookup_attachment`.
 #[derive(Clone)]
 struct ChainCallerBlock {
-    crop_args: serde_json::Value,
+    target_block: String,
+    args: serde_json::Value,
     attached_bytes: Vec<u8>,
 }
 
@@ -973,7 +974,7 @@ impl Block for ChainCallerBlock {
             "test/chain-caller",
             "0.0.0",
             "h@v1",
-            "Drives a chained call to gizza-ai/image-crop with attachments.",
+            "Drives a chained call to a configurable target block with attachments.",
         )
     }
 
@@ -988,13 +989,13 @@ impl Block for ChainCallerBlock {
             },
         );
 
-        let body = serde_json::to_vec(&self.crop_args).expect("serialize crop args");
+        let body = serde_json::to_vec(&self.args).expect("serialize args");
 
         let mut msg = Message::new("invoke");
         msg.set_meta(wafer_block::meta::META_REQ_ACTION, "create");
 
         match ctx
-            .call_block_buffered_with_attachments("gizza-ai/image-crop", msg, &body, atts)
+            .call_block_buffered_with_attachments(&self.target_block, msg, &body, atts)
             .await
         {
             Ok(resp) => OutputStream::respond(resp.body),
@@ -1072,7 +1073,8 @@ async fn dispatch_chains_resize_then_crop_via_ref() {
         .register_block(
             "test/chain-caller",
             Arc::new(ChainCallerBlock {
-                crop_args: json!({
+                target_block: "gizza-ai/image-crop".into(),
+                args: json!({
                     "ref": "call_1",
                     "x": 0,
                     "y": 0,
@@ -1333,4 +1335,103 @@ async fn video_frame_extract_surfaces_ffmpeg_failure() {
     )
     .await;
     assert!(result.is_err());
+}
+
+// -- Cross-modality chain: video-frame-extract → image-resize via ref --------
+
+#[tokio::test]
+async fn dispatch_chains_video_frame_extract_then_image_resize_via_ref() {
+    use std::collections::BTreeMap;
+    use wafer_block::Attachment;
+
+    // Step 1: extract a frame from a fake video to obtain real PNG bytes.
+    let png_bytes: Vec<u8> = b"\x89PNG\r\n\x1a\n"
+        .iter()
+        .chain([0u8; 200].iter())
+        .copied()
+        .collect();
+    let extract_svc = Arc::new(FakeFfmpegService::ok(png_bytes.clone(), "fake frame extract log"));
+
+    let extract_envelope = dispatch_image_op(
+        "gizza-ai/video-frame-extract",
+        "video-frame-extract",
+        FRAME_EXTRACT_WASM,
+        "https://example.test/sample.mp4",
+        json!({ "timestamp": 1.5 }),
+        extract_svc,
+    )
+    .await
+    .expect("frame-extract succeeds");
+
+    let data_url = extract_envelope["_for_ui"]["data_url"]
+        .as_str()
+        .expect("data_url present");
+    assert!(data_url.starts_with("data:image/png;base64,"));
+    let comma = data_url.find(',').expect("data: URL has comma");
+    let b64 = &data_url[comma + 1..];
+    let chained_bytes = base64::engine::general_purpose::STANDARD
+        .decode(b64)
+        .expect("data_url base64 decodes");
+    assert!(!chained_bytes.is_empty());
+    let _ = png_bytes; // (kept for clarity; chained_bytes is the verified roundtrip)
+
+    // Step 2: drive image-resize with {ref: "call_1"} + the extracted bytes.
+    let mut wafer = Wafer::builder()
+        .disable_inventory()
+        .disable_lockfile()
+        .build()
+        .expect("Wafer::build");
+    wafer
+        .register_block("wafer-run/network", Arc::new(FakeNetworkBlock))
+        .expect("register fake network");
+    let resize_svc: Arc<dyn gizza_ai::ffmpeg::FfmpegService> = Arc::new(FakeFfmpegService::ok(
+        b"\x89PNG\r\n\x1a\n".iter().chain([0u8; 88].iter()).copied().collect(),
+        "fake resize log",
+    ));
+    wafer
+        .register_block(
+            "gizza-ai/ffmpeg-runtime",
+            Arc::new(gizza_ai::blocks::ffmpeg::FfmpegBlock::new(resize_svc)),
+        )
+        .expect("register ffmpeg-runtime");
+    wafer
+        .register_block(
+            "gizza-ai/image-resize",
+            Arc::new(WasmiBlock::load_from_bytes(RESIZE_WASM).expect("load image-resize")),
+        )
+        .expect("register image-resize");
+    wafer
+        .register_block(
+            "test/chain-caller",
+            Arc::new(ChainCallerBlock {
+                target_block: "gizza-ai/image-resize".into(),
+                args: json!({
+                    "ref": "call_1",
+                    "width": 50,
+                }),
+                attached_bytes: chained_bytes,
+            }),
+        )
+        .expect("register chain caller");
+    let wafer = wafer.start().await.expect("start runtime");
+
+    let output = wafer
+        .run_block(
+            "test/chain-caller",
+            Message::new("invoke"),
+            InputStream::empty(),
+        )
+        .await;
+    let resp = output
+        .collect_buffered()
+        .await
+        .expect("chain-caller returns success");
+
+    let envelope: serde_json::Value =
+        serde_json::from_slice(&resp.body).expect("resize returns SP4 envelope");
+    let resized_data_url = envelope["_for_ui"]["data_url"]
+        .as_str()
+        .expect("resize emits data_url");
+    assert!(resized_data_url.starts_with("data:image/"));
+    assert!(resized_data_url.len() > 100);
 }

--- a/tests/dispatch_skills.rs
+++ b/tests/dispatch_skills.rs
@@ -69,12 +69,21 @@ impl Block for FakeNetworkBlock {
             h.insert("content-type".to_string(), vec!["image/png".to_string()]);
             h.insert("content-length".to_string(), vec!["5242880".to_string()]);
             (200, h, Vec::new())
+        } else if url == "https://example.test/huge.mp4" {
+            // Special case: huge.mp4 signals oversize via Content-Length header (20 MiB > 10 MiB cap).
+            let mut h = HashMap::new();
+            h.insert("content-type".to_string(), vec!["video/mp4".to_string()]);
+            h.insert("content-length".to_string(), vec!["20971520".to_string()]);
+            (200, h, Vec::new())
         } else {
             let (status, content_type, body_bytes): (u16, &str, Vec<u8>) = match url {
                 "https://example.test/web-fetch.txt" => {
                     (200, "text/plain", b"WEBFETCH_OK_8f3a2".to_vec())
                 }
                 "https://example.test/sample.mp4" => (200, "video/mp4", b"FAKE_MP4_BYTES".to_vec()),
+                "https://example.test/sample.webm" => {
+                    (200, "video/webm", b"FAKE_WEBM_BYTES".to_vec())
+                }
                 "https://example.test/cat.png" => (200, "image/png", {
                     // Minimal valid-looking PNG header bytes; real validity not required —
                     // the skill doesn't decode the image.
@@ -83,6 +92,9 @@ impl Block for FakeNetworkBlock {
                     v
                 }),
                 "https://example.test/not-an-image.html" => {
+                    (200, "text/html", b"<html></html>".to_vec())
+                }
+                "https://example.test/not-a-video.html" => {
                     (200, "text/html", b"<html></html>".to_vec())
                 }
                 "https://example.test/small.png" => (200, "image/png", {
@@ -1092,4 +1104,233 @@ async fn dispatch_chains_resize_then_crop_via_ref() {
         .expect("crop emits data_url");
     assert!(data_url.starts_with("data:image/"));
     assert!(data_url.len() > 100, "cropped data_url suspiciously small");
+}
+
+// -- video-transcode dispatch tests ------------------------------------------
+
+const TRANSCODE_WASM: &[u8] = include_bytes!("../blocks/video-transcode/target/block.wasm");
+const TRIM_WASM: &[u8] = include_bytes!("../blocks/video-trim/target/block.wasm");
+const FRAME_EXTRACT_WASM: &[u8] =
+    include_bytes!("../blocks/video-frame-extract/target/block.wasm");
+
+#[tokio::test]
+async fn video_transcode_happy_path_returns_envelope() {
+    let svc = Arc::new(FakeFfmpegService::ok(
+        b"\x00\x00\x00\x18ftypmp42"
+            .iter()
+            .chain([0u8; 200].iter())
+            .copied()
+            .collect(),
+        "fake transcode log",
+    ));
+    let env = dispatch_image_op(
+        "gizza-ai/video-transcode",
+        "video-transcode",
+        TRANSCODE_WASM,
+        "https://example.test/sample.mp4",
+        json!({ "format": "mp4", "quality": 75 }),
+        svc,
+    )
+    .await
+    .expect("transcode succeeds");
+    assert_eq!(env["_for_ui"]["mime"], "video/mp4");
+    assert!(env["_for_ui"]["data_url"]
+        .as_str()
+        .unwrap()
+        .starts_with("data:video/mp4;base64,"));
+}
+
+#[tokio::test]
+async fn video_transcode_rejects_oversize_input() {
+    let svc = Arc::new(FakeFfmpegService::ok(b"unused".to_vec(), "unused"));
+    let result = dispatch_image_op(
+        "gizza-ai/video-transcode",
+        "video-transcode",
+        TRANSCODE_WASM,
+        "https://example.test/huge.mp4",
+        json!({ "format": "mp4" }),
+        svc.clone(),
+    )
+    .await;
+    assert!(result.is_err(), "oversize must error");
+    assert_eq!(svc.calls(), 0, "ffmpeg-runtime must not be called when input rejected");
+}
+
+#[tokio::test]
+async fn video_transcode_rejects_non_video_content_type() {
+    let svc = Arc::new(FakeFfmpegService::ok(b"unused".to_vec(), "unused"));
+    let result = dispatch_image_op(
+        "gizza-ai/video-transcode",
+        "video-transcode",
+        TRANSCODE_WASM,
+        "https://example.test/not-a-video.html",
+        json!({ "format": "mp4" }),
+        svc.clone(),
+    )
+    .await;
+    assert!(result.is_err());
+    assert_eq!(svc.calls(), 0);
+}
+
+#[tokio::test]
+async fn video_transcode_surfaces_ffmpeg_failure() {
+    let svc = Arc::new(FakeFfmpegService::fail(127, "ffmpeg crashed"));
+    let result = dispatch_image_op(
+        "gizza-ai/video-transcode",
+        "video-transcode",
+        TRANSCODE_WASM,
+        "https://example.test/sample.mp4",
+        json!({ "format": "mp4" }),
+        svc,
+    )
+    .await;
+    assert!(result.is_err());
+}
+
+// -- video-trim dispatch tests -----------------------------------------------
+
+#[tokio::test]
+async fn video_trim_happy_path_returns_envelope() {
+    let svc = Arc::new(FakeFfmpegService::ok(
+        b"\x00\x00\x00\x18ftypmp42"
+            .iter()
+            .chain([0u8; 88].iter())
+            .copied()
+            .collect(),
+        "fake trim log",
+    ));
+    let env = dispatch_image_op(
+        "gizza-ai/video-trim",
+        "video-trim",
+        TRIM_WASM,
+        "https://example.test/sample.mp4",
+        json!({ "start": 1.0, "duration": 2.0 }),
+        svc,
+    )
+    .await
+    .expect("trim succeeds");
+    assert_eq!(env["_for_ui"]["mime"], "video/mp4");
+}
+
+#[tokio::test]
+async fn video_trim_rejects_oversize_input() {
+    let svc = Arc::new(FakeFfmpegService::ok(b"unused".to_vec(), "unused"));
+    let result = dispatch_image_op(
+        "gizza-ai/video-trim",
+        "video-trim",
+        TRIM_WASM,
+        "https://example.test/huge.mp4",
+        json!({ "start": 0.0, "duration": 1.0 }),
+        svc.clone(),
+    )
+    .await;
+    assert!(result.is_err());
+    assert_eq!(svc.calls(), 0);
+}
+
+#[tokio::test]
+async fn video_trim_rejects_non_video_content_type() {
+    let svc = Arc::new(FakeFfmpegService::ok(b"unused".to_vec(), "unused"));
+    let result = dispatch_image_op(
+        "gizza-ai/video-trim",
+        "video-trim",
+        TRIM_WASM,
+        "https://example.test/not-a-video.html",
+        json!({ "start": 0.0, "duration": 1.0 }),
+        svc.clone(),
+    )
+    .await;
+    assert!(result.is_err());
+    assert_eq!(svc.calls(), 0);
+}
+
+#[tokio::test]
+async fn video_trim_surfaces_ffmpeg_failure() {
+    let svc = Arc::new(FakeFfmpegService::fail(1, "stream copy failed"));
+    let result = dispatch_image_op(
+        "gizza-ai/video-trim",
+        "video-trim",
+        TRIM_WASM,
+        "https://example.test/sample.mp4",
+        json!({ "start": 0.0, "duration": 1.0 }),
+        svc,
+    )
+    .await;
+    assert!(result.is_err());
+}
+
+// -- video-frame-extract dispatch tests --------------------------------------
+
+#[tokio::test]
+async fn video_frame_extract_happy_path_returns_envelope() {
+    let svc = Arc::new(FakeFfmpegService::ok(
+        b"\x89PNG\r\n\x1a\n"
+            .iter()
+            .chain([0u8; 200].iter())
+            .copied()
+            .collect(),
+        "fake frame extract log",
+    ));
+    let env = dispatch_image_op(
+        "gizza-ai/video-frame-extract",
+        "video-frame-extract",
+        FRAME_EXTRACT_WASM,
+        "https://example.test/sample.mp4",
+        json!({ "timestamp": 1.5 }),
+        svc,
+    )
+    .await
+    .expect("frame-extract succeeds");
+    assert_eq!(env["_for_ui"]["mime"], "image/png");
+    assert!(env["_for_ui"]["data_url"]
+        .as_str()
+        .unwrap()
+        .starts_with("data:image/png;base64,"));
+}
+
+#[tokio::test]
+async fn video_frame_extract_rejects_oversize_input() {
+    let svc = Arc::new(FakeFfmpegService::ok(b"unused".to_vec(), "unused"));
+    let result = dispatch_image_op(
+        "gizza-ai/video-frame-extract",
+        "video-frame-extract",
+        FRAME_EXTRACT_WASM,
+        "https://example.test/huge.mp4",
+        json!({ "timestamp": 0.0 }),
+        svc.clone(),
+    )
+    .await;
+    assert!(result.is_err());
+    assert_eq!(svc.calls(), 0);
+}
+
+#[tokio::test]
+async fn video_frame_extract_rejects_non_video_content_type() {
+    let svc = Arc::new(FakeFfmpegService::ok(b"unused".to_vec(), "unused"));
+    let result = dispatch_image_op(
+        "gizza-ai/video-frame-extract",
+        "video-frame-extract",
+        FRAME_EXTRACT_WASM,
+        "https://example.test/not-a-video.html",
+        json!({ "timestamp": 0.0 }),
+        svc.clone(),
+    )
+    .await;
+    assert!(result.is_err());
+    assert_eq!(svc.calls(), 0);
+}
+
+#[tokio::test]
+async fn video_frame_extract_surfaces_ffmpeg_failure() {
+    let svc = Arc::new(FakeFfmpegService::fail(1, "no decoder for stream"));
+    let result = dispatch_image_op(
+        "gizza-ai/video-frame-extract",
+        "video-frame-extract",
+        FRAME_EXTRACT_WASM,
+        "https://example.test/sample.mp4",
+        json!({ "timestamp": 0.0 }),
+        svc,
+    )
+    .await;
+    assert!(result.is_err());
 }

--- a/tests/skills_embed.rs
+++ b/tests/skills_embed.rs
@@ -110,3 +110,51 @@ fn image_convert_skill_is_embedded() {
     assert!(!bytes.is_empty());
     assert_eq!(&bytes[..4], b"\0asm");
 }
+
+#[test]
+fn video_frame_extract_skill_is_embedded() {
+    assert!(
+        gizza_ai::skills::SKILLS
+            .iter()
+            .any(|(n, _)| *n == "gizza-ai/video-frame-extract"),
+        "gizza-ai/video-frame-extract should be embedded — did you forget to build the block first?"
+    );
+    let (_, bytes) = gizza_ai::skills::SKILLS
+        .iter()
+        .find(|(n, _)| *n == "gizza-ai/video-frame-extract")
+        .expect("video-frame-extract");
+    assert!(!bytes.is_empty());
+    assert_eq!(&bytes[..4], b"\0asm");
+}
+
+#[test]
+fn video_transcode_skill_is_embedded() {
+    assert!(
+        gizza_ai::skills::SKILLS
+            .iter()
+            .any(|(n, _)| *n == "gizza-ai/video-transcode"),
+        "gizza-ai/video-transcode should be embedded — did you forget to build the block first?"
+    );
+    let (_, bytes) = gizza_ai::skills::SKILLS
+        .iter()
+        .find(|(n, _)| *n == "gizza-ai/video-transcode")
+        .expect("video-transcode");
+    assert!(!bytes.is_empty());
+    assert_eq!(&bytes[..4], b"\0asm");
+}
+
+#[test]
+fn video_trim_skill_is_embedded() {
+    assert!(
+        gizza_ai::skills::SKILLS
+            .iter()
+            .any(|(n, _)| *n == "gizza-ai/video-trim"),
+        "gizza-ai/video-trim should be embedded — did you forget to build the block first?"
+    );
+    let (_, bytes) = gizza_ai::skills::SKILLS
+        .iter()
+        .find(|(n, _)| *n == "gizza-ai/video-trim")
+        .expect("video-trim");
+    assert!(!bytes.is_empty());
+    assert_eq!(&bytes[..4], b"\0asm");
+}


### PR DESCRIPTION
## Summary

Three new video skills layered on `gizza-ai/ffmpeg-runtime`, mirroring the SP5 image-ops template:

- **`gizza-ai/video-transcode`** — `{url|ref, format: mp4|webm, quality?: 1..100}` → encoded video. Uses `libx264 + aac` for mp4, `libvpx-vp9 + libopus` for webm. CRF mapping: `quality=100→crf=0`, `quality=75→crf≈13`, `quality=1→crf=51`.
- **`gizza-ai/video-trim`** — `{url|ref, start: f64, duration: f64}` → mp4 via stream-copy (no re-encode). Fast; preserves source codecs but requires h264/aac source streams.
- **`gizza-ai/video-frame-extract`** — `{url|ref, timestamp: f64}` → single-frame PNG. Output is image, so it chains naturally into the existing `image-resize`/`crop`/`convert` skills via the SP4 envelope's `data_url`.

All three use `#[wafer_block(skill(...))]` from day one; advertised to LLM out of the box. 10 MiB symmetric caps (image-ops were 4 MiB; video bitrate justifies the bump).

Spec: `workspace/docs/superpowers/specs/2026-05-06-gizza-ai-video-ops-skills-design.md`
Plan: `workspace/docs/superpowers/plans/2026-05-06-gizza-ai-video-ops-skills.md`

## Test plan
- [x] `cargo test` — 23 lib + 38 dispatch + 10 skills_embed + per-block unit (transcode 7, trim 5, frame-extract 5) all green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] `dispatch_chains_video_frame_extract_then_image_resize_via_ref` — proves the cross-modality chain (video producer → image consumer) works through the existing attachment ABI
- [ ] Manual headed smoke (deferred — needs real video sample): chat-prompt "extract frame at 5s and resize to 200px" and confirm Qwen calls frame-extract then image-resize via `{ref}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)