### PR TITLE
feat: SP3 drag-drop file upload UI

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -8,6 +8,7 @@ actually pick up next session."
 
 A productive day across three repos. Stack of merges, top to bottom:
 
+- **gizza-ai #33** (this PR) — SP3 drag-drop file upload UI. User drops image/video onto the chat; appears as removable chips above the textarea; on send, files become attachments under `upload_N` ids and the LLM sees them as synthetic prior tool_results matching the Phase A chaining hint format. Uses the same `{ref}` mechanism as chained skill outputs. 10 MiB per-file cap, image/video only, multi-file, paperclip fallback for mobile/a11y.
 - **wafer-run #36 / #37 / #38** — attachment ABI (per-call host helpers `__wafer_host_stream_attach` + `__wafer_host_lookup_attachment` + `Context::lookup_attachment` + `Attachment` type), `#[wafer_block(skill(...))]` macro attribute for LLM tool schemas, and wafer-cli validator stubs for the new imports.
 - **gizza-ai #32** (this PR) — SP5 video slice. Three new skills: `gizza-ai/video-transcode` (mp4/webm with quality knob), `gizza-ai/video-trim` (stream-copy to mp4), `gizza-ai/video-frame-extract` (single-frame PNG, naturally chainable into image-* skills via the SP4 envelope). 10 MiB symmetric caps. All accept `{url|ref}`. The `dispatch_chains_video_frame_extract_then_image_resize_via_ref` test proves the cross-modality chain.
 - **gizza-ai #31** (this PR) — skill-output chaining. Agent block stashes `_for_ui` attachments per request and appends a ref hint to `_for_llm`; image-resize / image-crop / image-convert accept `{ref: "<call-id>"}` as an alternative to `{url}`. **Also fixes a pre-existing gap:** every gizza-ai skill block (clock, calculator, web-fetch, image-fetch, ffmpeg, image-resize, image-crop, image-convert) now uses the new `skill(...)` macro attribute, so the LLM finally sees them in the tool list. Before this PR, `Context::registered_blocks()` had `role: None` and `tool: None` on every wasmi-built skill; the agent's `build_tools()` returned an empty `Vec<ToolDefinition>` on every chat request.
@@ -21,8 +22,7 @@ A productive day across three repos. Stack of merges, top to bottom:
 **Top of the queue:**
 
 1. **Operator items below — your action only.** Unblock the live site.
-2. **ffmpeg sub-project 3** (file drag-drop UI) — needs a design pass first.
-3. **Conversation persistence** — still blocked on producer-side solobase change.
+2. **Conversation persistence** — still blocked on producer-side solobase change.
 
 **Cross-repo news from the 2026-05-03 session:**
 
@@ -86,7 +86,7 @@ A productive day across three repos. Stack of merges, top to bottom:
 - [~] `gizza-ai/ffmpeg` — flagship. Decomposed into sub-projects (see specs). Status:
   - [x] **Sub-project 1** — ffmpeg-runtime invocation primitive (PR #21). Native `FfmpegBlock` registered as `gizza-ai/ffmpeg-runtime`, JS bridge at `js/ffmpeg.js` lazy-loads `@ffmpeg/ffmpeg` from jsdelivr.
   - [x] **Sub-project 2** — ffprobe-scope skill (PR #22). Two-hop `call_block` (network → bytes → ffmpeg-runtime → log). Tool surface: `{url}` only; returns `{url, info}` JSON.
-  - [ ] **Sub-project 3** — file drag-drop UI (deferred — needs design pass).
+  - [x] **Sub-project 3** — file drag-drop UI shipped in PR #33. Image/video files drop onto the page → chips → on send, the LLM sees `upload_N` refs alongside chained-call refs.
   - [x] **Sub-project 4** — inline `<img>`/`<video>` rendering (PR #26). Envelope wire format `{_for_llm, _for_ui}` bifurcates LLM history from UI rendering. Demonstrating skill `gizza-ai/image-fetch` proves the path. Renders inside the tool-call row. Sub-project 5 inherits the envelope; image transcoding can ship without further wire changes (video transcoding uses the `media-src` CSP entry added here).
   - [x] **Sub-project 5** — resize/transcode/crop/trim. Image slice (image-resize/crop/convert) shipped in PR #30. Video slice (video-transcode/trim/frame-extract) shipped in PR #32 — same SP5 template, 10 MiB caps, chainable via {url|ref}.
 - [ ] `gizza-ai/search-messages` — calls `suppers-ai/messages` via `ctx.call_block` to search past conversation. **Blocked**: chat history isn't persisted to `suppers-ai/messages` today, and persistence itself is blocked on a producer-side change (see Plan E).

--- a/js/pending.test.js
+++ b/js/pending.test.js
@@ -1,0 +1,101 @@
+import { test, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseHTML } from 'linkedom';
+import {
+    addPending,
+    removePending,
+    clearPending,
+    getPending,
+    renderChips,
+    _resetForTests,
+} from '../site/pending.js';
+
+function setupDom() {
+    const { document } = parseHTML(
+        '<!doctype html><div id="upload-chips" class="upload-chips empty"></div>',
+    );
+    globalThis.document = document;
+    return document.querySelector('#upload-chips');
+}
+
+beforeEach(() => {
+    _resetForTests();
+});
+
+function fakeFile(name, type, size = 100) {
+    return {
+        name,
+        type,
+        size,
+    };
+}
+
+test('addPending with image creates chip with image-type label', () => {
+    const strip = setupDom();
+    const r = addPending(fakeFile('cat.png', 'image/png'));
+    assert.equal(r.ok, true);
+    assert.equal(r.entry.id, 'upload_1');
+    renderChips(strip);
+    assert.equal(strip.classList.contains('empty'), false);
+    const chip = strip.querySelector('.chip');
+    assert.ok(chip, 'chip rendered');
+    assert.ok(chip.textContent.includes('cat.png'));
+    assert.ok(chip.querySelector('button.remove'));
+});
+
+test('addPending with video creates chip with filename text', () => {
+    const strip = setupDom();
+    addPending(fakeFile('clip.mp4', 'video/mp4'));
+    renderChips(strip);
+    const chip = strip.querySelector('.chip');
+    assert.ok(chip.textContent.includes('clip.mp4'));
+});
+
+test('addPending rejects non-image non-video', () => {
+    const strip = setupDom();
+    const r = addPending(fakeFile('a.pdf', 'application/pdf'));
+    assert.equal(r.ok, false);
+    assert.match(r.error, /image|video/i);
+    renderChips(strip);
+    assert.equal(getPending().length, 0);
+});
+
+test('addPending rejects oversize file (>10 MiB)', () => {
+    const strip = setupDom();
+    const r = addPending(fakeFile('big.png', 'image/png', 10 * 1024 * 1024 + 1));
+    assert.equal(r.ok, false);
+    assert.match(r.error, /too large|10 MiB/i);
+    renderChips(strip);
+    assert.equal(getPending().length, 0);
+});
+
+test('removePending clears chip and pending entry; nextUploadId is monotonic', () => {
+    const strip = setupDom();
+    const a = addPending(fakeFile('a.png', 'image/png')).entry;
+    const b = addPending(fakeFile('b.png', 'image/png')).entry;
+    assert.equal(a.id, 'upload_1');
+    assert.equal(b.id, 'upload_2');
+
+    removePending(a.id);
+    renderChips(strip);
+    const ids = [...strip.querySelectorAll('.chip')].map((c) =>
+        c.getAttribute('data-id'),
+    );
+    assert.deepEqual(ids, ['upload_2']);
+
+    // After remove, the next id is upload_3 (monotonic — does NOT reuse upload_1).
+    const c = addPending(fakeFile('c.png', 'image/png')).entry;
+    assert.equal(c.id, 'upload_3');
+});
+
+test('clearPending empties the strip and pending list', () => {
+    const strip = setupDom();
+    addPending(fakeFile('a.png', 'image/png'));
+    addPending(fakeFile('b.png', 'image/png'));
+    assert.equal(getPending().length, 2);
+    clearPending();
+    renderChips(strip);
+    assert.equal(getPending().length, 0);
+    assert.equal(strip.classList.contains('empty'), true);
+    assert.equal(strip.children.length, 0);
+});

--- a/site/gizza-app.js
+++ b/site/gizza-app.js
@@ -2,10 +2,30 @@
 // SSE parsing. All state is in-memory — no persistence for MVP.
 
 import { renderToolAttachment } from './render.js';
+import {
+    addPending,
+    removePending,
+    clearPending,
+    getPending,
+    renderChips,
+} from './pending.js';
 
 const history = []; // OpenAI-format messages.
 
 const $ = (id) => document.getElementById(id);
+
+async function blobToBase64(blob) {
+    return await new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+            const result = reader.result; // "data:<mime>;base64,<payload>"
+            const comma = result.indexOf(',');
+            resolve(comma >= 0 ? result.slice(comma + 1) : result);
+        };
+        reader.onerror = () => reject(reader.error);
+        reader.readAsDataURL(blob);
+    });
+}
 
 // Local-storage key for the user's chosen WebLLM model id. Set whenever the
 // model picker changes; read at page-init to restore the previous choice.
@@ -113,6 +133,94 @@ function updateToolRow(row, ok, result) {
     row.appendChild(resSpan);
     row.classList.add(ok ? 'is-done' : 'is-error');
 }
+
+// --- Drag-drop + file-picker upload wiring ---
+
+function showUploadError(text) {
+    const strip = document.getElementById('upload-chips');
+    strip.replaceChildren();
+    const err = document.createElement('span');
+    err.className = 'upload-error';
+    err.textContent = text;
+    strip.appendChild(err);
+    strip.classList.remove('empty');
+}
+
+function refreshChips() {
+    const strip = document.getElementById('upload-chips');
+    renderChips(strip);
+    strip.querySelectorAll('button.remove').forEach((btn) => {
+        const chip = btn.closest('.chip');
+        const id = chip?.getAttribute('data-id');
+        if (id) {
+            btn.addEventListener('click', () => {
+                removePending(id);
+                refreshChips();
+            });
+        }
+    });
+}
+
+function ingestFiles(fileList) {
+    let firstError = null;
+    for (const f of fileList) {
+        const r = addPending(f);
+        if (!r.ok && !firstError) firstError = r.error;
+    }
+    if (firstError && getPending().length === 0) {
+        showUploadError(firstError);
+        return;
+    }
+    refreshChips();
+    if (firstError) {
+        console.warn('Upload partially rejected:', firstError);
+    }
+}
+
+function setupUploads() {
+    const attach = document.getElementById('attach');
+    const picker = document.getElementById('file-picker');
+    if (!attach || !picker) return;
+    attach.addEventListener('click', () => picker.click());
+    picker.addEventListener('change', () => {
+        ingestFiles(picker.files);
+        picker.value = '';
+    });
+
+    const overlay = document.createElement('div');
+    overlay.id = 'drop-overlay';
+    overlay.hidden = true;
+    overlay.innerHTML =
+        '<div class="drop-overlay-inner">Drop image or video to attach.</div>';
+    document.body.appendChild(overlay);
+
+    let dragDepth = 0;
+    document.addEventListener('dragenter', (e) => {
+        if (!e.dataTransfer || !Array.from(e.dataTransfer.types).includes('Files')) return;
+        e.preventDefault();
+        dragDepth += 1;
+        overlay.hidden = false;
+    });
+    document.addEventListener('dragover', (e) => {
+        if (!e.dataTransfer || !Array.from(e.dataTransfer.types).includes('Files')) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'copy';
+    });
+    document.addEventListener('dragleave', (e) => {
+        if (!e.dataTransfer || !Array.from(e.dataTransfer.types).includes('Files')) return;
+        dragDepth = Math.max(0, dragDepth - 1);
+        if (dragDepth === 0) overlay.hidden = true;
+    });
+    document.addEventListener('drop', (e) => {
+        if (!e.dataTransfer || e.dataTransfer.files.length === 0) return;
+        e.preventDefault();
+        dragDepth = 0;
+        overlay.hidden = true;
+        ingestFiles(e.dataTransfer.files);
+    });
+}
+
+setupUploads();
 
 // Progress card \u2014 created lazily inside the Settings dialog while the model
 // downloads. Holds the verbose stage message so the Load model button text
@@ -393,6 +501,17 @@ $('composer').addEventListener('submit', async (e) => {
     const assistantEl = addAssistantBubble();
     const toolRows = new Map(); // tool-call id -> DOM row
 
+    const pendingUploads = getPending();
+    const uploads = await Promise.all(
+        pendingUploads.map(async (p) => ({
+            id: p.id,
+            mime: p.mime,
+            filename: p.filename,
+            bytes_base64: await blobToBase64(p.blob),
+        })),
+    );
+
+    let roundTripCompleted = false;
     try {
         const resp = await fetch('/b/agent/chat', {
             method: 'POST',
@@ -401,6 +520,7 @@ $('composer').addEventListener('submit', async (e) => {
                 user_message: text,
                 messages: history.slice(0, -1),
                 model_id: selectedModelId(),
+                uploads,
             }),
         });
         if (!resp.ok) throw new Error(`agent HTTP ${resp.status}`);
@@ -424,12 +544,20 @@ $('composer').addEventListener('submit', async (e) => {
         if (assistantText) {
             history.push({ role: 'assistant', content: assistantText });
         }
+        roundTripCompleted = true;
     } catch (err) {
         assistantEl.textContent = `(error: ${err.message})`;
     } finally {
         input.disabled = false;
         $('send').disabled = false;
         input.focus();
+        // Clear pending uploads only on a successful round-trip — leave chips
+        // visible on network/parse error so the user can retry without
+        // re-attaching the files.
+        if (roundTripCompleted) {
+            clearPending();
+            refreshChips();
+        }
     }
 
     function processFrame(frame) {

--- a/site/gizza.css
+++ b/site/gizza.css
@@ -759,3 +759,115 @@ dialog button[value="close"] {
     margin-top: 0.5rem;
     border-radius: 4px;
 }
+
+/* ─── Upload chips ─────────────────────────────────────────────────────── */
+/* The chip strip lives above the textarea inside #composer. Hidden when
+ * empty (no padding, no border) so the composer doesn't show extra
+ * vertical space when there are no pending uploads. */
+
+#composer #upload-chips {
+  grid-column: 1 / -1;
+  grid-row: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+  padding: 0 var(--space-xs);
+  margin-bottom: var(--space-xs);
+}
+#composer #upload-chips.empty {
+  display: none;
+}
+/* Bump the textarea down to row 2 (chips take row 1). */
+#composer:has(#upload-chips:not(.empty)) textarea {
+  grid-row: 2;
+}
+
+#composer .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px 4px 10px;
+  border: 1px solid var(--color-hairline-strong);
+  border-radius: 14px;
+  background: var(--color-surface-card);
+  color: var(--color-ink);
+  font-size: 13px;
+  line-height: 1.2;
+  max-width: 240px;
+}
+#composer .chip .chip-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+#composer .chip .remove {
+  /* Override the inherited 36px composer-button shell. */
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--color-muted);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  margin: 0;
+}
+#composer .chip .remove:hover {
+  color: var(--color-ink);
+  background: var(--color-hairline);
+}
+
+#composer .upload-error {
+  color: var(--color-on-primary, #b00020);
+  font-size: 13px;
+  padding: 4px 8px;
+}
+
+/* ─── Paperclip attach button ──────────────────────────────────────────── */
+/* Inherits the 36px circle shell from the existing #composer button rules.
+ * Just provide the icon mask. */
+#composer #attach {
+  grid-row: 2;
+}
+#composer #attach::before {
+  content: "";
+  width: 18px;
+  height: 18px;
+  background: currentColor;
+  -webkit-mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'><path d='M21.44 11.05l-9.19 9.19a6 6 0 1 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66L9.41 17.41a2 2 0 0 1-2.83-2.83l8.49-8.49'/></svg>");
+          mask-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'><path d='M21.44 11.05l-9.19 9.19a6 6 0 1 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66L9.41 17.41a2 2 0 0 1-2.83-2.83l8.49-8.49'/></svg>");
+  -webkit-mask-repeat: no-repeat;
+          mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+          mask-position: center;
+  -webkit-mask-size: contain;
+          mask-size: contain;
+}
+
+/* ─── Drop overlay ─────────────────────────────────────────────────────── */
+/* Full-page dimmer + "Drop image or video to attach" caption. The overlay
+ * is created by gizza-app.js and toggled via the [hidden] attribute. */
+
+#drop-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: grid;
+  place-items: center;
+  background: color-mix(in oklch, var(--color-canvas) 70%, transparent);
+  backdrop-filter: blur(2px);
+  pointer-events: none;
+}
+#drop-overlay[hidden] { display: none; }
+#drop-overlay .drop-overlay-inner {
+  padding: var(--space-base) var(--space-lg);
+  border: 2px dashed var(--color-primary);
+  border-radius: 16px;
+  background: var(--color-surface-card);
+  color: var(--color-ink);
+  font-family: var(--font-display);
+  font-size: 18px;
+}

--- a/site/pending.js
+++ b/site/pending.js
@@ -1,0 +1,94 @@
+// Pending-uploads state machine for the chat composer.
+//
+// Single responsibility: track files the user has dropped/picked but not yet
+// sent. Pure state + DOM rendering — no event wiring (that's gizza-app.js).
+
+const MAX_FILE_BYTES = 10 * 1024 * 1024; // 10 MiB; matches video skill caps.
+
+const pending = []; // [{ id, mime, filename, blob }]
+let nextUploadId = 1;
+
+/**
+ * Add a File to the pending list. Returns `{ok: true, entry}` on success,
+ * `{ok: false, error}` on validation failure (wrong mime / too large).
+ *
+ * The id is monotonically increasing and never reused, even after a remove —
+ * so a chip identified by `upload_3` always means the third addPending call
+ * since page load.
+ */
+export function addPending(file) {
+    const isImage = typeof file.type === 'string' && file.type.startsWith('image/');
+    const isVideo = typeof file.type === 'string' && file.type.startsWith('video/');
+    if (!isImage && !isVideo) {
+        return { ok: false, error: 'Only images and videos are supported.' };
+    }
+    if (typeof file.size === 'number' && file.size > MAX_FILE_BYTES) {
+        return { ok: false, error: 'File too large; 10 MiB max.' };
+    }
+    const entry = {
+        id: `upload_${nextUploadId++}`,
+        mime: file.type,
+        filename: file.name || (isImage ? 'image' : 'video'),
+        blob: file,
+    };
+    pending.push(entry);
+    return { ok: true, entry };
+}
+
+/** Remove the entry with the given id. No-op if not found. */
+export function removePending(id) {
+    const idx = pending.findIndex((e) => e.id === id);
+    if (idx >= 0) pending.splice(idx, 1);
+}
+
+/** Clear all pending entries. Does NOT reset nextUploadId. */
+export function clearPending() {
+    pending.length = 0;
+}
+
+/** Snapshot of the current pending list. Returns a new array (safe to iterate). */
+export function getPending() {
+    return [...pending];
+}
+
+/**
+ * Render the pending list into the given strip element.
+ * Replaces existing children. Adds/removes the `empty` class on the strip.
+ *
+ * Each chip is `<span class="chip" data-id="upload_N">…<button class="remove">×</button></span>`.
+ * The caller is responsible for wiring the click handler on `.remove` —
+ * `removePending(id)` then `renderChips(strip)` again.
+ */
+export function renderChips(strip) {
+    strip.replaceChildren();
+    if (pending.length === 0) {
+        strip.classList.add('empty');
+        return;
+    }
+    strip.classList.remove('empty');
+    for (const entry of pending) {
+        const chip = document.createElement('span');
+        chip.className = 'chip';
+        chip.setAttribute('data-id', entry.id);
+
+        const label = document.createElement('span');
+        label.className = 'chip-label';
+        label.textContent = entry.filename;
+        chip.appendChild(label);
+
+        const remove = document.createElement('button');
+        remove.type = 'button';
+        remove.className = 'remove';
+        remove.setAttribute('aria-label', `Remove ${entry.filename}`);
+        remove.textContent = '×';
+        chip.appendChild(remove);
+
+        strip.appendChild(chip);
+    }
+}
+
+/** Test-only: reset all module state. Not exported in production paths. */
+export function _resetForTests() {
+    pending.length = 0;
+    nextUploadId = 1;
+}

--- a/src/blocks/agent.rs
+++ b/src/blocks/agent.rs
@@ -374,7 +374,16 @@ async fn run_agent_loop(
     for (id, att, _display) in &staged_uploads {
         attachments.insert(id.clone(), att.clone());
     }
-    let _ = staged_uploads; // synthetic-history injection: see DDT2.
+    // Inject synthetic upload history BEFORE the user message.
+    // history at entry contains [...prior messages, current user message] —
+    // pop the user, splice the prefix, push the user back.
+    if !staged_uploads.is_empty() {
+        let user_msg = history.pop();
+        history.extend(build_upload_history_prefix(&staged_uploads));
+        if let Some(u) = user_msg {
+            history.push(u);
+        }
+    }
 
     for round in 1..=MAX_ROUNDS {
         // Convert OpenAI-format history to ChatMessage vec.
@@ -759,6 +768,45 @@ pub(crate) fn format_ref_hint(id: &str, att: &Attachment) -> String {
         size = att.bytes.len(),
         fn_clause = filename_clause,
     )
+}
+
+/// Build the synthetic assistant + tool history-prefix entries the agent
+/// injects ahead of the user message when the request carries uploads.
+///
+/// Returns two `serde_json::Value` entries per upload:
+///   1. `{role: "assistant", tool_calls: [{id, function: {name: "user_upload", arguments: "{}"}}]}`
+///   2. `{role: "tool", tool_call_id: id, content: "ref upload_1 saved (...). Pass {\"ref\":\"upload_1\"} to a skill."}`
+///
+/// The phrasing mirrors `format_ref_hint` so the LLM treats `upload_N` ids
+/// the same as chained-call ids (`call_N`) — same `{ref}` mechanism.
+pub(crate) fn build_upload_history_prefix(
+    staged: &[(String, Attachment, String)],
+) -> Vec<serde_json::Value> {
+    let mut out = Vec::with_capacity(staged.len() * 2);
+    for (id, att, display) in staged {
+        out.push(serde_json::json!({
+            "role": "assistant",
+            "tool_calls": [{
+                "id": id,
+                "type": "function",
+                "function": { "name": "user_upload", "arguments": "{}" }
+            }]
+        }));
+        let content = format!(
+            "ref {id} saved ({mime}, {size} bytes, {display:?}). \
+             Pass {{\"ref\": \"{id}\"}} to a skill.",
+            id = id,
+            mime = att.mime,
+            size = att.bytes.len(),
+            display = display,
+        );
+        out.push(serde_json::json!({
+            "role": "tool",
+            "tool_call_id": id,
+            "content": content,
+        }));
+    }
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -1404,5 +1452,61 @@ mod tests {
         }];
         let staged = decode_uploads(&entries).expect("decoded");
         assert_eq!(staged[0].2, "video");
+    }
+
+    #[test]
+    fn build_upload_history_prefix_emits_assistant_and_tool_pair_per_upload() {
+        let staged = vec![
+            (
+                "upload_1".to_string(),
+                Attachment {
+                    mime: "image/png".into(),
+                    bytes: vec![0u8; 1228800],
+                    filename: Some("cat.png".into()),
+                },
+                "cat.png".to_string(),
+            ),
+            (
+                "upload_2".to_string(),
+                Attachment {
+                    mime: "video/mp4".into(),
+                    bytes: vec![0u8; 5_000_000],
+                    filename: None,
+                },
+                "video".to_string(),
+            ),
+        ];
+        let prefix = build_upload_history_prefix(&staged);
+        // Two messages per upload (assistant tool_call + tool result).
+        assert_eq!(prefix.len(), 4);
+        // First upload: assistant tool_calls entry.
+        assert_eq!(prefix[0]["role"], "assistant");
+        assert_eq!(prefix[0]["tool_calls"][0]["id"], "upload_1");
+        assert_eq!(
+            prefix[0]["tool_calls"][0]["function"]["name"],
+            "user_upload"
+        );
+        // First upload: tool result references the same id.
+        assert_eq!(prefix[1]["role"], "tool");
+        assert_eq!(prefix[1]["tool_call_id"], "upload_1");
+        let content = prefix[1]["content"].as_str().unwrap();
+        assert!(content.contains("upload_1"));
+        assert!(content.contains("image/png"));
+        assert!(content.contains("1228800"));
+        assert!(content.contains("cat.png"));
+        assert!(content.contains(r#"{"ref": "upload_1"}"#));
+        // Second upload: video, no filename — content uses fallback display name.
+        assert_eq!(prefix[3]["tool_call_id"], "upload_2");
+        let content = prefix[3]["content"].as_str().unwrap();
+        assert!(content.contains("upload_2"));
+        assert!(content.contains("video/mp4"));
+        assert!(content.contains("video")); // display name fallback
+    }
+
+    #[test]
+    fn build_upload_history_prefix_empty_for_no_uploads() {
+        let staged: Vec<(String, Attachment, String)> = Vec::new();
+        let prefix = build_upload_history_prefix(&staged);
+        assert!(prefix.is_empty());
     }
 }

--- a/src/blocks/agent.rs
+++ b/src/blocks/agent.rs
@@ -93,11 +93,22 @@ struct AgentRequest {
     /// LLM service loads/uses without per-request server-side config.
     #[serde(default)]
     model_id: Option<String>,
+    #[serde(default)]
+    uploads: Vec<UploadEntry>,
 }
 
 #[derive(Debug, Deserialize)]
 struct LoadModelRequest {
     model_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct UploadEntry {
+    id: String,
+    mime: String,
+    #[serde(default)]
+    filename: Option<String>,
+    bytes_base64: String,
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -153,6 +164,7 @@ async fn handle_chat(ctx: &dyn Context, input: InputStream) -> OutputStream {
             user_message: String::new(),
             messages: Vec::new(),
             model_id: None,
+            uploads: Vec::new(),
         }
     } else {
         match serde_json::from_slice(&body_bytes) {
@@ -167,7 +179,13 @@ async fn handle_chat(ctx: &dyn Context, input: InputStream) -> OutputStream {
         return error_response(400, "bad_request", "user_message or messages required");
     }
 
-    // 2. Build ToolDefinitions from registered skill blocks.
+    // 2a. Decode uploads. Reject the request on any invalid entry.
+    let staged_uploads = match decode_uploads(&req.uploads) {
+        Ok(v) => v,
+        Err(e) => return error_response(400, "bad_request", &e),
+    };
+
+    // 2b. Build ToolDefinitions from registered skill blocks.
     let tools = build_tools(&ctx.registered_blocks());
 
     // 3. Compose conversation history: prior messages + new user turn.
@@ -189,7 +207,7 @@ async fn handle_chat(ctx: &dyn Context, input: InputStream) -> OutputStream {
         .to_string();
 
     // 5. Run the tool-use loop, buffering the SSE output.
-    let sse_body = run_agent_loop(ctx, history, tools, &model_id).await;
+    let sse_body = run_agent_loop(ctx, history, tools, &model_id, staged_uploads).await;
 
     // 6. Respond with text/event-stream.
     let meta = vec![
@@ -348,9 +366,15 @@ async fn run_agent_loop(
     mut history: Vec<serde_json::Value>,
     tools: Vec<ToolDefinition>,
     model_id: &str,
+    staged_uploads: Vec<(String, Attachment, String)>,
 ) -> String {
     let mut out = String::new();
     let mut attachments: HashMap<String, Attachment> = HashMap::new();
+    // Pre-seed with uploads so dispatch_tool can resolve {ref:"upload_N"}.
+    for (id, att, _display) in &staged_uploads {
+        attachments.insert(id.clone(), att.clone());
+    }
+    let _ = staged_uploads; // synthetic-history injection: see DDT2.
 
     for round in 1..=MAX_ROUNDS {
         // Convert OpenAI-format history to ChatMessage vec.
@@ -633,6 +657,58 @@ pub(crate) fn parse_skill_response(body: &str) -> ToolOutcome {
         for_llm: for_llm.to_string(),
         for_ui,
     }
+}
+
+/// Decode an [`UploadEntry`] vec into staged-upload tuples
+/// `(id, Attachment, display_name)`. Returns an error string suitable for the
+/// 4xx error_response on the first invalid entry. v1 caps each upload at
+/// 10 MiB; only `image/*` and `video/*` MIMEs are accepted; ids must start
+/// with `"upload_"`.
+pub(crate) fn decode_uploads(
+    entries: &[UploadEntry],
+) -> Result<Vec<(String, Attachment, String)>, String> {
+    const MAX_UPLOAD_BYTES: usize = 10 * 1024 * 1024;
+    let mut staged = Vec::with_capacity(entries.len());
+    for u in entries {
+        if !u.id.starts_with("upload_") {
+            return Err(format!(
+                "invalid upload id {:?}: must start with \"upload_\"",
+                u.id
+            ));
+        }
+        if !(u.mime.starts_with("image/") || u.mime.starts_with("video/")) {
+            return Err(format!(
+                "upload {:?}: only image/* and video/* are accepted, got {}",
+                u.id, u.mime
+            ));
+        }
+        let bytes = B64
+            .decode(&u.bytes_base64)
+            .map_err(|e| format!("upload {:?}: base64 decode failed: {e}", u.id))?;
+        if bytes.len() > MAX_UPLOAD_BYTES {
+            return Err(format!(
+                "upload {:?}: {} bytes exceeds 10 MiB cap",
+                u.id,
+                bytes.len()
+            ));
+        }
+        let display_name = u.filename.clone().unwrap_or_else(|| {
+            if u.mime.starts_with("image/") {
+                "image".into()
+            } else if u.mime.starts_with("video/") {
+                "video".into()
+            } else {
+                "file".into()
+            }
+        });
+        let att = Attachment {
+            mime: u.mime.clone(),
+            bytes,
+            filename: u.filename.clone(),
+        };
+        staged.push((u.id.clone(), att, display_name));
+    }
+    Ok(staged)
 }
 
 /// Decode the SP4 envelope's `_for_ui` value into an `Attachment`, if it is
@@ -1241,5 +1317,92 @@ mod tests {
             !h.contains("bytes, \""),
             "filename clause must be omitted when None: got {h:?}"
         );
+    }
+
+    // ---------------------------------------------------------------------------
+    // decode_uploads tests
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn decode_uploads_seeds_attachments_with_upload_ids() {
+        let raw = b"\x89PNG\r\n\x1a\n";
+        let b64 = B64.encode(raw);
+        let entries = vec![UploadEntry {
+            id: "upload_1".into(),
+            mime: "image/png".into(),
+            filename: Some("cat.png".into()),
+            bytes_base64: b64,
+        }];
+        let staged = decode_uploads(&entries).expect("decoded");
+        assert_eq!(staged.len(), 1);
+        assert_eq!(staged[0].0, "upload_1");
+        assert_eq!(staged[0].1.mime, "image/png");
+        assert_eq!(staged[0].1.bytes, raw);
+        assert_eq!(staged[0].1.filename.as_deref(), Some("cat.png"));
+        assert_eq!(staged[0].2, "cat.png");
+    }
+
+    #[test]
+    fn decode_uploads_rejects_non_upload_id() {
+        let entries = vec![UploadEntry {
+            id: "call_1".into(),
+            mime: "image/png".into(),
+            filename: None,
+            bytes_base64: B64.encode(b"x"),
+        }];
+        let r = decode_uploads(&entries);
+        assert!(r.is_err());
+        let msg = r.unwrap_err();
+        assert!(msg.contains("upload_"), "error must mention id format: {msg}");
+    }
+
+    #[test]
+    fn decode_uploads_rejects_unsupported_mime() {
+        let entries = vec![UploadEntry {
+            id: "upload_1".into(),
+            mime: "application/pdf".into(),
+            filename: None,
+            bytes_base64: B64.encode(b"x"),
+        }];
+        let r = decode_uploads(&entries);
+        assert!(r.is_err());
+        let msg = r.unwrap_err();
+        assert!(msg.contains("image/") || msg.contains("video/"));
+    }
+
+    #[test]
+    fn decode_uploads_rejects_oversize_decoded_bytes() {
+        let big = vec![0u8; 10 * 1024 * 1024 + 1]; // 10 MiB + 1
+        let entries = vec![UploadEntry {
+            id: "upload_1".into(),
+            mime: "image/png".into(),
+            filename: None,
+            bytes_base64: B64.encode(&big),
+        }];
+        let r = decode_uploads(&entries);
+        assert!(r.is_err());
+        let msg = r.unwrap_err();
+        assert!(msg.contains("10 MiB") || msg.contains("cap"));
+    }
+
+    #[test]
+    fn decode_uploads_uses_fallback_display_name_when_filename_missing() {
+        let entries = vec![UploadEntry {
+            id: "upload_1".into(),
+            mime: "image/png".into(),
+            filename: None,
+            bytes_base64: B64.encode(b"x"),
+        }];
+        let staged = decode_uploads(&entries).expect("decoded");
+        assert_eq!(staged[0].2, "image");
+
+        let entries = vec![UploadEntry {
+            id: "upload_2".into(),
+            mime: "video/mp4".into(),
+            filename: None,
+            bytes_base64: B64.encode(b"x"),
+        }];
+        let staged = decode_uploads(&entries).expect("decoded");
+        assert_eq!(staged[0].2, "video");
     }
 }

--- a/src/blocks/agent.rs
+++ b/src/blocks/agent.rs
@@ -103,7 +103,7 @@ struct LoadModelRequest {
 }
 
 #[derive(Debug, Deserialize)]
-struct UploadEntry {
+pub(crate) struct UploadEntry {
     id: String,
     mime: String,
     #[serde(default)]
@@ -1401,7 +1401,10 @@ mod tests {
         let r = decode_uploads(&entries);
         assert!(r.is_err());
         let msg = r.unwrap_err();
-        assert!(msg.contains("upload_"), "error must mention id format: {msg}");
+        assert!(
+            msg.contains("upload_"),
+            "error must mention id format: {msg}"
+        );
     }
 
     #[test]

--- a/src/blocks/ui.rs
+++ b/src/blocks/ui.rs
@@ -118,8 +118,11 @@ fn render_chat() -> maud::Markup {
                         div class="empty" { "Load a model in settings to start." }
                     }
                     form slot="composer" id="composer" autocomplete="off" {
+                        div id="upload-chips" class="upload-chips empty" {}
                         textarea id="user-input" name="user_message" placeholder="Ask anything…" rows="2" {}
+                        button id="attach" type="button" aria-label="Attach file" title="Attach image or video" {}
                         button id="send" type="submit" disabled { "Send" }
+                        input id="file-picker" type="file" accept="image/*,video/*" multiple style="display:none;";
                     }
                 }
                 dialog id="settings" {

--- a/tests/dispatch_skills.rs
+++ b/tests/dispatch_skills.rs
@@ -965,6 +965,7 @@ struct ChainCallerBlock {
     target_block: String,
     args: serde_json::Value,
     attached_bytes: Vec<u8>,
+    attachment_id: String,
 }
 
 #[async_trait::async_trait]
@@ -981,7 +982,7 @@ impl Block for ChainCallerBlock {
     async fn handle(&self, ctx: &dyn Context, _msg: Message, _input: InputStream) -> OutputStream {
         let mut atts = BTreeMap::new();
         atts.insert(
-            "call_1".to_string(),
+            self.attachment_id.clone(),
             Attachment {
                 mime: "image/png".into(),
                 bytes: self.attached_bytes.clone(),
@@ -1081,6 +1082,7 @@ async fn dispatch_chains_resize_then_crop_via_ref() {
                     "width": 50,
                     "height": 50,
                 }),
+                attachment_id: "call_1".into(),
                 attached_bytes: chained_bytes,
             }),
         )
@@ -1417,6 +1419,85 @@ async fn dispatch_chains_video_frame_extract_then_image_resize_via_ref() {
                     "width": 50,
                 }),
                 attached_bytes: chained_bytes,
+                attachment_id: "call_1".into(),
+            }),
+        )
+        .expect("register chain caller");
+    let wafer = wafer.start().await.expect("start runtime");
+
+    let output = wafer
+        .run_block(
+            "test/chain-caller",
+            Message::new("invoke"),
+            InputStream::empty(),
+        )
+        .await;
+    let resp = output
+        .collect_buffered()
+        .await
+        .expect("chain-caller returns success");
+
+    let envelope: serde_json::Value =
+        serde_json::from_slice(&resp.body).expect("resize returns SP4 envelope");
+    let resized_data_url = envelope["_for_ui"]["data_url"]
+        .as_str()
+        .expect("resize emits data_url");
+    assert!(resized_data_url.starts_with("data:image/"));
+    assert!(resized_data_url.len() > 100);
+}
+
+#[tokio::test]
+async fn dispatch_uploaded_image_then_resize_via_ref() {
+    // Simulate what the agent block does post-decode_uploads: it pre-seeds
+    // the per-loop attachment map with bytes keyed by `upload_N`. The LLM
+    // then emits {ref:"upload_1"} which routes through dispatch_tool —
+    // exactly the path ChainCallerBlock exercises by parameterising
+    // `attachment_id`.
+    let png_bytes: Vec<u8> = b"\x89PNG\r\n\x1a\n"
+        .iter()
+        .chain([0u8; 200].iter())
+        .copied()
+        .collect();
+
+    let mut wafer = Wafer::builder()
+        .disable_inventory()
+        .disable_lockfile()
+        .build()
+        .expect("Wafer::build");
+    wafer
+        .register_block("wafer-run/network", Arc::new(FakeNetworkBlock))
+        .expect("register fake network");
+    let resize_svc: Arc<dyn gizza_ai::ffmpeg::FfmpegService> = Arc::new(FakeFfmpegService::ok(
+        b"\x89PNG\r\n\x1a\n"
+            .iter()
+            .chain([0u8; 88].iter())
+            .copied()
+            .collect(),
+        "fake resize log",
+    ));
+    wafer
+        .register_block(
+            "gizza-ai/ffmpeg-runtime",
+            Arc::new(gizza_ai::blocks::ffmpeg::FfmpegBlock::new(resize_svc)),
+        )
+        .expect("register ffmpeg-runtime");
+    wafer
+        .register_block(
+            "gizza-ai/image-resize",
+            Arc::new(WasmiBlock::load_from_bytes(RESIZE_WASM).expect("load image-resize")),
+        )
+        .expect("register image-resize");
+    wafer
+        .register_block(
+            "test/chain-caller",
+            Arc::new(ChainCallerBlock {
+                target_block: "gizza-ai/image-resize".into(),
+                args: json!({
+                    "ref": "upload_1",
+                    "width": 100,
+                }),
+                attached_bytes: png_bytes,
+                attachment_id: "upload_1".into(),
             }),
         )
         .expect("register chain caller");


### PR DESCRIPTION
## Summary

Closes the SP3 loop: user drops a local image or video onto the chat, sees it as a removable chip in the composer, types a question, and on send the LLM sees the file as a prior `tool_result` it can reference via `{ref: "upload_1"}` — exactly the same mechanism chained skill outputs already use (PR #31).

- Frontend: drag-drop overlay + paperclip button + `<input type="file">` fallback. Pending list lives in `site/pending.js` (focused module, six unit tests). On submit, files are base64-encoded into a new `uploads` array on the existing `/b/agent/chat` JSON body.
- Backend: `decode_uploads()` validates id format / mime / 10 MiB cap and decodes base64; `build_upload_history_prefix()` emits one `assistant{tool_calls:[...]}` + one `tool` message per upload, mirroring the Phase A `format_ref_hint` phrasing so Qwen2.5-1.5B treats `upload_1` like `call_42`. Both injected into history before the user message in `run_agent_loop`.
- Per-`run_agent_loop` lifetime — chips clear on successful send. Cross-turn re-use is future work (file-size considerations).
- Drive-by: `ChainCallerBlock` (test helper from PR #32) gained an `attachment_id` field so the new dispatch test can attach under `upload_1` rather than the previously hard-coded `call_1` — proving the runtime treats both id prefixes identically.

Spec: `workspace/docs/superpowers/specs/2026-05-06-gizza-ai-drag-drop-ui-design.md`
Plan: `workspace/docs/superpowers/plans/2026-05-06-gizza-ai-drag-drop-ui.md`

## Test plan
- [x] `cargo test` — 30 lib + 39 dispatch + 10 skills_embed all green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo +nightly fmt --all -- --check` clean
- [x] `npm test` — 12 (6 render + 6 pending) all green
- [x] `dispatch_uploaded_image_then_resize_via_ref` — proves `upload_N` attachments dispatch through `image-resize` exactly like chained `call_N` refs
- [ ] Manual headed smoke (deferred — needs WebGPU + a real image): drop a PNG, type "resize to 200 wide", confirm Qwen calls `image-resize({ref:"upload_1", width: 200})` and the cropped thumbnail renders inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)