### PR TITLE
fix: /b/agent/* routing + persistent test cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ Cargo.lock
 # to point wafer-* crate names at sibling working copies.
 /.cargo/config.toml
 .data/
+
+# Playwright persistent-context cache (WebLLM model shards in OPFS/IndexedDB).
+tests/.cache/
+tests/test-results/

--- a/solobase.toml
+++ b/solobase.toml
@@ -7,7 +7,7 @@ boot_redirect = "/"
 manifest_path = "../solobase"
 
 [assets]
-extra_bypass_prefix = ["/gizza-app.js", "/gizza.css", "/render.js"]
+extra_bypass_prefix = ["/gizza-app.js", "/gizza.css", "/render.js", "/pending.js", "/gis.png"]
 
 [[assets.overlay]]
 from = "site/index.html"
@@ -24,6 +24,14 @@ to = "gizza.css"
 [[assets.overlay]]
 from = "site/render.js"
 to = "render.js"
+
+[[assets.overlay]]
+from = "site/pending.js"
+to = "pending.js"
+
+[[assets.overlay]]
+from = "site/gis.png"
+to = "gis.png"
 
 [[assets.overlay]]
 from = "static/CNAME"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,12 @@ pub async fn initialize() -> Result<(), JsValue> {
                 "SUPPERS_AI__LLM__DEFAULT_MODEL": "Qwen2.5-1.5B-Instruct-q4f32_1-MLC",
             }),
         )
-        .add_route("/", "gizza-ai/ui", RouteAccess::Public)
+        // Note: `/` is routed at the OUTER wafer-run/router level (see step
+        // 6a below), so it never reaches suppers-ai/router. Adding `/` to
+        // suppers-ai/router's extra routes here would be dead code AND
+        // actively harmful — its match uses `starts_with`, so a `/` prefix
+        // would catch every `/b/**` request that has no built-in solobase
+        // route (e.g. `/b/agent/load-model`) before more specific extras.
         .add_route("/b/ui", "gizza-ai/ui", RouteAccess::Public)
         .add_route("/b/ui/", "gizza-ai/ui", RouteAccess::Public)
         .add_route("/b/agent/", "gizza-ai/agent", RouteAccess::Public)

--- a/tests/e2e_smoke.spec.ts
+++ b/tests/e2e_smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 test.describe('gizza-ai smoke', () => {
   test('page loads, model loads, clock prompt produces some response', async ({ page }) => {
@@ -19,7 +19,7 @@ test.describe('gizza-ai smoke', () => {
     // Click "Load model". WebLLM will download the model weights on first run
     // (~1.2 GB for Qwen2.5-1.5B-Instruct-q4f32_1-MLC) so we allow 3 minutes.
     await page.locator('#load-model').click();
-    await expect(page.locator('#load-model')).toHaveText('Ready', { timeout: 180_000 });
+    await expect(page.locator('#load-model')).toHaveText('Ready', { timeout: 600_000 });
 
     // Close the settings dialog via the form[method=dialog] close button.
     await page.locator('#settings button[value="close"]').click();
@@ -49,7 +49,7 @@ test.describe('gizza-ai smoke', () => {
     await page.locator('#open-settings').click();
     await expect(page.locator('#settings')).toBeVisible();
     await page.locator('#load-model').click();
-    await expect(page.locator('#load-model')).toHaveText('Ready', { timeout: 180_000 });
+    await expect(page.locator('#load-model')).toHaveText('Ready', { timeout: 600_000 });
     await page.locator('#settings button[value="close"]').click();
     await expect(page.locator('#settings')).not.toBeVisible();
 

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,0 +1,39 @@
+// Persistent-context test fixture.
+//
+// WebLLM downloads ~600 MB–1.2 GB of model shards on first run and caches
+// them in OPFS / IndexedDB / Cache Storage. Playwright's default per-test
+// context wipes that cache between tests AND between runs. Switching to a
+// persistent context backed by a fixed user-data directory makes the cache
+// survive both — first run pays the download cost, subsequent runs (and the
+// second test in the same run) skip straight to "Ready".
+//
+// Fixture is worker-scoped so all tests in a single worker share one
+// persistent browser. Repo-relative `.cache/chromium-profile/` is gitignored.
+
+import { test as base, chromium, type BrowserContext } from '@playwright/test';
+import path from 'node:path';
+
+const USER_DATA_DIR = path.resolve(__dirname, '.cache/chromium-profile');
+
+export const test = base.extend<object, { persistentContext: BrowserContext }>({
+  persistentContext: [
+    async ({}, use) => {
+      const ctx = await chromium.launchPersistentContext(USER_DATA_DIR, {
+        // WebGPU isn't available in headless Chromium on Linux.
+        headless: false,
+      });
+      await use(ctx);
+      await ctx.close();
+    },
+    { scope: 'worker' },
+  ],
+  context: async ({ persistentContext }, use) => {
+    await use(persistentContext);
+  },
+  page: async ({ persistentContext }, use) => {
+    const page = persistentContext.pages()[0] ?? (await persistentContext.newPage());
+    await use(page);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: '.',
-  timeout: 600_000, // 10 min — WebLLM model download is ~1.2 GB on cold runs.
+  timeout: 1_200_000, // 20 min — WebLLM model download is ~1.2 GB on cold runs.
   expect: { timeout: 120_000 },
   fullyParallel: false,
   workers: 1,


### PR DESCRIPTION
## Summary

- **Real bug fix:** `SolobaseBuilder::add_route("/", "gizza-ai/ui", …)` was
  registering `/` as an extra route on `suppers-ai/router`, whose match uses
  `path.starts_with(prefix)`. Every `/b/**` request that had no built-in
  solobase route (`/b/agent/load-model`, `/b/agent/chat`, `/b/foo/bar`, …)
  matched the `/` prefix first and got dispatched to `gizza-ai/ui` — which
  404s anything other than `/`, `/b/ui`, and `/b/ui/`. The UI flipped Load
  model → "Try again" within seconds, end-to-end agent flow was completely
  broken. The `/` extra route was also dead code: `/` is dispatched at the
  outer `wafer-run/router` level via `add_block_config`, so it never reaches
  `suppers-ai/router`.
- **Asset overlay:** `site/pending.js` and `site/gis.png` are referenced by
  the UI block (`<img src="/gis.png">`) and `gizza-app.js` (static
  `import './pending.js'`) but weren't in `solobase.toml`'s overlay list.
  The JS import failure prevented the cog/settings handler from attaching.
- **Test cache:** WebLLM stores model shards in OPFS/IndexedDB. Playwright's
  default per-test context wiped that cache between every test and every
  run, paying the full ~600 MB cold-download cost each time. Switching to
  `chromium.launchPersistentContext` with a repo-relative profile dir
  (`tests/.cache/chromium-profile/`, gitignored), worker-scoped, lets both
  tests in a single run share a browser AND lets the cache survive across
  runs. Per-model timeout bumped 3 min → 10 min and per-test 10 min → 20
  min so a cold first run has room to finish.

## Test plan

- [x] `solobase build` — produces fresh `pkg/`
- [x] `python3 -m http.server --directory pkg 8001` and load `http://localhost:8001`
- [x] Inline probe: `fetch('/b/agent/load-model', POST)` reaches the agent
      block (verified via Playwright MCP, no longer 404 from `gizza-ai/ui`)
- [x] `fetch('/b/foo/bar')` correctly hits `suppers-ai/router`'s
      `not_found_response` (`{"error":"NotFound","message":"endpoint not found"}`)
      instead of being captured by gizza-ai/ui
- [x] Persistent profile dir is created and survives between runs
- [ ] Full smoke pass requires WebLLM model fetch to complete — cold-cache
      runs failed with `net::ERR_FAILED` after ~5 min on the test bench;
      this looks like a SW wasm-trap-self-destruct triggered by the
      WebLLM/WebGPU path (independent of this PR's changes). Subsequent
      warm runs should benefit from any partial cache and complete faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)