### PR TITLE
feat(agent): keep-alive heartbeat on /b/agent/load-model SSE

### DIFF
--- a/src/blocks/agent.rs
+++ b/src/blocks/agent.rs
@@ -70,6 +70,20 @@ const MAX_ROUNDS: u32 = 5;
 /// ~0–1s and never approaches the budget.
 const STREAM_FRAME_TIMEOUT: Duration = Duration::from_secs(300);
 
+/// Keep-alive heartbeat interval for the load-model SSE response.
+///
+/// WebLLM's `initProgressCallback` is intermittent — it fires during shard
+/// fetch ticks but goes quiet between shards (HF range-fetch latency,
+/// model-compile pauses). Chrome's Service Worker fetch handler drops idle
+/// connections after ~30–60s of zero bytes, so we emit an SSE comment
+/// frame (`: keep-alive\n\n`) every 15s while we're waiting on the LLM
+/// stream. Comment frames are valid SSE and ignored by the consumer parser
+/// in `gizza-app.js`, but they keep the wire warm.
+///
+/// The overall no-progress timeout (`STREAM_FRAME_TIMEOUT`) is preserved by
+/// counting consecutive idle ticks so the SW still bails on a real stall.
+const LOAD_MODEL_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(15);
+
 /// The agent block's own chat endpoint.
 const AGENT_CHAT_PATH: &str = "/b/agent/chat";
 
@@ -321,17 +335,39 @@ async fn handle_load_model(ctx: &dyn Context, input: InputStream) -> OutputStrea
         // 2. Pump frames from wafer-run/llm. Each `Ok(LoadProgress)` becomes
         //    one `event: load_progress` SSE frame written to the sink — and
         //    therefore one chunk delivered to the browser as it's produced.
+        //
+        //    Wrap each `stream.next()` in `LOAD_MODEL_KEEPALIVE_INTERVAL`
+        //    instead of the longer `STREAM_FRAME_TIMEOUT`: when WebLLM is
+        //    quiet between shards we send an SSE comment frame to keep
+        //    Chrome's SW fetch keep-alive happy, then go back to waiting.
+        //    Real stalls are caught by counting consecutive keep-alive
+        //    ticks against `STREAM_FRAME_TIMEOUT`.
         let stream = output.body_stream();
         pin_mut!(stream);
         let mut had_error: Option<String> = None;
+        let mut idle_elapsed = Duration::ZERO;
         loop {
-            match timeout(STREAM_FRAME_TIMEOUT, stream.next()).await {
+            match timeout(LOAD_MODEL_KEEPALIVE_INTERVAL, stream.next()).await {
                 Err(_elapsed) => {
-                    had_error = Some("llm load timed out".to_string());
-                    break;
+                    // No frame in the keep-alive window — emit a comment
+                    // chunk and resume waiting unless we've now been idle
+                    // for the full STREAM_FRAME_TIMEOUT.
+                    idle_elapsed += LOAD_MODEL_KEEPALIVE_INTERVAL;
+                    if idle_elapsed >= STREAM_FRAME_TIMEOUT {
+                        had_error = Some("llm load timed out".to_string());
+                        break;
+                    }
+                    if sink
+                        .send_chunk(b": keep-alive\n\n".to_vec())
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
                 }
                 Ok(None) => break,
                 Ok(Some(bytes)) => {
+                    idle_elapsed = Duration::ZERO;
                     match serde_json::from_slice::<Result<LoadProgress, LlmError>>(&bytes) {
                         Ok(Ok(progress)) => {
                             let data = serde_json::to_value(&progress)


### PR DESCRIPTION
## Summary

Follow-up to #35. WebLLM's \`initProgressCallback\` is intermittent — ticks fire during shard fetches but go quiet between shards (HF range-fetch latency, model-compile pauses). Chrome's Service Worker fetch keep-alive drops idle connections after ~30–60s of zero bytes, so even with the streaming pipeline (suppers-ai/solobase#93 + #35) our SSE response could still die mid-load. Smoke test post-#35 still hits the 5-min \`Try again\` pattern.

This wraps each \`stream.next()\` in \`LOAD_MODEL_KEEPALIVE_INTERVAL\` (15s) instead of the longer \`STREAM_FRAME_TIMEOUT\`: when the wait expires we emit \`: keep-alive\n\n\` (a valid SSE comment line, dropped silently by \`gizza-app.js\`'s parser) and resume waiting. The original no-progress timeout is preserved by counting consecutive idle ticks against \`STREAM_FRAME_TIMEOUT\` so a real GPU stall still bails.

## Why a comment frame, not an event?

\`gizza-app.js\` only acts on \`event: load_progress\` and \`event: load_done\` — any other line shape is parsed and discarded. A leading \`:\` comment is the SSE-spec way to declare a no-op heartbeat (\`https://html.spec.whatwg.org/multipage/server-sent-events.html#dispatchMessage\`); browsers (and the parser here) will read the bytes off the wire and drop them, which is exactly what we want.

## Effect

The wire never goes idle longer than 15s regardless of WebLLM's tick cadence. Chat is unaffected — it's still buffered for v1, but its frame cadence is fast enough that keep-alive isn't needed.

## Test plan

- [x] \`solobase build\` clean
- [x] gizza-app.js parser doesn't choke on comment lines (verified: \`if (line.startsWith('event:')) ... else if (line.startsWith('data:')) ...\` — comment lines fail both branches)
- [ ] Smoke test passes (running concurrently with PR submission; I'll comment with the result)

🤖 Generated with [Claude Code](https://claude.com/claude-code)