### PR TITLE
fix(picker): strip embedding-model batch-size suffix from base_id

### DIFF
--- a/site/model-picker.js
+++ b/site/model-picker.js
@@ -54,8 +54,10 @@ function paramsLabel(baseId) {
 }
 
 function stripVariantSuffix(modelId) {
-    // <base>-<quant>-MLC[-<ctx>] → <base>
-    return modelId.replace(/-q\d+f\d+(_\d+)?-MLC(-\d+k(_cs\d+k)?)?$/, '');
+    // <base>-<quant>-MLC[-<ctx>][-<batch>] → <base>
+    // -<ctx>   is `-Nk` (optionally `_csNk`) on chat models
+    // -<batch> is `-bN` on embedding models (e.g. snowflake-arctic-embed)
+    return modelId.replace(/-q\d+f\d+(_\d+)?-MLC(-\d+k(_cs\d+k)?)?(-b\d+)?$/, '');
 }
 
 function extractQuant(modelId) {

--- a/tests/unit/model-picker.test.mjs
+++ b/tests/unit/model-picker.test.mjs
@@ -37,6 +37,21 @@ test('groupModels: no group contains a quantization suffix in its base_id', () =
     for (const g of groups) {
         assert.doesNotMatch(g.base_id, /-q\d+f\d+(_\d+)?-MLC$/, `base_id leaked variant suffix: ${g.base_id}`);
         assert.doesNotMatch(g.base_id, /-MLC(-\d+k)?$/, `base_id leaked -MLC suffix: ${g.base_id}`);
+        assert.doesNotMatch(g.base_id, /-b\d+$/, `base_id leaked batch-size suffix: ${g.base_id}`);
+    }
+});
+
+test('groupModels: collapses snowflake-arctic-embed batch variants into one base entry', () => {
+    const groups = groupModels(fixture);
+    // Fixture contains snowflake-arctic-embed-{m,s}-q0f32-MLC-b{4,32}; each base
+    // model should appear exactly once with all batch variants collapsed.
+    const m = groups.find((g) => g.base_id === 'snowflake-arctic-embed-m');
+    const s = groups.find((g) => g.base_id === 'snowflake-arctic-embed-s');
+    assert.ok(m, 'expected a snowflake-arctic-embed-m group');
+    assert.ok(s, 'expected a snowflake-arctic-embed-s group');
+    // Each base must keep its full WebLLM model_id for engine handoff.
+    for (const v of m.variants) {
+        assert.ok(v.id.startsWith('snowflake-arctic-embed-m-'), `unexpected variant id ${v.id}`);
     }
 });
 


### PR DESCRIPTION
## Summary

`stripVariantSuffix` in `site/model-picker.js` didn't handle the `-bN` trailing piece MLC appends to embedding models (e.g. `snowflake-arctic-embed-m-q0f32-MLC-b32`). Result: the picker rendered the raw model_id with the batch suffix visible in the displayed name, and each base model duplicated once per batch variant instead of collapsing into a single group.

This was captured as a follow-up in the May 9 model-picker handoff.

## Changes

- `site/model-picker.js` — extend the regex to also strip an optional trailing `-bN`.
- `tests/unit/model-picker.test.mjs` — add a guard assertion that no group's `base_id` ends in `-bN`, and a positive test that `snowflake-arctic-embed-{m,s}` collapse to single groups.

## Test plan

- [x] `node --test tests/unit/model-picker.test.mjs` — 17 / 17 pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)