### PR TITLE
fix(ui): prefetch WebLLM + friendly no-model-loaded error

### DIFF
--- a/site/gizza-app.js
+++ b/site/gizza-app.js
@@ -610,8 +610,13 @@ async function startModelLoad(modelId) {
 
 // --- Picker overlay integration ---
 
+// Start fetching the WebLLM module at page load so the first picker open
+// doesn't pay ~5MB of CDN download cost. By the time the user clicks the
+// brain icon, the promise has typically resolved and the await is a no-op.
+const _webllmModulePromise = import('https://cdn.jsdelivr.net/npm/@mlc-ai/web-llm@0.2.74/+esm');
+
 async function launchPicker() {
-    const mod = await import('https://cdn.jsdelivr.net/npm/@mlc-ai/web-llm@0.2.74/+esm');
+    const mod = await _webllmModulePromise;
     const prebuiltList = mod?.prebuiltAppConfig?.model_list || [];
     const result = await openPicker({
         prebuiltList,
@@ -775,8 +780,14 @@ $('composer').addEventListener('submit', async (e) => {
             const reason = payload?.reason;
             const errText = payload?.error;
             if (reason === 'error') {
-                assistantText = `_(agent error: ${errText || 'unknown'})_`;
-                renderAssistantContent(assistantEl, assistantText);
+                if (errText && /no engine loaded/i.test(errText)) {
+                    assistantText = '_No model loaded — pick one first._';
+                    renderAssistantContent(assistantEl, assistantText);
+                    launchPicker();
+                } else {
+                    assistantText = `_(agent error: ${errText || 'unknown'})_`;
+                    renderAssistantContent(assistantEl, assistantText);
+                }
             } else if (reason === 'max_rounds_exceeded') {
                 if (!assistantText) {
                     assistantText = '_(stopped: max tool-use rounds exceeded)_';


### PR DESCRIPTION
## Summary

Two small UX fixes on the picker / chat path, both single-file.

1. **Prefetch WebLLM at page load.** The `await import('@mlc-ai/web-llm')` inside `launchPicker` was the dominant first-click cost (~5 MB CDN module). Hoisted to a module-scoped promise that starts at script load — by the time the user clicks the brain icon, the import has typically resolved and the await is a no-op. Picker open is near-instant in the common case.

2. **Friendly no-model-loaded error.** When the chat agent fails with "webllm: no engine loaded", the SSE done/error handler used to render the raw `(agent error: Internal: llm.chat: backend error: webllm: no engine loaded)` text. Detect that specific substring (case-insensitive), replace the bubble with _"No model loaded — pick one first."_, and auto-open the picker so the user can act in one click instead of two. All other agent errors surface unchanged.

## Test plan

- [x] Local dev: hard-reload page, click brain icon → picker opens with ~no delay (vs. visible wait before).
- [x] Local dev: with no model loaded, send a chat message → friendly bubble, picker auto-opens.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)