### PR TITLE
feat(picker, chat): tier-card picker, single Load, AI-formatted slash output

### DIFF
--- a/site/gizza-app.js
+++ b/site/gizza-app.js
@@ -145,28 +145,70 @@ function startThinking(node, opening = null) {
     };
 }
 
-// Modal popup for the raw JSON behind a formatted slash result. Reuses
-// <dialog> for native ESC/focus-trap behaviour.
-function showRawPopup(raw, title = 'Raw result') {
-    let pretty = raw;
-    try { pretty = JSON.stringify(JSON.parse(raw), null, 2); } catch (_e) { /* not JSON — show as-is */ }
+// Modal popup with two tabs (Input | Output) for the raw JSON behind a
+// formatted slash result. Lets users see what the LLM extracted from their
+// message vs what the skill returned — useful for debugging cases like a
+// /calculator typo where the LLM read 't2' as a variable.
+function showRawPopup({ input, output, title = 'Raw' } = {}) {
+    const pretty = (v) => {
+        if (v == null) return '(none)';
+        if (typeof v === 'string') {
+            try { return JSON.stringify(JSON.parse(v), null, 2); } catch { return v; }
+        }
+        try { return JSON.stringify(v, null, 2); } catch { return String(v); }
+    };
+    const inputText = pretty(input);
+    const outputText = pretty(output);
+
     const dlg = el('dialog', { class: 'raw-popup' });
+
+    // Header with tabs.
+    let activeTab = output != null ? 'output' : 'input';
+    const inputBtn = el('button', {
+        class: 'raw-popup-tab',
+        type: 'button',
+        onClick: () => switchTab('input'),
+    }, 'Input');
+    const outputBtn = el('button', {
+        class: 'raw-popup-tab',
+        type: 'button',
+        onClick: () => switchTab('output'),
+    }, 'Output');
+    const closeBtn = el('button', {
+        class: 'raw-popup-close',
+        'aria-label': 'Close',
+        onClick: () => dlg.close(),
+    }, '✕');
+    const tabs = el('div', { class: 'raw-popup-tabs' }, [inputBtn, outputBtn]);
     const header = el('div', { class: 'raw-popup-header' }, [
         el('h3', {}, title),
-        el('button', { class: 'raw-popup-close', 'aria-label': 'Close', onClick: () => dlg.close() }, '✕'),
+        tabs,
+        closeBtn,
     ]);
-    const body = el('pre', { class: 'raw-popup-body' }, el('code', {}, pretty));
-    const footer = el('div', { class: 'raw-popup-footer' }, [
-        el('button', {
-            class: 'raw-popup-copy',
-            onClick: async () => {
-                try { await navigator.clipboard.writeText(pretty); } catch (_e) {}
-                const ok = el('span', { class: 'raw-popup-copied' }, 'Copied');
-                footer.appendChild(ok);
-                setTimeout(() => ok.remove(), 1200);
-            },
-        }, 'Copy'),
-    ]);
+
+    const codeNode = el('code', {}, activeTab === 'output' ? outputText : inputText);
+    const body = el('pre', { class: 'raw-popup-body' }, codeNode);
+
+    const copyBtn = el('button', {
+        class: 'raw-popup-copy',
+        onClick: async () => {
+            const txt = activeTab === 'output' ? outputText : inputText;
+            try { await navigator.clipboard.writeText(txt); } catch (_e) {}
+            const ok = el('span', { class: 'raw-popup-copied' }, 'Copied');
+            footer.appendChild(ok);
+            setTimeout(() => ok.remove(), 1200);
+        },
+    }, 'Copy');
+    const footer = el('div', { class: 'raw-popup-footer' }, [copyBtn]);
+
+    function switchTab(name) {
+        activeTab = name;
+        codeNode.textContent = name === 'output' ? outputText : inputText;
+        inputBtn.classList.toggle('is-active', name === 'input');
+        outputBtn.classList.toggle('is-active', name === 'output');
+    }
+    switchTab(activeTab);
+
     dlg.appendChild(header);
     dlg.appendChild(body);
     dlg.appendChild(footer);
@@ -176,14 +218,16 @@ function showRawPopup(raw, title = 'Raw result') {
 }
 
 // Append a small {} icon button to a bubble that opens the raw popup on click.
-function appendRawButton(bubble, raw) {
-    if (!raw) return;
+// `input` is what the LLM dispatched to the skill (extracted params); `output`
+// is what the skill returned. Both are stringified for the popup.
+function appendRawButton(bubble, { input, output } = {}) {
+    if (input == null && output == null) return;
     const btn = el('button', {
         class: 'raw-toggle',
         type: 'button',
-        title: 'Show raw output',
-        'aria-label': 'Show raw output',
-        onClick: () => showRawPopup(raw),
+        title: 'Show raw input + output',
+        'aria-label': 'Show raw input + output',
+        onClick: () => showRawPopup({ input, output }),
     }, '{ }');
     bubble.appendChild(document.createTextNode(' '));
     bubble.appendChild(btn);
@@ -314,6 +358,78 @@ async function formatSlashResultWithLLM({ cmd, args, raw, bubbleText }) {
         if (!acc) {
             // LLM produced nothing — fall back to raw so user sees something.
             bubbleText.textContent = raw;
+        }
+    }
+}
+
+/**
+ * When a slash skill returns an error, run a small LLM follow-up that takes
+ * the user's original message + the skill error and emits a friendly
+ * "did you mean…?" suggestion in plain language. Falls back to the raw error
+ * envelope when no model is loaded or the LLM call fails.
+ */
+async function suggestCorrectionWithLLM({ cmd, args, error, userMessage, bubbleText }) {
+    const modelId = selectedModelId();
+    if (!modelId) {
+        bubbleText.textContent = `Error: ${error}`;
+        return;
+    }
+    const prompt =
+        `The user typed: ${JSON.stringify(userMessage)}\n\n` +
+        `That dispatched the \`/${cmd}\` skill, which failed with this error:\n\n` +
+        `> ${error}\n\n` +
+        `Write a one-sentence response in plain language explaining what likely went wrong, ` +
+        `and (if possible) suggest a corrected version of the user's message. ` +
+        `Do not echo the error verbatim and do not mention "the skill" or "the LLM" — ` +
+        `just talk to the user like a helpful assistant.`;
+    const thinker = startThinking(bubbleText, 'figuring');
+    let acc = '';
+    try {
+        const resp = await fetch('/b/agent/chat', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                user_message: prompt,
+                messages: [],
+                model_id: modelId,
+            }),
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            let idx;
+            while ((idx = buffer.indexOf('\n\n')) !== -1) {
+                const frame = buffer.slice(0, idx);
+                buffer = buffer.slice(idx + 2);
+                const lines = frame.split('\n');
+                let event = '';
+                let data = '';
+                for (const line of lines) {
+                    if (line.startsWith('event:')) event = line.slice(6).trim();
+                    else if (line.startsWith('data:')) data += line.slice(5).replace(/^ /, '');
+                }
+                if (event === 'token') {
+                    let p; try { p = JSON.parse(data); } catch { p = null; }
+                    if (p?.delta) {
+                        if (acc === '') thinker.stop();
+                        acc += p.delta;
+                        renderAssistantContent(bubbleText, acc);
+                        scrollToBottom();
+                    }
+                }
+            }
+        }
+    } catch (_e) {
+        // fall through — show raw error
+    } finally {
+        thinker.stop();
+        if (!acc) {
+            bubbleText.textContent = `Error: ${error}`;
         }
     }
 }
@@ -1176,20 +1292,44 @@ $('composer').addEventListener('submit', async (e) => {
         }
         if (buffer.trim()) processFrame(buffer);
 
-        // Slash-command path: try a cheap deterministic template first; only
-        // fall back to the LLM-summarize pass for complex shapes. Either way,
-        // attach a `{ }` button so the user can see the raw JSON.
+        // Slash-command path. For each parked slash tool_result:
+        //
+        //  1. If the skill returned `{error: …}`, run an LLM correction
+        //     follow-up — feed the original user message + the error back to
+        //     the model and ask for a friendly "did you mean…?" suggestion.
+        //     Beats dumping a raw stack trace at the user.
+        //  2. Otherwise try the cheap deterministic template
+        //     (calculator/clock/web-fetch/…). When it matches we render
+        //     instantly and skip the LLM pass.
+        //  3. Otherwise fall through to the LLM-format pass.
+        //
+        // Either way the `{ }` button gets appended with both `input` (what
+        // the LLM dispatched to the skill) and `raw` (what the skill
+        // returned), so users can flip between the two in the popup.
         for (const f of slashFollowups) {
-            const templated = templateSimpleResult(f.cmd, f.raw);
-            if (templated !== null) {
-                assistantEl.replaceChildren();
-                renderAssistantContent(assistantEl, templated);
-            } else {
-                await formatSlashResultWithLLM({
-                    cmd: f.cmd, args: f.args, raw: f.raw, bubbleText: assistantEl,
+            let parsed = null;
+            try { parsed = JSON.parse(f.raw); } catch { /* not JSON */ }
+            const skillError = parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+                && typeof parsed.error === 'string'
+                ? parsed.error : null;
+
+            if (skillError) {
+                await suggestCorrectionWithLLM({
+                    cmd: f.cmd, args: f.args, error: skillError, userMessage: text,
+                    bubbleText: assistantEl,
                 });
+            } else {
+                const templated = templateSimpleResult(f.cmd, f.raw);
+                if (templated !== null) {
+                    assistantEl.replaceChildren();
+                    renderAssistantContent(assistantEl, templated);
+                } else {
+                    await formatSlashResultWithLLM({
+                        cmd: f.cmd, args: f.args, raw: f.raw, bubbleText: assistantEl,
+                    });
+                }
             }
-            appendRawButton(assistantEl.parentElement, f.raw);
+            appendRawButton(assistantEl.parentElement, { input: f.input, output: f.raw });
         }
 
         if (assistantText) {
@@ -1254,9 +1394,14 @@ $('composer').addEventListener('submit', async (e) => {
                     // Defer the LLM formatting until the SSE stream is done
                     // so we don't race the original stream with a fresh
                     // /b/agent/chat. Park the work and run it after the loop.
+                    // `input` is the params the agent dispatched to the skill
+                    // (added in agent.rs alongside `result`) — surfaced in the
+                    // `{ }` popup's Input tab so users can see what the LLM
+                    // understood from their message.
                     slashFollowups.push({
                         cmd: slashCmd?.[1] || '?',
                         args: slashCmd?.[2] || '',
+                        input: payload?.input ?? null,
                         raw: summary,
                     });
                 }

--- a/site/gizza-app.js
+++ b/site/gizza-app.js
@@ -63,10 +63,25 @@ document.title = 'gizza.ai';
     }
 }
 
-function el(tag, attrs = {}, text = '') {
+function el(tag, attrs = {}, children = '') {
     const e = document.createElement(tag);
-    for (const [k, v] of Object.entries(attrs)) e.setAttribute(k, v);
-    if (text) e.textContent = text;
+    for (const [k, v] of Object.entries(attrs)) {
+        if (k === 'onClick' && typeof v === 'function') e.addEventListener('click', v);
+        else if (k === 'onInput' && typeof v === 'function') e.addEventListener('input', v);
+        else if (k === 'onChange' && typeof v === 'function') e.addEventListener('change', v);
+        else if (v === true) e.setAttribute(k, '');
+        else if (v !== false && v != null) e.setAttribute(k, v);
+    }
+    if (Array.isArray(children)) {
+        for (const c of children) {
+            if (c == null) continue;
+            e.appendChild(typeof c === 'string' ? document.createTextNode(c) : c);
+        }
+    } else if (children instanceof Node) {
+        e.appendChild(children);
+    } else if (children) {
+        e.textContent = children;
+    }
     return e;
 }
 
@@ -92,6 +107,215 @@ function addAssistantBubble() {
     msgs.appendChild(bubble);
     scrollToBottom();
     return text;
+}
+
+// Playful cycling status while we wait for the model. Returns a handle whose
+// `.stop()` clears the timer and the placeholder. If the node has been written
+// to before stop(), we leave the content alone (caller has rendered real text).
+const THINKING_WORDS = [
+    'thinking', 'pondering', 'noodling', 'cooking', 'untangling',
+    'brewing', 'mulling', 'ruminating', 'cogitating', 'plotting',
+    'figuring', 'churning', 'simmering', 'percolating',
+];
+function startThinking(node, opening = null) {
+    if (!node) return { stop: () => {} };
+    const pick = (i) => `${opening || THINKING_WORDS[i % THINKING_WORDS.length]}`;
+    let i = Math.floor(Math.random() * THINKING_WORDS.length);
+    const span = el('span', { class: 'thinking' });
+    const word = el('span', { class: 'thinking-word' }, pick(i));
+    const dots = el('span', { class: 'thinking-dots' }, '…');
+    span.appendChild(word);
+    span.appendChild(dots);
+    node.replaceChildren(span);
+    const timer = setInterval(() => {
+        i++;
+        word.textContent = pick(i);
+    }, 1500);
+    let stopped = false;
+    return {
+        stop: () => {
+            if (stopped) return;
+            stopped = true;
+            clearInterval(timer);
+            // If the placeholder is still the only child, clear it so the
+            // caller can write real content. If the caller already wrote, the
+            // span will have been replaced — nothing to do.
+            if (node.firstChild === span) node.replaceChildren();
+        },
+    };
+}
+
+// Modal popup for the raw JSON behind a formatted slash result. Reuses
+// <dialog> for native ESC/focus-trap behaviour.
+function showRawPopup(raw, title = 'Raw result') {
+    let pretty = raw;
+    try { pretty = JSON.stringify(JSON.parse(raw), null, 2); } catch (_e) { /* not JSON — show as-is */ }
+    const dlg = el('dialog', { class: 'raw-popup' });
+    const header = el('div', { class: 'raw-popup-header' }, [
+        el('h3', {}, title),
+        el('button', { class: 'raw-popup-close', 'aria-label': 'Close', onClick: () => dlg.close() }, '✕'),
+    ]);
+    const body = el('pre', { class: 'raw-popup-body' }, el('code', {}, pretty));
+    const footer = el('div', { class: 'raw-popup-footer' }, [
+        el('button', {
+            class: 'raw-popup-copy',
+            onClick: async () => {
+                try { await navigator.clipboard.writeText(pretty); } catch (_e) {}
+                const ok = el('span', { class: 'raw-popup-copied' }, 'Copied');
+                footer.appendChild(ok);
+                setTimeout(() => ok.remove(), 1200);
+            },
+        }, 'Copy'),
+    ]);
+    dlg.appendChild(header);
+    dlg.appendChild(body);
+    dlg.appendChild(footer);
+    document.body.appendChild(dlg);
+    dlg.addEventListener('close', () => dlg.remove());
+    dlg.showModal();
+}
+
+// Append a small {} icon button to a bubble that opens the raw popup on click.
+function appendRawButton(bubble, raw) {
+    if (!raw) return;
+    const btn = el('button', {
+        class: 'raw-toggle',
+        type: 'button',
+        title: 'Show raw output',
+        'aria-label': 'Show raw output',
+        onClick: () => showRawPopup(raw),
+    }, '{ }');
+    bubble.appendChild(document.createTextNode(' '));
+    bubble.appendChild(btn);
+}
+
+// Cheap deterministic templating for slash-skill results whose shape is small
+// and unambiguous (single-key results, error envelopes, clock format). Returns
+// the rendered string when a template matches, or `null` to fall through to
+// the LLM-format pass. Saves a full LLM round-trip + the small-model verbosity
+// for simple cases like `/calculator 5+5` → `{"result": 10}`.
+function templateSimpleResult(cmd, raw) {
+    let v;
+    try { v = JSON.parse(raw); } catch { return null; }
+    if (v == null || typeof v !== 'object' || Array.isArray(v)) return null;
+    const keys = Object.keys(v);
+
+    // Error envelope: every skill emits `{error: "..."}` on failure.
+    if (keys.length === 1 && typeof v.error === 'string') {
+        return `**Error:** ${v.error}`;
+    }
+
+    // /calculator → {result: number}
+    if (cmd === 'calculator' && keys.length === 1 && typeof v.result === 'number') {
+        // Render floats without trailing zeros: 8.0 → 8, 3.14 → 3.14.
+        const n = Number.isInteger(v.result) ? String(v.result) : String(v.result);
+        return `**${n}**`;
+    }
+
+    // /clock → {time: "ISO 8601", tz: "UTC"}
+    if (cmd === 'clock' && typeof v.time === 'string') {
+        // Prettify the ISO timestamp to "YYYY-MM-DD HH:MM:SS UTC" so users
+        // don't have to mentally parse the T-separator.
+        const m = v.time.match(/^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})/);
+        const stamp = m ? `${m[1]} ${m[2]}` : v.time;
+        const tz = typeof v.tz === 'string' ? v.tz : 'UTC';
+        return `**${stamp} ${tz}**`;
+    }
+
+    // /web-fetch → {status, url, content_type?, body, truncated}
+    // Known shape, so we template rather than feeding (potentially huge)
+    // page bodies to a small LLM. Raw button still gives the full body.
+    if (cmd === 'web-fetch' && typeof v.status === 'number' && typeof v.body === 'string') {
+        const url = typeof v.url === 'string' ? v.url : '';
+        const ct = typeof v.content_type === 'string' && v.content_type ? v.content_type : 'unknown';
+        const trunc = v.truncated ? ' (truncated)' : '';
+        const bytes = v.body.length;
+        const head = `**${v.status}** from \`${url}\` — ${bytes} chars, ${ct}${trunc}.`;
+        // Short bodies: inline a preview so the user sees the content immediately.
+        if (bytes > 0 && bytes <= 400) {
+            return `${head}\n\n\`\`\`\n${v.body}\n\`\`\``;
+        }
+        return head;
+    }
+
+    // Generic one-key string-value (e.g. some future `{summary: "..."}` shape).
+    if (keys.length === 1 && typeof v[keys[0]] === 'string' && v[keys[0]].length <= 200) {
+        return v[keys[0]];
+    }
+
+    return null;
+}
+
+// Asks the loaded LLM to summarize a slash-skill JSON result in plain language.
+// Streams tokens into `bubbleText` (replacing whatever was there). On any
+// failure (no model, network error, …) falls back to the raw output so the
+// user still sees something. Returns when the stream completes.
+async function formatSlashResultWithLLM({ cmd, args, raw, bubbleText }) {
+    const modelId = selectedModelId();
+    if (!modelId) {
+        bubbleText.textContent = raw;
+        return;
+    }
+    // Limit prompt size — huge fetched documents shouldn't blow up the LLM.
+    const MAX = 4000;
+    const slice = raw.length > MAX ? `${raw.slice(0, MAX)}\n…[truncated, ${raw.length} bytes total]` : raw;
+    const prompt =
+        `The user ran the slash-command \`/${cmd}${args ? ' ' + args : ''}\`. ` +
+        `The skill returned this JSON output:\n\n\`\`\`json\n${slice}\n\`\`\`\n\n` +
+        `Reply with a short, friendly answer in plain language that directly addresses ` +
+        `what the user asked. Use 1–2 sentences. Do not mention "the JSON", "the skill", ` +
+        `or "the output" — just state the result naturally.`;
+    const thinker = startThinking(bubbleText, 'summarizing');
+    let acc = '';
+    try {
+        const resp = await fetch('/b/agent/chat', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                user_message: prompt,
+                messages: [],
+                model_id: modelId,
+            }),
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+            let idx;
+            while ((idx = buffer.indexOf('\n\n')) !== -1) {
+                const frame = buffer.slice(0, idx);
+                buffer = buffer.slice(idx + 2);
+                const lines = frame.split('\n');
+                let event = '';
+                let data = '';
+                for (const line of lines) {
+                    if (line.startsWith('event:')) event = line.slice(6).trim();
+                    else if (line.startsWith('data:')) data += line.slice(5).replace(/^ /, '');
+                }
+                if (event === 'token') {
+                    let p; try { p = JSON.parse(data); } catch { p = null; }
+                    if (p?.delta) {
+                        if (acc === '') thinker.stop();
+                        acc += p.delta;
+                        renderAssistantContent(bubbleText, acc);
+                        scrollToBottom();
+                    }
+                }
+            }
+        }
+    } catch (_e) {
+        // fall through — show raw
+    } finally {
+        thinker.stop();
+        if (!acc) {
+            // LLM produced nothing — fall back to raw so user sees something.
+            bubbleText.textContent = raw;
+        }
+    }
 }
 
 // Render assistant text as markdown with syntax-highlighted code blocks.
@@ -644,42 +868,6 @@ if (brandMascot) {
 // Progress card \u2014 created lazily inside the Settings dialog while the model
 // downloads. Holds the verbose stage message so the Load model button text
 // can stay short.
-function setLoadProgress(text, percent, isError = false) {
-    let card = $('load-progress');
-    if (!card) {
-        card = el('div', { id: 'load-progress', class: 'progress-card' });
-        const stage = el('div', { class: 'progress-stage' });
-        const bar = el('div', { class: 'progress-bar' });
-        const fill = el('div', { class: 'progress-bar-fill' });
-        bar.appendChild(fill);
-        card.appendChild(stage);
-        card.appendChild(bar);
-        // Prefer to show progress inline in the chat surface so it's visible
-        // when the user kicked off the load from the empty-state CTA (the
-        // settings dialog is closed in that flow). Fall back to next-to the
-        // settings dialog's load button when the empty state has been
-        // dismissed.
-        const empty = document.querySelector('#messages .empty');
-        const loadBtn = $('open-model-picker') || $('load-model');
-        if (empty) {
-            empty.replaceChildren(card);
-        } else if (loadBtn) {
-            loadBtn.parentNode.insertBefore(card, loadBtn);
-        }
-    }
-    card.querySelector('.progress-stage').textContent = text || '';
-    const bar = card.querySelector('.progress-bar');
-    const fill = card.querySelector('.progress-bar-fill');
-    if (typeof percent === 'number' && !isNaN(percent)) {
-        const pct = Math.max(0, Math.min(100, percent));
-        fill.style.width = `${pct}%`;
-        bar.classList.remove('is-indeterminate');
-    } else {
-        bar.classList.add('is-indeterminate');
-    }
-    card.classList.toggle('is-error', !!isError);
-}
-
 function clearLoadProgress() {
     const card = $('load-progress');
     if (card) card.remove();
@@ -689,13 +877,6 @@ function clearLoadProgress() {
     if (empty && empty.childElementCount === 0 && !empty.textContent.trim()) {
         empty.textContent = 'Ready — ask anything below.';
     }
-}
-
-// Pull a percent like "15% completed" out of the runtime's stage message.
-function parsePercentFromStage(stage) {
-    if (!stage) return null;
-    const m = stage.match(/(\d+(?:\.\d+)?)\s*%/);
-    return m ? parseFloat(m[1]) : null;
 }
 
 // --- Settings dialog ---
@@ -852,39 +1033,6 @@ function getCurrentEngineModelId() {
     return _loadedModelId;
 }
 
-async function startModelLoad(modelId) {
-    // If no modelId passed, fall back to whatever is persisted in localStorage.
-    const id = modelId || selectedModelId();
-    const btn = $('open-model-picker') || $('load-model');
-    if (btn) {
-        btn.disabled = true;
-        btn.textContent = 'Downloading\u2026';
-    }
-    setLoadProgress('Starting\u2026', null);
-    try {
-        await loadEngine(id, (text) => {
-            if (btn) btn.textContent = 'Downloading\u2026';
-            setLoadProgress(text || 'Downloading\u2026', parsePercentFromStage(text));
-        });
-        _loadedModelId = id;
-        if (btn) btn.textContent = 'Ready';
-        clearLoadProgress();
-        $('send').disabled = false;
-    } catch (e) {
-        const msg = String(e?.message ?? e);
-        if (/compatible GPU|WebGPU|gpu adapter/i.test(msg)) {
-            const warn = $('webgpu-warning');
-            if (warn) warn.hidden = false;
-            if (btn) btn.textContent = 'Load model';
-            clearLoadProgress();
-        } else {
-            if (btn) btn.textContent = 'Try again';
-            setLoadProgress(msg, null, true);
-        }
-        if (btn) btn.disabled = false;
-    }
-}
-
 // --- Picker overlay integration ---
 
 // Start fetching the WebLLM module at page load so the first picker open
@@ -897,30 +1045,48 @@ async function launchPicker() {
     const prebuiltList = mod?.prebuiltAppConfig?.model_list || [];
     const result = await openPicker({
         prebuiltList,
-        currentModelId: getCurrentEngineModelId(),
+        getCurrentModelId: getCurrentEngineModelId,
+        loadEngine,
+        unloadEngine,
+        // Picker drives load/unload itself; reflect the result onto the chat
+        // surface as the active model changes (incl. on unload → null).
+        onActiveChange: (modelId) => {
+            _loadedModelId = modelId;
+            const send = $('send');
+            if (send) send.disabled = !modelId;
+            if (modelId) {
+                localStorage.setItem(SELECTED_MODEL_KEY, modelId);
+            }
+            const btn = $('open-model-picker') || $('load-model');
+            if (btn) {
+                btn.disabled = false;
+                btn.textContent = modelId ? 'Change model' : 'Load model';
+            }
+            if (modelId) clearLoadProgress();
+            // Swap the bootstrap "I can't do much without a brain…" copy
+            // for a friendlier ready hint. On unload (modelId === null) we
+            // restore the cold-state copy so the chat surface explains
+            // again why nothing's happening.
+            const empty = document.querySelector('#messages .empty');
+            if (empty) {
+                if (modelId) {
+                    empty.replaceChildren(document.createTextNode('Ready — ask anything below.'));
+                } else if (empty.childElementCount === 0) {
+                    // Only restore the prompt if we previously replaced it
+                    // with a plain text node; if the original maud HTML is
+                    // still there, leave it alone.
+                    empty.replaceChildren(document.createTextNode("I can't do much without a brain — load one from the picker."));
+                }
+            }
+        },
     });
-    if (!result?.model_id) return;
-    if (result.mode === 'download') {
-        // Cache weights to IndexedDB without making this the active engine.
-        // Implemented as load-then-unload via the page-direct engine — keeps
-        // weights cached locally; existing _engine is replaced (single-slot
-        // WebGPU constraint).
-        setLoadProgress(`Downloading ${result.model_id}…`, null);
-        try {
-            await loadEngine(result.model_id, (text) => {
-                setLoadProgress(text || 'Downloading…', parsePercentFromStage(text));
-            });
-            await unloadEngine?.();
-            _loadedModelId = null;
-            setLoadProgress(`${result.model_id} cached.`, 100);
-            setTimeout(clearLoadProgress, 2000);
-        } catch (e) {
-            setLoadProgress(`Download failed: ${e?.message ?? e}`, null, true);
-        }
-        return;
+    // After the picker closes, persist the final active model. If the user
+    // closed the picker mid-load, `result` reflects the active model at close
+    // time (which may not yet be the in-flight one); `onActiveChange` above
+    // will fire when the load eventually completes.
+    if (result?.model_id) {
+        localStorage.setItem(SELECTED_MODEL_KEY, result.model_id);
     }
-    localStorage.setItem(SELECTED_MODEL_KEY, result.model_id);
-    await startModelLoad(result.model_id);
 }
 
 // Settings → Choose model (closes the dialog so the full-screen picker takes over).
@@ -963,6 +1129,12 @@ $('composer').addEventListener('submit', async (e) => {
     let assistantText = '';
     const assistantEl = addAssistantBubble();
     const toolRows = new Map(); // tool-call id -> DOM row
+    // Show a cycling status while we wait for the first token / tool_result.
+    const thinker = startThinking(assistantEl);
+    // Slash-command bookkeeping so the tool_result handler can call the LLM
+    // formatter with the original cmd + args.
+    const slashCmd = text.match(/^\/(\S+)(?:\s+(.+))?$/);
+    const slashFollowups = [];
 
     const pendingUploads = getPending();
     const uploads = await Promise.all(
@@ -1004,13 +1176,31 @@ $('composer').addEventListener('submit', async (e) => {
         }
         if (buffer.trim()) processFrame(buffer);
 
+        // Slash-command path: try a cheap deterministic template first; only
+        // fall back to the LLM-summarize pass for complex shapes. Either way,
+        // attach a `{ }` button so the user can see the raw JSON.
+        for (const f of slashFollowups) {
+            const templated = templateSimpleResult(f.cmd, f.raw);
+            if (templated !== null) {
+                assistantEl.replaceChildren();
+                renderAssistantContent(assistantEl, templated);
+            } else {
+                await formatSlashResultWithLLM({
+                    cmd: f.cmd, args: f.args, raw: f.raw, bubbleText: assistantEl,
+                });
+            }
+            appendRawButton(assistantEl.parentElement, f.raw);
+        }
+
         if (assistantText) {
             history.push({ role: 'assistant', content: assistantText });
         }
         roundTripCompleted = true;
     } catch (err) {
+        thinker.stop();
         assistantEl.textContent = `(error: ${err.message})`;
     } finally {
+        thinker.stop();
         window.__brandStopTyping?.();
         input.disabled = false;
         $('send').disabled = false;
@@ -1037,34 +1227,43 @@ $('composer').addEventListener('submit', async (e) => {
         try { payload = JSON.parse(data); } catch { payload = data; }
 
         if (event === 'token' && payload?.delta) {
+            if (assistantText === '') thinker.stop();
             assistantText += payload.delta;
             renderAssistantContent(assistantEl, assistantText);
             scrollToBottom();
         } else if (event === 'tool_call') {
+            thinker.stop();
             const row = addToolRow(payload?.name ?? '?', payload?.arguments ?? '');
             toolRows.set(payload?.id ?? crypto.randomUUID(), row);
         } else if (event === 'tool_result') {
+            thinker.stop();
             const row = toolRows.get(payload?.id);
             if (row) {
                 updateToolRow(row, !payload?.error, payload?.result ?? payload?.error ?? '');
                 renderToolAttachment(row, payload?.for_ui);
             } else {
                 // Slash-command path: no preceding tool_call event because
-                // the user-typed `/<cmd>` IS the call. Render the result
-                // (and any inline-media attachment) into the assistant
-                // bubble. The textual summary is purely informational —
-                // _for_ui carries the image/video for the user.
+                // the user-typed `/<cmd>` IS the call. Run the result
+                // through the LLM for a plain-language summary and stash the
+                // raw JSON behind a small `{ }` button. `for_ui` (images,
+                // video) skips the formatter — the media speaks for itself.
                 const summary = payload?.result ?? payload?.error ?? '';
-                if (summary && !payload?.for_ui) {
-                    assistantText += summary;
-                    renderAssistantContent(assistantEl, assistantText);
-                }
                 if (payload?.for_ui) {
                     renderToolAttachment(assistantEl, payload.for_ui);
+                } else if (summary) {
+                    // Defer the LLM formatting until the SSE stream is done
+                    // so we don't race the original stream with a fresh
+                    // /b/agent/chat. Park the work and run it after the loop.
+                    slashFollowups.push({
+                        cmd: slashCmd?.[1] || '?',
+                        args: slashCmd?.[2] || '',
+                        raw: summary,
+                    });
                 }
                 scrollToBottom();
             }
         } else if (event === 'confirm') {
+            thinker.stop();
             // PR 5: ambiguous slash-command params — backend asks the user
             // to confirm before dispatching. Render a question line and
             // [Yes]/[No] chips into the assistant bubble.
@@ -1083,6 +1282,7 @@ $('composer').addEventListener('submit', async (e) => {
                 renderAssistantContent(assistantEl, assistantText);
             });
         } else if (event === 'done') {
+            thinker.stop();
             // Surface terminal errors and empty-stop states so the user
             // isn't left staring at a blank bubble. Token paths overwrite
             // assistantText already, so this only fires when nothing

--- a/site/gizza-app.js
+++ b/site/gizza-app.js
@@ -666,6 +666,18 @@ function handleSlashKeydown(e) {
     if (!input) return;
     input.addEventListener('input', handleSlashInput);
     input.addEventListener('keydown', handleSlashKeydown);
+    // Enter (without Shift) submits the chat form. Shift+Enter falls
+    // through to the textarea's native newline behaviour. Slash-autocomplete
+    // handler runs first and calls preventDefault when the dropdown is up,
+    // so the `defaultPrevented` guard keeps this submit out of the way of
+    // completion.
+    input.addEventListener('keydown', (e) => {
+        if (e.key !== 'Enter' || e.shiftKey) return;
+        if (e.defaultPrevented) return;
+        e.preventDefault();
+        const form = document.getElementById('composer');
+        form?.requestSubmit?.();
+    });
     input.addEventListener('blur', () => {
         // Slight delay so a mousedown on the dropdown gets to fire first.
         setTimeout(hideSlashDropdown, 100);

--- a/site/gizza.css
+++ b/site/gizza.css
@@ -1189,3 +1189,134 @@ dialog button[value="close"] {
     cursor: pointer;
 }
 .empty-state-link:hover { color: var(--color-primary-active); }
+
+/* ─── Cycling "thinking…" placeholder in an empty assistant bubble ────── */
+.thinking {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 2px;
+    color: var(--color-muted);
+    font-style: italic;
+}
+.thinking-word {
+    display: inline-block;
+    animation: thinking-fade 1.5s ease-in-out infinite;
+}
+.thinking-dots {
+    display: inline-block;
+    animation: thinking-pulse 1.2s ease-in-out infinite;
+}
+@keyframes thinking-fade {
+    0%, 100% { opacity: 0.6; }
+    50%      { opacity: 1; }
+}
+@keyframes thinking-pulse {
+    0%, 100% { transform: translateY(0); opacity: 0.5; }
+    50%      { transform: translateY(-1px); opacity: 1; }
+}
+
+/* ─── { } button next to a formatted slash-skill answer ────────────────── */
+.raw-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 6px;
+    padding: 1px 6px;
+    font-family: var(--sa-mono, ui-monospace, "SF Mono", monospace);
+    font-size: 11px;
+    font-weight: 600;
+    background: var(--color-canvas-soft);
+    color: var(--color-muted);
+    border: 1px solid var(--color-hairline);
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    vertical-align: baseline;
+    transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+.raw-toggle:hover {
+    background: var(--color-surface-strong);
+    color: var(--color-ink);
+    border-color: var(--color-hairline-strong);
+}
+
+/* ─── Raw-JSON popup dialog ────────────────────────────────────────────── */
+dialog.raw-popup {
+    width: min(720px, 90vw);
+    max-height: 80vh;
+    padding: 0;
+    border: 1px solid var(--color-hairline-strong);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface-card);
+    color: var(--color-ink);
+    font-family: var(--font-display);
+    box-shadow: 0 24px 60px rgba(0,0,0,0.18);
+    overflow: hidden;
+}
+dialog.raw-popup::backdrop { background: rgba(0,0,0,0.4); }
+.raw-popup-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-sm) var(--space-base);
+    border-bottom: 1px solid var(--color-hairline);
+    background: var(--color-canvas-soft);
+}
+.raw-popup-header h3 {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 16px;
+    font-weight: 500;
+    color: var(--color-ink);
+}
+.raw-popup-close {
+    background: transparent;
+    border: none;
+    font-size: 18px;
+    line-height: 1;
+    color: var(--color-muted);
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: var(--radius-sm);
+}
+.raw-popup-close:hover { color: var(--color-ink); background: var(--color-surface-strong); }
+.raw-popup-body {
+    margin: 0;
+    padding: var(--space-base);
+    max-height: 60vh;
+    overflow: auto;
+    font-family: var(--sa-mono, ui-monospace, "SF Mono", monospace);
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--color-ink);
+    background: var(--color-canvas);
+    white-space: pre;
+}
+.raw-popup-body code {
+    font-family: inherit;
+    background: none;
+    padding: 0;
+}
+.raw-popup-footer {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: var(--space-sm) var(--space-base);
+    border-top: 1px solid var(--color-hairline);
+    background: var(--color-canvas-soft);
+}
+.raw-popup-copy {
+    padding: 6px 14px;
+    font-family: var(--font-display);
+    font-size: 13px;
+    font-weight: 500;
+    background: var(--color-primary);
+    color: var(--color-on-primary);
+    border: 1px solid var(--color-primary);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+}
+.raw-popup-copy:hover { background: var(--color-primary-active); border-color: var(--color-primary-active); }
+.raw-popup-copied {
+    font-size: 12px;
+    color: var(--color-success);
+}

--- a/site/gizza.css
+++ b/site/gizza.css
@@ -1256,7 +1256,7 @@ dialog.raw-popup::backdrop { background: rgba(0,0,0,0.4); }
 .raw-popup-header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    gap: var(--space-base);
     padding: var(--space-sm) var(--space-base);
     border-bottom: 1px solid var(--color-hairline);
     background: var(--color-canvas-soft);
@@ -1267,6 +1267,30 @@ dialog.raw-popup::backdrop { background: rgba(0,0,0,0.4); }
     font-size: 16px;
     font-weight: 500;
     color: var(--color-ink);
+    flex: 0 0 auto;
+}
+.raw-popup-tabs {
+    flex: 1 1 auto;
+    display: flex;
+    gap: 4px;
+}
+.raw-popup-tab {
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    padding: 4px 12px;
+    font-family: var(--font-display);
+    font-size: 13px;
+    color: var(--color-muted);
+    cursor: pointer;
+    transition: color 120ms ease, background 120ms ease, border-color 120ms ease;
+}
+.raw-popup-tab:hover { color: var(--color-ink); }
+.raw-popup-tab.is-active {
+    color: var(--color-ink);
+    background: var(--color-surface-card);
+    border-color: var(--color-hairline);
+    font-weight: 500;
 }
 .raw-popup-close {
     background: transparent;

--- a/site/model-picker.css
+++ b/site/model-picker.css
@@ -3,17 +3,23 @@
  * don't collide with `dialog#settings`. Tokens come from gizza.css. */
 
 dialog#model-picker {
-    /* Override the small centered modal style from gizza.css */
-    width: 100vw;
-    height: 100vh;
-    max-width: none;
-    max-height: none;
-    margin: 0;
+    /* Centered card overlay. The dialog element auto-centers when its margin
+     * is `auto`; we size it to a comfortable max but cap it at 92vw / 88vh so
+     * it stays well inside the viewport with breathing room around it. */
+    width: min(1100px, 92vw);
+    height: min(820px, 88vh);
+    max-width: 1100px;
+    max-height: 88vh;
+    margin: auto;
     padding: 0;
-    border: none;
-    border-radius: 0;
+    border: 1px solid var(--color-hairline-strong);
+    border-radius: var(--radius-lg);
     background: var(--color-canvas);
     color: var(--color-ink);
+    box-shadow:
+        0 30px 80px rgba(0, 0, 0, 0.22),
+        0 4px 12px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
     display: flex;
     flex-direction: column;
     /* Consistent brand voice — Itim throughout the picker, including
@@ -26,7 +32,27 @@ dialog#model-picker select,
 dialog#model-picker button {
     font-family: var(--font-display);
 }
-dialog#model-picker::backdrop { background: rgba(0, 0, 0, 0.4); }
+dialog#model-picker::backdrop {
+    background: rgba(15, 15, 20, 0.5);
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
+}
+
+/* On narrow viewports (mobile / split-screen) the centered card wastes more
+ * space on chrome than it saves; collapse back to full-screen so the table
+ * + tier cards get every pixel. */
+@media (max-width: 720px) {
+    dialog#model-picker {
+        width: 100vw;
+        height: 100vh;
+        max-width: none;
+        max-height: none;
+        margin: 0;
+        border: none;
+        border-radius: 0;
+        box-shadow: none;
+    }
+}
 
 /* ─── Header ───────────────────────────────────────────────────────────── */
 .mp-header {
@@ -196,11 +222,23 @@ dialog#model-picker::backdrop { background: rgba(0, 0, 0, 0.4); }
 .mp-cell-model-name {
     font-weight: 500;
     color: var(--color-ink);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+.mp-cell-model-title {
+    flex: 0 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 .mp-cell-model-sub {
     font-size: 11px;
     color: var(--color-muted);
     margin-top: 2px;
+    margin-left: 30px;  /* align under title (after star) */
 }
 .mp-cell-hf-link {
     color: var(--color-primary);
@@ -247,6 +285,59 @@ dialog#model-picker::backdrop { background: rgba(0, 0, 0, 0.4); }
     background: var(--color-canvas-soft);
     border-color: var(--color-hairline-strong);
     color: var(--color-muted-soft);
+}
+.mp-action-btn.mp-unload-btn {
+    background: var(--color-surface-card);
+    border-color: #b91c1c;
+    color: #b91c1c;
+}
+.mp-action-btn.mp-unload-btn:hover:not(:disabled) {
+    background: #fef2f2;
+    border-color: #991b1b;
+    color: #991b1b;
+}
+.mp-action-btn.mp-unload-btn:disabled {
+    color: var(--color-muted-soft);
+    border-color: var(--color-hairline-strong);
+    background: var(--color-canvas-soft);
+}
+
+/* ─── Per-row load progress in the Status cell ─────────────────────────── */
+.mp-cell-status.is-loading {
+    min-width: 180px;
+}
+.mp-load-progress {
+    width: 100%;
+    height: 6px;
+    background: var(--color-canvas-soft);
+    border-radius: 999px;
+    overflow: hidden;
+    border: 1px solid var(--color-hairline-soft);
+}
+.mp-load-progress-bar {
+    height: 100%;
+    background: var(--color-primary);
+    transition: width 200ms ease;
+}
+.mp-load-progress-text {
+    margin-top: 4px;
+    font-size: 11px;
+    color: var(--color-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 220px;
+}
+.mp-cell-status.is-error {
+    color: #b91c1c;
+    font-weight: 500;
+    max-width: 220px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.mp-row.is-loading {
+    background: #fff7f1;
 }
 
 .mp-empty {
@@ -357,18 +448,26 @@ dialog#model-picker::backdrop { background: rgba(0, 0, 0, 0.4); }
 }
 
 .mp-star {
+    flex: 0 0 22px;
+    width: 22px;
+    height: 22px;
+    padding: 0;
     background: transparent;
     border: none;
-    padding: 4px 8px;
-    font-size: 18px;
+    font-size: 16px;
     line-height: 1;
     cursor: pointer;
-    color: var(--color-muted);
-    border-radius: var(--radius-md);
+    color: var(--color-muted-soft);
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: color 120ms ease, transform 120ms ease;
 }
-.mp-star:hover { background: rgba(0, 0, 0, 0.04); color: var(--color-ink); }
+.mp-star:hover { color: #f59e0b; transform: scale(1.1); }
+.mp-star:focus-visible { outline: 2px solid var(--color-primary); outline-offset: 2px; }
 .mp-star.active { color: #f59e0b; }
-.mp-star.active:hover { background: rgba(245, 158, 11, 0.08); }
+.mp-star.active:hover { color: #d97706; }
 
 .mp-trash {
     background: transparent;
@@ -382,3 +481,265 @@ dialog#model-picker::backdrop { background: rgba(0, 0, 0, 0.4); }
     border-radius: var(--radius-md);
 }
 .mp-trash:hover { background: rgba(220, 38, 38, 0.08); color: #b91c1c; }
+
+/* ─── Brain-tier landing view ──────────────────────────────────────────── */
+.mp-tiers {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: var(--space-lg);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-lg);
+}
+.mp-tiers-intro {
+    margin: 0;
+    max-width: 720px;
+    text-align: center;
+    color: var(--color-body);
+    font-size: 15px;
+    line-height: 1.5;
+}
+.mp-tier-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(260px, 1fr));
+    gap: var(--space-base);
+    width: 100%;
+    max-width: 960px;
+}
+@media (max-width: 820px) {
+    .mp-tier-grid { grid-template-columns: 1fr; }
+}
+
+.mp-tier-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    background: var(--color-surface-card);
+    border: 1px solid var(--color-hairline);
+    border-radius: var(--radius-lg);
+    padding: var(--space-base);
+    /* Reserve enough vertical space for the progress bar + text so the foot
+     * row doesn't shift down when loading starts. Tagline (flex: 1 auto)
+     * absorbs the slack while idle. */
+    min-height: 230px;
+    transition: border-color 120ms ease, box-shadow 120ms ease, transform 120ms ease;
+}
+.mp-tier-card:hover { border-color: var(--color-hairline-strong); }
+.mp-tier-card.is-recommended {
+    border-color: var(--color-primary);
+    box-shadow: 0 4px 18px rgba(0,0,0,0.06);
+}
+.mp-tier-card.is-active {
+    border-color: var(--color-success);
+    background: #f5fdf9;
+}
+.mp-tier-card.is-loading {
+    border-color: var(--color-primary);
+    background: #fff7f1;
+}
+.mp-tier-card.is-unavailable {
+    opacity: 0.55;
+    background: var(--color-canvas-soft);
+}
+
+.mp-tier-head {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-sm);
+    margin-bottom: var(--space-xs);
+}
+.mp-tier-emoji {
+    font-size: 32px;
+    line-height: 1;
+    flex: 0 0 auto;
+}
+.mp-tier-titles { flex: 1 1 auto; min-width: 0; }
+.mp-tier-label {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 18px;
+    font-weight: 500;
+    color: var(--color-ink);
+    line-height: 1.2;
+}
+.mp-tier-sub {
+    margin-top: 4px;
+    font-size: 11px;
+    color: var(--color-muted);
+    font-family: var(--sa-mono, ui-monospace, "SF Mono", monospace);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.mp-tier-badge {
+    position: absolute;
+    top: -10px;
+    right: var(--space-base);
+    padding: 3px 10px;
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    background: var(--color-primary);
+    color: var(--color-on-primary);
+    border-radius: var(--radius-pill);
+}
+
+.mp-tier-tagline {
+    margin: 0 0 var(--space-base);
+    color: var(--color-body);
+    font-size: 13px;
+    line-height: 1.45;
+    flex: 1 1 auto;
+}
+
+.mp-tier-progress {
+    width: 100%;
+    height: 6px;
+    margin-bottom: 6px;
+    background: var(--color-canvas-soft);
+    border: 1px solid var(--color-hairline-soft);
+    border-radius: 999px;
+    overflow: hidden;
+}
+.mp-tier-progress-bar {
+    height: 100%;
+    background: var(--color-primary);
+    transition: width 200ms ease;
+}
+.mp-tier-progress-text {
+    margin-bottom: var(--space-xs);
+    font-size: 11px;
+    color: var(--color-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.mp-tier-foot {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-sm);
+    margin-top: auto;
+}
+.mp-tier-status {
+    font-size: 12px;
+    font-weight: 500;
+}
+.mp-tier-status.is-loaded { color: var(--color-success); }
+.mp-tier-status.is-cached { color: var(--color-body); }
+.mp-tier-status.is-empty  { color: var(--color-muted-soft); }
+.mp-tier-status.is-unavailable { color: var(--color-muted-soft); font-style: italic; }
+.mp-tier-status.is-loading { color: transparent; }
+
+.mp-tier-btn {
+    padding: 8px 16px;
+    font-size: 13px;
+    font-weight: 500;
+    font-family: var(--font-display);
+    background: var(--color-surface-card);
+    border: 1px solid var(--color-hairline-strong);
+    border-radius: var(--radius-md);
+    color: var(--color-ink);
+    cursor: pointer;
+    transition: background 120ms ease, border-color 120ms ease;
+}
+.mp-tier-btn:hover:not(:disabled) { border-color: var(--color-ink); }
+.mp-tier-btn:disabled {
+    color: var(--color-muted-soft);
+    cursor: default;
+    background: var(--color-canvas-soft);
+}
+.mp-tier-btn.primary {
+    background: var(--color-primary);
+    border-color: var(--color-primary);
+    color: var(--color-on-primary);
+}
+.mp-tier-btn.primary:hover:not(:disabled) {
+    background: var(--color-primary-active);
+    border-color: var(--color-primary-active);
+}
+.mp-tier-btn.primary:disabled {
+    background: var(--color-canvas-soft);
+    border-color: var(--color-hairline-strong);
+    color: var(--color-muted-soft);
+}
+.mp-tier-btn.mp-tier-unload {
+    background: var(--color-surface-card);
+    border-color: #b91c1c;
+    color: #b91c1c;
+}
+.mp-tier-btn.mp-tier-unload:hover:not(:disabled) {
+    background: #fef2f2;
+    border-color: #991b1b;
+    color: #991b1b;
+}
+
+.mp-tiers-footer {
+    margin-top: var(--space-base);
+    text-align: center;
+}
+.mp-tiers-more {
+    background: transparent;
+    border: none;
+    color: var(--color-primary);
+    font-family: var(--font-display);
+    font-size: 14px;
+    cursor: pointer;
+    padding: 6px 12px;
+    border-radius: var(--radius-sm);
+    transition: background 120ms ease;
+}
+.mp-tiers-more:hover {
+    background: rgba(0,0,0,0.04);
+    text-decoration: underline;
+}
+
+/* Back arrow in the header when on the Custom view. */
+.mp-back {
+    background: transparent;
+    border: 1px solid var(--color-hairline);
+    border-radius: var(--radius-md);
+    padding: 4px 10px;
+    margin-right: auto;
+    margin-left: var(--space-base);
+    font-family: var(--font-display);
+    font-size: 13px;
+    color: var(--color-ink);
+    cursor: pointer;
+}
+.mp-back:hover { border-color: var(--color-ink); background: var(--color-surface-strong); }
+
+/* ─── shader-f16 unsupported banner (custom view only) ─────────────────── */
+.mp-f16-banner {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: 10px var(--space-lg);
+    background: #fff4e0;
+    border-bottom: 1px solid #f4d8a0;
+    color: #7a5510;
+    font-size: 13px;
+    line-height: 1.45;
+}
+.mp-f16-banner-icon {
+    flex: 0 0 auto;
+    font-size: 16px;
+    line-height: 1;
+}
+.mp-f16-banner code {
+    background: rgba(0, 0, 0, 0.04);
+    padding: 1px 5px;
+    border-radius: var(--radius-sm);
+    font-family: var(--sa-mono, ui-monospace, "SF Mono", monospace);
+    font-size: 12px;
+}
+
+/* Faded styling for f16-blocked variants inside the Variant dropdown. */
+.mp-quality-select option[data-needs-f16="true"] {
+    color: var(--color-muted-soft);
+    font-style: italic;
+}

--- a/site/model-picker.js
+++ b/site/model-picker.js
@@ -271,6 +271,86 @@ const SIZE_TIERS = [
     { id: 'large', label: 'Large (5+ GB)', min_mb: 5120 },
 ];
 
+/**
+ * Curated brain tiers shown on the picker landing.
+ *
+ * Each tier carries a `f16` and `f32` variant. `q4f16_1` quantizations are
+ * smaller but require the WebGPU `shader-f16` feature — older GPUs and many
+ * Linux drivers don't expose it, so we probe at open time
+ * ([`probeShaderF16`]) and resolve to the f32 fallback when missing. Picks
+ * are all Qwen2.5 for ladder coherence — same family, just more brain.
+ * Medium is flagged `recommended` so the empty-state defaults to it.
+ */
+const BRAIN_TIERS = [
+    {
+        id: 'small',
+        label: 'Small brain',
+        emoji: '🧠',
+        variants: {
+            f16: { id: 'Qwen2.5-0.5B-Instruct-q4f16_1-MLC', size_gb: 0.9 },
+            f32: { id: 'Qwen2.5-0.5B-Instruct-q4f32_1-MLC', size_gb: 1.0 },
+        },
+        tagline: 'Fastest. Quick chats and simple slash commands.',
+    },
+    {
+        id: 'medium',
+        label: 'Medium brain',
+        emoji: '🧠',
+        variants: {
+            f16: { id: 'Qwen2.5-1.5B-Instruct-q4f16_1-MLC', size_gb: 1.6 },
+            f32: { id: 'Qwen2.5-1.5B-Instruct-q4f32_1-MLC', size_gb: 1.9 },
+        },
+        tagline: 'Balanced. Reliably understands slash commands.',
+        recommended: true,
+    },
+    {
+        id: 'big',
+        label: 'Big brain',
+        emoji: '🧠',
+        variants: {
+            f16: { id: 'Qwen2.5-3B-Instruct-q4f16_1-MLC', size_gb: 2.4 },
+            f32: { id: 'Qwen2.5-3B-Instruct-q4f32_1-MLC', size_gb: 2.9 },
+        },
+        tagline: 'Smartest. Better reasoning, longer to load.',
+    },
+];
+
+/**
+ * Probe the user's WebGPU adapter for the `shader-f16` feature. q4f16
+ * quantizations emit `enable f16;` at the top of their compute shader and the
+ * device rejects compilation if the feature is absent. We default to `false`
+ * on any error so the picker always lands on a working variant.
+ */
+export async function probeShaderF16() {
+    try {
+        if (typeof navigator === 'undefined' || !navigator.gpu) return false;
+        const adapter = await navigator.gpu.requestAdapter();
+        return !!adapter?.features?.has('shader-f16');
+    } catch (_e) {
+        return false;
+    }
+}
+
+/** Resolve a tier to its concrete `(model_id, size_gb)` based on the f16 probe. */
+function resolveTierVariant(tier, f16Supported) {
+    const v = f16Supported && tier.variants.f16 ? tier.variants.f16 : tier.variants.f32;
+    return { ...tier, model_id: v.id, size_gb: v.size_gb };
+}
+
+/**
+ * Locate the (group, variant) tuple for a tier's `model_id` in the grouped
+ * model list. Returns `null` when WebLLM has dropped the exact variant (rare
+ * but possible across versions). Caller can use that to grey out the card
+ * with a "model not available in this WebLLM version" message.
+ */
+function resolveTierGroupVariant(groups, modelId) {
+    for (const g of groups) {
+        const v = g.variants.find((x) => x.id === modelId);
+        if (v) return { group: g, variant: v };
+    }
+    return null;
+}
+
 const FAMILY_CHIP_OPTIONS = ['Llama', 'Qwen', 'Phi', 'Hermes', 'Gemma', 'Mistral', 'Other'];
 
 const SORT_OPTIONS = [
@@ -318,20 +398,51 @@ function formatDownloads(n) {
     return `${n} ↓`;
 }
 
+/**
+ * Does a quant string carry an f16 payload that the WebGPU shader will need
+ * the `shader-f16` extension for? Any `…f16…` substring matches (covers
+ * `q0f16`, `q4f16_1`, `q3f16_1`, etc.); `q*f32*` quants compile without the
+ * extension and are universally supported.
+ */
+function requiresShaderF16(quant) {
+    return /f16/i.test(quant || '');
+}
+
+/**
+ * Pick a sensible default variant for a row in the custom-table view. When
+ * `shader-f16` is missing we prefer the first non-f16 variant so the row
+ * lands on a loadable quantization; falls back to the middle variant (which
+ * the UI will mark disabled) if every variant needs f16.
+ */
+function pickInitialVariant(group, f16Supported) {
+    const middle = group.variants[Math.floor(group.variants.length / 2)] || group.variants[0];
+    if (f16Supported) return middle;
+    return group.variants.find((v) => !requiresShaderF16(v.quant)) || middle;
+}
+
 function renderTableRow(group, ctx) {
+    const f16Supported = ctx.f16Supported !== false;
     const initialVariant = ctx.selection?.base_id === group.base_id
         ? ctx.selection.variant
-        : group.variants[Math.floor(group.variants.length / 2)] || group.variants[0];
+        : pickInitialVariant(group, f16Supported);
     const isCached = ctx.cached.has(group.base_id);
     const isActive = group.variants.some((v) => v.id === ctx.active);
+    const loadingVariantId = ctx.loading?.variantId || null;
+    const loadingInGroup = loadingVariantId
+        && group.variants.some((v) => v.id === loadingVariantId);
+    const anyLoad = loadingVariantId != null;
+    const initialBlockedByF16 = !f16Supported && requiresShaderF16(initialVariant?.quant);
 
     const tr = el('tr', {
-        class: ['mp-row', isActive ? 'is-active' : '', isCached && !isActive ? 'is-cached' : ''].filter(Boolean).join(' '),
+        class: ['mp-row',
+            isActive ? 'is-active' : '',
+            isCached && !isActive ? 'is-cached' : '',
+            loadingInGroup ? 'is-loading' : '',
+        ].filter(Boolean).join(' '),
         'data-base-id': group.base_id,
     });
 
-    // Model cell — name + HF link + favorite star + delete-cached trash
-    // (the last two preserved from the pre-rebase card layout, PR #42).
+    // Model cell — favorite star + name (+ HF link on sub line).
     const isFav = ctx.favorites?.has(group.base_id);
     const favoriteBtn = el('button', {
         type: 'button',
@@ -343,7 +454,7 @@ function renderTableRow(group, ctx) {
             ctx.onFavoriteToggle?.(group.base_id);
         },
     }, [isFav ? '★' : '☆']);
-    const trashBtn = isCached && !isActive ? el('button', {
+    const trashBtn = isCached && !isActive && !loadingInGroup ? el('button', {
         type: 'button',
         class: 'mp-trash',
         'aria-label': `Delete cached ${group.base_id}`,
@@ -356,7 +467,7 @@ function renderTableRow(group, ctx) {
     const modelCell = el('td', { class: 'mp-cell-model' }, [
         el('div', { class: 'mp-cell-model-name' }, [
             favoriteBtn,
-            group.base_id,
+            el('span', { class: 'mp-cell-model-title' }, [group.base_id]),
             trashBtn,
         ]),
         el('div', { class: 'mp-cell-model-sub' }, [
@@ -376,9 +487,15 @@ function renderTableRow(group, ctx) {
     // Provider.
     tr.appendChild(el('td', { class: 'mp-cell-provider' }, [group.family || '—']));
 
-    // Variant dropdown.
+    // Variant dropdown — disabled while this row is loading. Inside the
+    // dropdown, f16 quantizations are individually disabled when the user's
+    // GPU lacks `shader-f16`.
     const variantCell = el('td', { class: 'mp-cell-variant' });
-    variantCell.appendChild(renderQualityPicker(group, initialVariant));
+    const qualityPicker = renderQualityPicker(group, initialVariant, f16Supported);
+    if (loadingInGroup) {
+        qualityPicker.querySelector('select')?.setAttribute('disabled', '');
+    }
+    variantCell.appendChild(qualityPicker);
     tr.appendChild(variantCell);
 
     // Size — updates when variant changes.
@@ -386,43 +503,84 @@ function renderTableRow(group, ctx) {
         el('strong', { class: 'mp-size-value' }, [formatBytes(initialVariant?.vram_mb)]),
     ]));
 
-    // Capabilities — Vision (vision detection lives in group.has_vision if set).
+    // Capabilities.
     const caps = el('td', { class: 'mp-cell-caps' });
     if (group.ctx) caps.appendChild(el('span', { class: 'mp-badge ctx' }, [`${Math.round(group.ctx / 1024)}k ctx`]));
     tr.appendChild(caps);
 
-    // Status.
-    let statusText, statusClass;
-    if (isActive) { statusText = '✓ Loaded'; statusClass = 'is-loaded'; }
-    else if (isCached) { statusText = '✓ Cached'; statusClass = 'is-cached'; }
-    else { statusText = '—'; statusClass = 'is-empty'; }
-    tr.appendChild(el('td', { class: `mp-cell-status ${statusClass}` }, [statusText]));
+    // Status — also hosts the per-row progress + error display.
+    let statusCell;
+    if (loadingInGroup) {
+        const pct = ctx.loading?.percent;
+        statusCell = el('td', { class: 'mp-cell-status is-loading' }, [
+            el('div', { class: 'mp-load-progress' }, [
+                el('div', {
+                    class: 'mp-load-progress-bar',
+                    style: typeof pct === 'number' ? `width: ${Math.max(0, Math.min(100, pct))}%` : 'width: 0%',
+                }),
+            ]),
+            el('div', { class: 'mp-load-progress-text' }, [
+                ctx.loading?.text || 'Starting…',
+            ]),
+        ]);
+    } else if (ctx.errorForBase === group.base_id && ctx.errorText) {
+        statusCell = el('td', { class: 'mp-cell-status is-error', title: ctx.errorText }, [
+            el('span', { class: 'mp-status-error' }, [`! ${ctx.errorText.slice(0, 60)}`]),
+        ]);
+    } else if (isActive) {
+        statusCell = el('td', { class: 'mp-cell-status is-loaded' }, ['✓ Loaded']);
+    } else if (isCached) {
+        statusCell = el('td', { class: 'mp-cell-status is-cached' }, ['✓ Cached']);
+    } else {
+        statusCell = el('td', { class: 'mp-cell-status is-empty' }, ['—']);
+    }
+    tr.appendChild(statusCell);
 
-    // Actions — Download + Load buttons.
+    // Actions — single button. Three states:
+    //   - this row is loading → "Loading…" (disabled)
+    //   - this row is the active engine → "Unload"
+    //   - otherwise → "Load" (disabled when another row is loading)
     const actionCell = el('td', { class: 'mp-cell-actions' });
-    const downloadBtn = el('button', {
-        class: 'mp-action-btn mp-download-btn',
-        type: 'button',
-        disabled: isCached || isActive ? '' : undefined,
-        title: isCached ? 'Already cached' : 'Download weights to browser cache',
-    }, [isCached || isActive ? 'Cached' : 'Download']);
-    const loadBtn = el('button', {
-        class: 'mp-action-btn mp-load-btn primary',
-        type: 'button',
-        disabled: isActive ? '' : undefined,
-        title: isActive ? 'Currently active' : 'Make this the active chat model',
-    }, [isActive ? 'Loaded' : 'Load']);
-    actionCell.appendChild(downloadBtn);
-    actionCell.appendChild(loadBtn);
+    let btn;
+    if (loadingInGroup) {
+        btn = el('button', {
+            class: 'mp-action-btn mp-load-btn primary',
+            type: 'button',
+            disabled: '',
+        }, ['Loading…']);
+    } else if (isActive) {
+        btn = el('button', {
+            class: 'mp-action-btn mp-unload-btn',
+            type: 'button',
+            disabled: anyLoad ? '' : undefined,
+            title: 'Release GPU memory (keeps cache)',
+        }, ['Unload']);
+    } else {
+        const disableForF16 = initialBlockedByF16;
+        let btnTitle;
+        if (anyLoad) btnTitle = 'Another model is loading…';
+        else if (disableForF16) btnTitle = 'shader-f16 not supported by your GPU — pick a different variant';
+        else btnTitle = isCached ? 'Load into GPU' : 'Download & load';
+        btn = el('button', {
+            class: 'mp-action-btn mp-load-btn primary',
+            type: 'button',
+            disabled: anyLoad || disableForF16 ? '' : undefined,
+            title: btnTitle,
+        }, ['Load']);
+    }
+    actionCell.appendChild(btn);
     tr.appendChild(actionCell);
 
     return tr;
 }
 
-function renderQualityPicker(group, initialVariant) {
+function renderQualityPicker(group, initialVariant, f16Supported = true) {
     // Single dropdown replaces the dense variant-pill row. Each option
     // includes the quality label + its quantization sublabel so users can
-    // still tell variants apart without four side-by-side buttons.
+    // still tell variants apart without four side-by-side buttons. f16
+    // variants are marked disabled (with a hint) when the user's WebGPU
+    // adapter lacks the `shader-f16` feature — the shader fails to compile
+    // otherwise.
     const wrap = el('div', { class: 'mp-quality' });
     const select = el('select', {
         class: 'mp-quality-select',
@@ -430,26 +588,180 @@ function renderQualityPicker(group, initialVariant) {
         onClick: (e) => e.stopPropagation(),
     });
     for (const v of group.variants) {
+        const blocked = !f16Supported && requiresShaderF16(v.quant);
+        const label = blocked
+            ? `${v.label} (${v.sublabel}) — needs shader-f16`
+            : `${v.label} (${v.sublabel})`;
         const opt = el('option', {
             value: v.id,
             'data-variant-id': v.id,
+            'data-needs-f16': blocked ? 'true' : undefined,
+            disabled: blocked ? '' : undefined,
             selected: v.id === initialVariant?.id ? '' : undefined,
-        }, [`${v.label} (${v.sublabel})`]);
+        }, [label]);
         select.appendChild(opt);
     }
     wrap.appendChild(select);
     return wrap;
 }
 
+/**
+ * Tier-card landing view: three big "brain" cards + a "Custom brain" panel
+ * (the full table) gated behind a link. Reuses the same `ctx.loading` /
+ * `ctx.active` state and the same `performLoad` / `performUnload` handlers
+ * the table view drives, so the load lifecycle is identical from either path.
+ *
+ * `ctx.onLoadModelId(modelId)` and `ctx.onUnload()` are the entry points;
+ * `ctx.onSwitchView('custom')` flips the picker to the full table.
+ */
+function renderTierCards(ctx) {
+    const wrap = el('div', { class: 'mp-tiers' });
+
+    // Intro line — sets the brain-metaphor expectation.
+    wrap.appendChild(el('p', { class: 'mp-tiers-intro' }, [
+        'Pick a brain to load into your browser. Bigger = smarter + slower download.',
+    ]));
+
+    const grid = el('div', { class: 'mp-tier-grid' });
+
+    // `ctx.tiers` is the f16/f32-resolved list from openPicker; fall back to
+    // raw BRAIN_TIERS with the f32 variant in case someone calls
+    // renderTierCards in isolation (e.g. tests).
+    const tiers = ctx.tiers
+        || BRAIN_TIERS.map((t) => resolveTierVariant(t, false));
+
+    for (const tier of tiers) {
+        const resolved = resolveTierGroupVariant(ctx.groups, tier.model_id);
+        const available = !!resolved;
+        const isActive = ctx.active === tier.model_id;
+        const isCached = available && ctx.cached.has(resolved.group.base_id);
+        const isLoading = ctx.loading?.variantId === tier.model_id;
+        const anyLoad = ctx.loading?.variantId != null;
+
+        const cardClasses = ['mp-tier-card'];
+        if (tier.recommended) cardClasses.push('is-recommended');
+        if (isActive) cardClasses.push('is-active');
+        if (isLoading) cardClasses.push('is-loading');
+        if (!available) cardClasses.push('is-unavailable');
+
+        const card = el('div', {
+            class: cardClasses.join(' '),
+            'data-tier-id': tier.id,
+            'data-model-id': tier.model_id,
+        });
+
+        // Head: emoji + label + (optional) recommended badge.
+        const head = el('div', { class: 'mp-tier-head' }, [
+            el('span', { class: 'mp-tier-emoji' }, [tier.emoji]),
+            el('div', { class: 'mp-tier-titles' }, [
+                el('h3', { class: 'mp-tier-label' }, [tier.label]),
+                el('div', { class: 'mp-tier-sub' }, [`${tier.size_gb} GB · ${tier.model_id.split('-q')[0]}`]),
+            ]),
+        ]);
+        if (tier.recommended) {
+            head.appendChild(el('span', { class: 'mp-tier-badge' }, ['Recommended']));
+        }
+        card.appendChild(head);
+
+        card.appendChild(el('p', { class: 'mp-tier-tagline' }, [tier.tagline]));
+
+        // Progress (only while this tier is loading).
+        if (isLoading) {
+            const pct = ctx.loading?.percent;
+            card.appendChild(el('div', { class: 'mp-tier-progress' }, [
+                el('div', {
+                    class: 'mp-tier-progress-bar',
+                    style: typeof pct === 'number' ? `width: ${Math.max(0, Math.min(100, pct))}%` : 'width: 0%',
+                }),
+            ]));
+            card.appendChild(el('div', { class: 'mp-tier-progress-text' }, [ctx.loading?.text || 'Starting…']));
+        }
+
+        // Status — only render when there's something meaningful to say. An
+        // empty cold-state card just shows the Load button + no status text.
+        let status = null;
+        if (isActive) {
+            status = el('div', { class: 'mp-tier-status is-loaded' }, ['✓ Loaded']);
+        } else if (isCached) {
+            status = el('div', { class: 'mp-tier-status is-cached' }, ['✓ Cached']);
+        } else if (!available) {
+            status = el('div', { class: 'mp-tier-status is-unavailable' }, ['Not in this version']);
+        }
+        // While loading, the progress bar + text above the foot communicate
+        // the live state — no extra label needed in the foot row.
+
+        // Foot needs to render a placeholder element when status is null so
+        // the button stays right-aligned via space-between.
+        const statusSlot = status || el('div', { class: 'mp-tier-status-placeholder' });
+
+        let btn;
+        if (isLoading) {
+            btn = el('button', { class: 'mp-tier-btn primary', type: 'button', disabled: '' }, ['Loading…']);
+        } else if (isActive) {
+            btn = el('button', {
+                class: 'mp-tier-btn mp-tier-unload',
+                type: 'button',
+                disabled: anyLoad ? '' : undefined,
+                title: 'Release GPU memory (keeps cached files)',
+                onClick: () => ctx.onUnload?.(),
+            }, ['Unload']);
+        } else if (!available) {
+            btn = el('button', { class: 'mp-tier-btn primary', type: 'button', disabled: '' }, ['Unavailable']);
+        } else {
+            btn = el('button', {
+                class: 'mp-tier-btn primary',
+                type: 'button',
+                disabled: anyLoad ? '' : undefined,
+                onClick: () => ctx.onLoadModelId?.(tier.model_id),
+            }, ['Load brain']);
+        }
+
+        card.appendChild(el('div', { class: 'mp-tier-foot' }, [statusSlot, btn]));
+        grid.appendChild(card);
+    }
+
+    wrap.appendChild(grid);
+
+    // "Custom brain" escape hatch — drops into the full table view.
+    wrap.appendChild(el('div', { class: 'mp-tiers-footer' }, [
+        el('button', {
+            class: 'mp-tiers-more',
+            type: 'button',
+            onClick: () => ctx.onSwitchView?.('custom'),
+        }, ['Custom brain — browse all models →']),
+    ]));
+
+    return wrap;
+}
+
 export function renderPickerDom(ctx) {
-    // ctx: { groups, popularity, cached, active, selection, filters, onClose, onSelect, onLoad, onFiltersChange }
+    // ctx: { groups, popularity, cached, active, selection, filters, view,
+    //        onClose, onFiltersChange, onSwitchView, onLoadModelId, onUnload }
     const dialog = el('dialog', { id: 'model-picker' });
+    const view = ctx.view === 'custom' ? 'custom' : 'tiers';
 
     // Header
-    const header = el('div', { class: 'mp-header' }, [
-        el('h2', {}, ['Choose a model']),
+    const headerChildren = [
+        el('h2', {}, [view === 'custom' ? 'Choose a model' : 'Pick a brain']),
         el('button', { class: 'mp-close', 'aria-label': 'Close', onClick: ctx.onClose }, ['✕']),
-    ]);
+    ];
+    if (view === 'custom') {
+        // Show a back-to-tiers affordance only in the full-table view.
+        headerChildren.splice(1, 0, el('button', {
+            class: 'mp-back',
+            type: 'button',
+            'aria-label': 'Back to brain tiers',
+            onClick: () => ctx.onSwitchView?.('tiers'),
+        }, ['← Back']));
+    }
+    const header = el('div', { class: 'mp-header' }, headerChildren);
+
+    // Tier-card landing: short-circuit before building filters + table.
+    if (view === 'tiers') {
+        dialog.appendChild(header);
+        dialog.appendChild(renderTierCards(ctx));
+        return { dialog, grid: null, thead: null, summaryEl: null, loadBtn: null, filtersEl: null, view };
+    }
 
     // Filter row
     const filtersEl = el('div', { class: 'mp-filters' }, [
@@ -564,6 +876,19 @@ export function renderPickerDom(ctx) {
     // and the header's ✕ provides the cancel path.
 
     dialog.appendChild(header);
+    // shader-f16 warning banner — surfaces the GPU limitation up-front so the
+    // user understands why some Variant dropdown rows look greyed out.
+    if (ctx.f16Supported === false) {
+        dialog.appendChild(el('div', { class: 'mp-f16-banner' }, [
+            el('span', { class: 'mp-f16-banner-icon' }, ['⚠']),
+            el('span', {}, [
+                'Your GPU doesn\'t support the WebGPU ',
+                el('code', {}, ['shader-f16']),
+                ' feature. Variants using f16 quantization are disabled — ',
+                'pick an f32 variant instead.',
+            ]),
+        ]));
+    }
     dialog.appendChild(filtersEl);
     dialog.appendChild(tableWrap);
 
@@ -777,40 +1102,77 @@ function updateResultCount(filtersEl, total, visible, onClear) {
     }
 }
 
+/** Parse a percent value out of a WebLLM init-progress text like
+ *  "Loading model from cache[12/24]: 50% complete, 8 secs elapsed.". Returns
+ *  `null` when no integer percent is present. */
+function parsePercentFromText(text) {
+    if (typeof text !== 'string') return null;
+    const m = text.match(/(\d+(?:\.\d+)?)\s*%/);
+    if (m) return Math.max(0, Math.min(100, parseFloat(m[1])));
+    const frac = text.match(/\[(\d+)\/(\d+)\]/);
+    if (frac) {
+        const a = parseInt(frac[1], 10);
+        const b = parseInt(frac[2], 10);
+        if (b > 0) return Math.max(0, Math.min(100, (a / b) * 100));
+    }
+    return null;
+}
+
 /**
- * Open the model picker. Returns a Promise that resolves with
- *   { model_id }     when the user clicks Load
- *   null             when the user closes without choosing
+ * Open the model picker. The picker owns the full load/unload lifecycle while
+ * open: clicking Load downloads + loads in-modal with per-row progress;
+ * clicking Unload on the active row releases the engine; closing (✕/Esc) does
+ * NOT cancel a load in flight — it keeps running in the shared engine module.
  *
- * Caller is responsible for kicking off the actual model download with the
- * returned model_id — this picker only commits a selection.
+ * Caller provides:
+ *   loadEngine(modelId, onProgress) → Promise<void>
+ *   unloadEngine()                  → Promise<void>
+ *   getCurrentModelId()             → string|null  (read latest active model)
+ *   onActiveChange(modelId|null)    — invoked every time the active model
+ *                                      changes (on successful load or unload)
+ *
+ * Resolves with `{ model_id }` (the active model when the picker closes) or
+ * `null` if nothing is loaded at close time.
  */
 export async function openPicker({
     prebuiltList,
-    currentModelId = null,
+    getCurrentModelId = () => null,
+    loadEngine,
+    unloadEngine,
+    onActiveChange = () => {},
 } = {}) {
     const groups = groupModels(prebuiltList);
     const popularity = await fetchHfPopularity();
-    const { cached, active } = await getCachedAndActive(groups, currentModelId);
+    const currentModelId = getCurrentModelId();
+    const { cached } = await getCachedAndActive(groups, currentModelId);
+    let active = currentModelId;
+
+    // Resolve each brain tier to a concrete model_id based on whether the
+    // user's WebGPU adapter exposes `shader-f16`. This is a one-shot probe;
+    // the result feeds renderTierCards via ctx.tiers.
+    const f16Supported = await probeShaderF16();
+    const tiers = BRAIN_TIERS.map((t) => resolveTierVariant(t, f16Supported));
 
     let filters = readPersistedFilters();
     let selection = null; // { base_id, variant }
     const favorites = readPersistedFavorites();
 
+    // In-modal load state. Only one load may be in flight at a time.
+    let loading = null;       // { variantId, baseId, text, percent }
+    let errorForBase = null;  // last failure: which base_id
+    let errorText = null;     // last failure: message to surface
+
+    // Picker view mode. Default to the curated tier-card landing; the user can
+    // flip to the full table via the "Custom brain →" link.
+    let view = 'tiers';
+
     return new Promise((resolve) => {
         const ctx = {
             groups, popularity, cached, active, selection, filters, favorites,
-            onClose: () => close(null),
-            onSelect: () => {},
-            onLoad: () => {
-                if (!selection) return;
-                close({ model_id: selection.variant.id });
-            },
+            loading, errorForBase, errorText, view, tiers, f16Supported,
+            onClose: () => close(),
             onFiltersChange: (next) => {
                 filters = next;
-                // Keep ctx.filters live so per-render closures (e.g. the
-                // sortable header click handler) read fresh state on each
-                // click instead of the value captured at first render.
                 ctx.filters = filters;
                 writePersistedFilters(filters);
                 rerenderHeader();
@@ -820,23 +1182,150 @@ export async function openPicker({
                 if (favorites.has(baseId)) favorites.delete(baseId);
                 else favorites.add(baseId);
                 writePersistedFavorites(favorites);
-                rerenderGrid();
+                rerenderEverything();
             },
             onDeleteCached: async (group) => {
                 if (!window.confirm(`Delete cached ${group.base_id}?`)) return;
                 await deleteCachedModel(group);
-                const refresh = await getCachedAndActive(groups, currentModelId);
+                const refresh = await getCachedAndActive(groups, active);
                 cached.clear();
                 for (const id of refresh.cached) cached.add(id);
-                rerenderGrid();
+                rerenderEverything();
             },
+            onSwitchView: (next) => {
+                view = next === 'custom' ? 'custom' : 'tiers';
+                ctx.view = view;
+                rebuildDialogBody();
+            },
+            onLoadModelId: (modelId) => {
+                const found = resolveTierGroupVariant(groups, modelId);
+                if (found) performLoad(found.group, found.variant);
+            },
+            onUnload: () => performUnload(),
         };
 
         const dom = renderPickerDom(ctx);
         document.body.appendChild(dom.dialog);
 
+        // Switch views by rebuilding the dialog's children in place. The
+        // dialog element itself is preserved so the `close` listener stays
+        // attached and `showModal` doesn't need to fire again. In tier mode
+        // the body is fully rendered by renderPickerDom; in custom mode the
+        // table skeleton lands but rows are populated by rerenderGrid().
+        function rebuildDialogBody() {
+            syncCtx();
+            const fresh = renderPickerDom(ctx);
+            dom.dialog.replaceChildren(...fresh.dialog.children);
+            dom.grid = fresh.grid;
+            dom.thead = fresh.thead;
+            dom.summaryEl = fresh.summaryEl;
+            dom.loadBtn = fresh.loadBtn;
+            dom.filtersEl = fresh.filtersEl;
+            dom.view = fresh.view;
+            if (view === 'custom') rerenderGrid();
+        }
+
+        function syncCtx() {
+            ctx.active = active;
+            ctx.loading = loading;
+            ctx.errorForBase = errorForBase;
+            ctx.errorText = errorText;
+        }
+
+        async function performLoad(group, variant) {
+            if (loading) return; // another load already in flight
+            if (typeof loadEngine !== 'function') return;
+            errorForBase = null;
+            errorText = null;
+            loading = { variantId: variant.id, baseId: group.base_id, text: 'Starting…', percent: null };
+            syncCtx();
+            rerenderGrid();
+
+            const onProgress = (text) => {
+                // The picker may have closed mid-load; skip DOM updates if so.
+                if (!dom.dialog.isConnected) return;
+                if (!loading || loading.variantId !== variant.id) return;
+                loading.text = text || 'Downloading…';
+                loading.percent = parsePercentFromText(text);
+                // Lightweight in-place update: avoid full grid rerender on
+                // every progress tick (which would discard select/scroll).
+                updateRowProgressInPlace(group.base_id, loading);
+            };
+
+            try {
+                await loadEngine(variant.id, onProgress);
+                active = variant.id;
+                cached.add(group.base_id);
+                onActiveChange(active);
+            } catch (e) {
+                errorForBase = group.base_id;
+                errorText = String(e?.message ?? e);
+            } finally {
+                loading = null;
+                if (dom.dialog.isConnected) {
+                    syncCtx();
+                    rerenderGrid();
+                }
+            }
+        }
+
+        async function performUnload() {
+            if (loading) return;
+            if (typeof unloadEngine !== 'function') return;
+            try {
+                await unloadEngine();
+            } catch (_e) { /* unload is best-effort */ }
+            active = null;
+            onActiveChange(null);
+            syncCtx();
+            if (dom.dialog.isConnected) rerenderGrid();
+        }
+
+        function updateRowProgressInPlace(baseId, loadingState) {
+            // Update the per-row bar (custom-table view).
+            const row = dom.grid?.querySelector(
+                `tr.mp-row[data-base-id="${CSS.escape(baseId)}"]`,
+            );
+            if (row) {
+                const text = row.querySelector('.mp-load-progress-text');
+                const bar = row.querySelector('.mp-load-progress-bar');
+                if (text) text.textContent = loadingState.text || 'Downloading…';
+                if (bar) {
+                    const pct = loadingState.percent;
+                    bar.style.width = typeof pct === 'number'
+                        ? `${Math.max(0, Math.min(100, pct))}%`
+                        : '0%';
+                }
+            }
+            // Update the matching tier card (tier-card view). The tier card
+            // matches on the exact model_id, not the base_id, so we look it
+            // up by data-model-id.
+            const card = dom.dialog.querySelector(
+                `.mp-tier-card[data-model-id="${CSS.escape(loadingState.variantId)}"]`,
+            );
+            if (card) {
+                const text = card.querySelector('.mp-tier-progress-text');
+                const bar = card.querySelector('.mp-tier-progress-bar');
+                if (text) text.textContent = loadingState.text || 'Downloading…';
+                if (bar) {
+                    const pct = loadingState.percent;
+                    bar.style.width = typeof pct === 'number'
+                        ? `${Math.max(0, Math.min(100, pct))}%`
+                        : '0%';
+                }
+            }
+        }
+
         function rerenderGrid() {
+            // Tier-card view: rebuild only the .mp-tiers panel so the dialog
+            // children aren't disturbed.
+            if (view === 'tiers') {
+                const old = dom.dialog.querySelector('.mp-tiers');
+                if (old) old.replaceWith(renderTierCards(ctx));
+                return;
+            }
             const filtered = applyFilters(groups, filters, popularity, cached, favorites);
+            if (!dom.grid) return;
             dom.grid.innerHTML = '';
             if (filtered.length === 0) {
                 const emptyRow = el('tr', {}, [el('td', { colspan: '7', class: 'mp-empty' }, [
@@ -848,31 +1337,30 @@ export async function openPicker({
                 for (const g of filtered) {
                     const row = renderTableRow(g, {
                         cached, active, popularity, selection, favorites,
+                        loading, errorForBase, errorText, f16Supported,
                         onFavoriteToggle: ctx.onFavoriteToggle,
                         onDeleteCached: ctx.onDeleteCached,
                     });
-                    bindCardEvents(row, g);
+                    bindRowEvents(row, g);
                     dom.grid.appendChild(row);
                 }
             }
-            updateResultCount(dom.filtersEl, groups.length, filtered.length, clearFilters);
+            if (dom.filtersEl) {
+                updateResultCount(dom.filtersEl, groups.length, filtered.length, clearFilters);
+            }
         }
 
         function clearFilters() {
             filters = { ...DEFAULT_FILTERS };
             ctx.filters = filters;
             writePersistedFilters(filters);
-            // Reset filter UI by re-rendering the dialog from scratch is heavy;
-            // simpler: replace the dialog contents.
             const newDom = renderPickerDom({ ...ctx, filters });
             dom.dialog.replaceChildren(...newDom.dialog.children);
-            // Rebind references to the new DOM
             dom.grid = newDom.grid;
             dom.thead = newDom.thead;
             dom.summaryEl = newDom.summaryEl;
             dom.loadBtn = newDom.loadBtn;
             dom.filtersEl = newDom.filtersEl;
-            // Reset selection
             selection = null;
             ctx.selection = null;
             rerenderGrid();
@@ -882,44 +1370,57 @@ export async function openPicker({
             rerenderTableHeader(dom.thead, ctx);
         }
 
-        function bindCardEvents(row, group) {
+        function bindRowEvents(row, group) {
             const select = row.querySelector('.mp-quality-select');
             let currentVariant = group.variants.find((v) => v.id === select?.value)
-                || group.variants[Math.floor(group.variants.length / 2)]
-                || group.variants[0];
+                || pickInitialVariant(group, f16Supported);
+
+            const loadBtn = row.querySelector('.mp-load-btn');
+
+            const refreshLoadGate = () => {
+                if (!loadBtn) return;
+                const blocked = !f16Supported && requiresShaderF16(currentVariant?.quant);
+                loadBtn.disabled = !!(loading || blocked);
+                if (blocked) {
+                    loadBtn.title = 'shader-f16 not supported by your GPU — pick a different variant';
+                } else if (loading) {
+                    loadBtn.title = 'Another model is loading…';
+                } else {
+                    loadBtn.title = '';
+                }
+            };
 
             select?.addEventListener('change', () => {
                 currentVariant = group.variants.find((v) => v.id === select.value) || currentVariant;
                 const sizeEl = row.querySelector('.mp-size-value');
                 if (sizeEl) sizeEl.textContent = formatBytes(currentVariant.vram_mb);
+                refreshLoadGate();
             });
 
-            const downloadBtn = row.querySelector('.mp-download-btn');
-            downloadBtn?.addEventListener('click', () => {
-                selection = { base_id: group.base_id, variant: currentVariant };
-                ctx.selection = selection;
-                close({ model_id: currentVariant.id, mode: 'download' });
-            });
-
-            const loadBtn = row.querySelector('.mp-load-btn');
             loadBtn?.addEventListener('click', () => {
-                selection = { base_id: group.base_id, variant: currentVariant };
-                ctx.selection = selection;
-                close({ model_id: currentVariant.id, mode: 'load' });
+                if (loading) return;
+                if (!f16Supported && requiresShaderF16(currentVariant?.quant)) return;
+                performLoad(group, currentVariant);
+            });
+
+            const unloadBtn = row.querySelector('.mp-unload-btn');
+            unloadBtn?.addEventListener('click', () => {
+                if (loading) return;
+                performUnload();
             });
         }
 
-        function close(value) {
+        function close() {
             try { dom.dialog.close(); } catch (_e) {}
             dom.dialog.remove();
-            resolve(value);
+            resolve(active ? { model_id: active } : null);
         }
 
-        // Esc key closes via <dialog> default; we still need to clean up DOM
+        // Esc closes via <dialog> default; ensure we clean up DOM and resolve.
         dom.dialog.addEventListener('close', () => {
             if (dom.dialog.parentElement) {
                 dom.dialog.remove();
-                resolve(null);
+                resolve(active ? { model_id: active } : null);
             }
         });
 

--- a/site/model-picker.js
+++ b/site/model-picker.js
@@ -1252,11 +1252,13 @@ export async function openPicker({
                 updateRowProgressInPlace(group.base_id, loading);
             };
 
+            let loadOk = false;
             try {
                 await loadEngine(variant.id, onProgress);
                 active = variant.id;
                 cached.add(group.base_id);
                 onActiveChange(active);
+                loadOk = true;
             } catch (e) {
                 errorForBase = group.base_id;
                 errorText = String(e?.message ?? e);
@@ -1267,6 +1269,10 @@ export async function openPicker({
                     rerenderGrid();
                 }
             }
+            // Auto-close the picker on first successful load so the user
+            // lands back on the chat surface ready to type. Errors keep the
+            // picker open so the user can read the failure + retry.
+            if (loadOk && dom.dialog.isConnected) close();
         }
 
         async function performUnload() {

--- a/src/blocks/agent.rs
+++ b/src/blocks/agent.rs
@@ -5,7 +5,10 @@
 //!     Request:  { "user_message": "...", "messages": [...], "model_id"?, "uploads"?, "confirm_yes"? }
 //!     Response: text/event-stream:
 //!       event: token        data: { "delta": "..." }                    — assistant LLM text
-//!       event: tool_result  data: { "id", "result", "for_ui"? }         — skill output
+//!       event: tool_result  data: { "id", "input", "result", "for_ui"? } — skill output
+//!         `input`  — the extracted params dispatched to the skill (lets
+//!                    the UI show users what the LLM understood from their
+//!                    slash command in a side-by-side Input/Output view).
 //!       event: confirm      data: { "question", "yes": {cmd, params} }  — PR 5 stub
 //!       event: done         data: { "reason": "stop" | "error", "error"? }
 //!
@@ -591,6 +594,7 @@ async fn run_skill_dispatch(
                 "tool_result",
                 &serde_json::json!({
                     "id": id,
+                    "input": params,
                     "result": format!(r#"{{"error":"unknown_ref","message":"no attachment for ref {ref_id:?}"}}"#),
                 }),
             ));
@@ -626,6 +630,7 @@ async fn run_skill_dispatch(
 
     let mut payload = serde_json::json!({
         "id": id,
+        "input": params,
         "result": outcome.for_llm,
     });
     if let Some(ref for_ui) = outcome.for_ui {


### PR DESCRIPTION
## Summary

Three feature commits stacking on top of each other, all in service of making the slash-command chat UX friendlier on the user's first 30 seconds.

### `feat(picker, chat): tier-card landing, single Load button, AI-formatted slash results`

**Picker redesign**
- Three brain tiers on a centered card-style modal (Small / Medium / Big, Qwen2.5-0.5B / 1.5B / 3B). Medium is pre-flagged **Recommended**. "Custom brain →" link drops into the existing full table with a **← Back** affordance.
- Single Load/Unload button per row replaces the dual Download + Load. The picker now owns the full load lifecycle in-modal: progress bar in-card, other rows disabled while one is loading, click **Unload** to release GPU memory while keeping cached weights.
- Probe `device.features.has('shader-f16')` once at open time. Tiers map to f16 quants when supported (smaller download) and f32 otherwise (works on every WebGPU device). In the custom view, individual f16 variants are disabled in the Variant dropdown with a "— needs shader-f16" suffix, and a banner explains the GPU limitation.
- Tiny favorites star (was rendering as a big white card); stable 230 px card height so the progress bar doesn't shift the layout when loading starts; empty-state status text removed from cold cards.
- Modal: no longer full-screen — centered card, rounded edges, soft drop shadow, blurred backdrop. Falls back to full-screen below 720 px.

**Chat polish**
- Cycling "thinking… / pondering… / noodling…" placeholder while waiting for the first token or tool_result; stops on first content.
- Slash-skill output routed through a cheap deterministic template first (calculator → "**8**", clock → "**YYYY-MM-DD HH:MM:SS UTC**", web-fetch → "**200** from \`url\` — N chars, …", generic error → "**Error:** …"). Only complex shapes fall through to a follow-up LLM-format pass.
- "{ }" raw-output button next to each formatted slash answer opens a modal popup with the pretty-printed JSON + Copy.
- Empty-state copy ("I can't do much without a brain…") swaps to "Ready — ask anything below." once a brain is loaded; restores on unload.

### `feat(chat): raw popup tabs (Input/Output) + LLM correction on skill errors`

- `agent.rs` now emits `input` (the params dispatched to the skill) in tool_result SSE events.
- Raw popup is a two-tab modal (**Input** | **Output**). Users can flip between what the LLM extracted from their message and what the skill returned — invaluable for debugging cases like \`/calculator what is 2 times t2?\` where the model reads "t2" as a variable.
- New `suggestCorrectionWithLLM` fires whenever a parsed slash result carries `error: string`. Prompts the loaded model with the user's original message + the error and asks for a one-sentence plain-language correction. Cycling opener: `figuring…`. Falls back to `Error: <text>` if no model is loaded.

### `feat(picker, chat): auto-close picker on load success + Enter-to-send`

- Picker auto-closes after a successful load. Errors keep it open so the user can read the failure + retry.
- Plain Enter in the composer submits the form; Shift+Enter still inserts a newline; slash-autocomplete still wins Enter when its dropdown is up (guarded via `defaultPrevented`).

## Dependencies

Requires [wafer-run #65](https://github.com/wafer-run/wafer-run/pull/65) for the runtime-side fixes — without it, \`/clock\` returns 1970-01-01 and any skill that calls another block (\`/web-fetch\`, \`/image-*\`, \`/video-*\`) fails the new interface-action validation.

## Test plan
- [x] Empty-state CTA opens the new tier-card picker
- [x] Load brain → in-card progress bar, other rows disabled, completes → "✓ Loaded" + Unload button → **picker auto-closes**
- [x] Empty-state copy swaps to "Ready — ask anything below."
- [x] **Enter** in the composer submits; **Shift+Enter** inserts newline
- [x] \`/clock\` chat flow: bubble shows formatted timestamp + \`{ }\` button
- [x] \`/calculator 9+9\` chat flow: bubble shows "18", popup tabs show Input \`{expr:"9+9"}\` / Output \`{result:18}\`
- [x] \`/calculator what is 2 times t2?\`: LLM correction follow-up runs ("figuring…"), bubble shows plain-language response, popup tabs reveal the diagnostic
- [x] Custom view: banner appears when shader-f16 is missing, f16 variants in the Variant dropdown are disabled with "— needs shader-f16" suffix
- [x] 23/23 unit tests pass (\`node --test tests/unit/model-picker.test.mjs\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)