### PR TITLE
refactor(blocks): dedup fetch/load helpers into block-utils

### DIFF
--- a/block-utils/src/lib.rs
+++ b/block-utils/src/lib.rs
@@ -3,6 +3,9 @@
 //! Pulled out of the duplicated copies in `blocks/image-*` and `blocks/video-*`.
 //! Each block crate depends on this via a `path = "../../block-utils"` dep.
 
+#[cfg(target_arch = "wasm32")]
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use wafer_block::core_types::{Message, WaferError};
 use wafer_sdk::ErrorCode;
@@ -175,6 +178,160 @@ fn hex_val(b: u8) -> Option<u8> {
         b'A'..=b'F' => Some(b - b'A' + 10),
         _ => None,
     }
+}
+
+// ---------------------------------------------------------------------------
+// AssetKind — image vs video, controls MIME prefix, expected-label, kind-label,
+// and default filename used by `fetch_from_url` / `load_from_attachment`.
+// Pulled out of the duplicated fetch helpers in blocks/image-* and blocks/video-*.
+// ---------------------------------------------------------------------------
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum AssetKind {
+    Image,
+    Video,
+}
+
+// Methods are only consumed by the wasm-gated fetch/load functions below
+// (plus tests). On host non-test builds, they look unused — silence the lint
+// rather than peppering each method with cfg attributes.
+#[allow(dead_code)]
+impl AssetKind {
+    pub(crate) fn mime_prefix(self) -> &'static str {
+        match self {
+            Self::Image => "image/",
+            Self::Video => "video/",
+        }
+    }
+
+    pub(crate) fn expected_url_label(self) -> &'static str {
+        match self {
+            Self::Image => "image/*",
+            Self::Video => "video/*",
+        }
+    }
+
+    pub(crate) fn expected_attachment_label(self) -> &'static str {
+        match self {
+            Self::Image => "image/* attachment",
+            Self::Video => "video/* attachment",
+        }
+    }
+
+    pub(crate) fn too_large_label(self) -> &'static str {
+        match self {
+            Self::Image => "input image",
+            Self::Video => "input video",
+        }
+    }
+
+    pub(crate) fn default_filename(self) -> &'static str {
+        match self {
+            Self::Image => "image",
+            Self::Video => "video",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fetch / load — bytes from URL or attachment, validated to a given AssetKind.
+// Both return (bytes, mime, filename).
+// ---------------------------------------------------------------------------
+
+/// GET `url`, validate `Content-Type` matches `kind`, enforce `max_bytes` against
+/// both the `Content-Length` header (if present) and the body. Returns the bytes,
+/// the normalized lowercase MIME (parameters stripped), and a filename derived
+/// from the URL's last path segment.
+///
+/// wasm-only because `wafer_sdk::clients::network` is wasm-gated in the SDK.
+#[cfg(target_arch = "wasm32")]
+pub fn fetch_from_url(
+    url: &str,
+    kind: AssetKind,
+    max_bytes: usize,
+) -> Result<(Vec<u8>, String, String), SkillError> {
+    let net = wafer_sdk::clients::network::do_request("GET", url, &HashMap::new(), None)?;
+    if net.status_code >= 400 {
+        return Err(SkillError::HttpStatus {
+            status: net.status_code,
+            url: url.to_string(),
+        });
+    }
+    let raw_mime = net
+        .headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+        .and_then(|(_, vs)| vs.first().cloned())
+        .unwrap_or_else(|| "application/octet-stream".to_string());
+    let mime: String = raw_mime
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_lowercase();
+    if !mime.starts_with(kind.mime_prefix()) {
+        return Err(SkillError::UnexpectedMime {
+            expected: kind.expected_url_label(),
+            actual: mime,
+        });
+    }
+    if let Some(cl) = net
+        .headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
+        .and_then(|(_, vs)| vs.first())
+        .and_then(|v| v.trim().parse::<usize>().ok())
+    {
+        if cl > max_bytes {
+            return Err(SkillError::TooLarge {
+                kind: kind.too_large_label(),
+                bytes: cl,
+                cap: max_bytes,
+            });
+        }
+    }
+    if net.body.len() > max_bytes {
+        return Err(SkillError::TooLarge {
+            kind: kind.too_large_label(),
+            bytes: net.body.len(),
+            cap: max_bytes,
+        });
+    }
+    let filename = derive_filename(url, kind.default_filename());
+    Ok((net.body, mime, filename))
+}
+
+/// Look up attachment `id`, validate its mime matches `kind`, enforce `max_bytes`.
+/// Returns the bytes, the attachment's mime, and its filename (falling back to
+/// `kind`'s default if the attachment carries none).
+///
+/// wasm-only because `wafer_sdk::lookup_attachment` is wasm-gated in the SDK.
+#[cfg(target_arch = "wasm32")]
+pub fn load_from_attachment(
+    id: &str,
+    kind: AssetKind,
+    max_bytes: usize,
+) -> Result<(Vec<u8>, String, String), SkillError> {
+    let att = wafer_sdk::lookup_attachment(id)
+        .map_err(|e| SkillError::Serialize(e.to_string()))?
+        .ok_or_else(|| SkillError::AttachmentNotFound(id.to_string()))?;
+    if !att.mime.starts_with(kind.mime_prefix()) {
+        return Err(SkillError::UnexpectedMime {
+            expected: kind.expected_attachment_label(),
+            actual: att.mime,
+        });
+    }
+    if att.bytes.len() > max_bytes {
+        return Err(SkillError::TooLarge {
+            kind: kind.too_large_label(),
+            bytes: att.bytes.len(),
+            cap: max_bytes,
+        });
+    }
+    let filename = att
+        .filename
+        .unwrap_or_else(|| kind.default_filename().to_string());
+    Ok((att.bytes, att.mime, filename))
 }
 
 // ---------------------------------------------------------------------------
@@ -374,6 +531,26 @@ mod tests {
         let we: WaferError = SkillError::Wafer(inner).into();
         assert_eq!(we.code, ErrorCode::UNAVAILABLE);
         assert_eq!(we.message, "underlying");
+    }
+
+    #[test]
+    fn asset_kind_image_labels() {
+        let k = AssetKind::Image;
+        assert_eq!(k.mime_prefix(), "image/");
+        assert_eq!(k.expected_url_label(), "image/*");
+        assert_eq!(k.expected_attachment_label(), "image/* attachment");
+        assert_eq!(k.too_large_label(), "input image");
+        assert_eq!(k.default_filename(), "image");
+    }
+
+    #[test]
+    fn asset_kind_video_labels() {
+        let k = AssetKind::Video;
+        assert_eq!(k.mime_prefix(), "video/");
+        assert_eq!(k.expected_url_label(), "video/*");
+        assert_eq!(k.expected_attachment_label(), "video/* attachment");
+        assert_eq!(k.too_large_label(), "input video");
+        assert_eq!(k.default_filename(), "video");
     }
 
     #[test]

--- a/blocks/image-convert/src/lib.rs
+++ b/blocks/image-convert/src/lib.rs
@@ -5,15 +5,16 @@
 // full rationale.
 #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
 
-use std::collections::HashMap;
-
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use gizza_ai_block_utils::{
-    derive_filename, dispatch_ffmpeg_runtime, mime_to_ext, pick_source, Envelope, FfmpegReq,
-    FfmpegResp, ForUi, SkillError, SkillResultExt, Source,
+    dispatch_ffmpeg_runtime, mime_to_ext, pick_source, AssetKind, Envelope, FfmpegReq, FfmpegResp,
+    ForUi, SkillError, SkillResultExt, Source,
 };
 use serde::Deserialize;
 use wafer_sdk::*;
+
+#[cfg(target_arch = "wasm32")]
+use gizza_ai_block_utils::{fetch_from_url, load_from_attachment};
 
 const MAX_INPUT_BYTES: usize = 4 * 1024 * 1024;
 const MAX_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
@@ -118,8 +119,8 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
 
     let (input_bytes, in_mime, in_filename) =
         match pick_source(args.url.as_deref(), args.r#ref.as_deref()).invalid_args("image-convert")? {
-            Source::Url(u) => fetch_image_from_url(&u)?,
-            Source::Ref(id) => load_image_from_attachment(&id)?,
+            Source::Url(u) => fetch_from_url(&u, AssetKind::Image, MAX_INPUT_BYTES)?,
+            Source::Ref(id) => load_from_attachment(&id, AssetKind::Image, MAX_INPUT_BYTES)?,
         };
 
     let in_ext = mime_to_ext(&in_mime).ok_or_else(|| {
@@ -171,81 +172,6 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
         },
     };
     serde_json::to_vec(&env).map_err(|e| SkillError::Serialize(format!("serialize envelope: {e}")))
-}
-
-#[cfg(target_arch = "wasm32")]
-fn fetch_image_from_url(url: &str) -> Result<(Vec<u8>, String, String), SkillError> {
-    let net = wafer_sdk::clients::network::do_request("GET", url, &HashMap::new(), None)?;
-    if net.status_code >= 400 {
-        return Err(SkillError::HttpStatus {
-            status: net.status_code,
-            url: url.to_string(),
-        });
-    }
-    let raw_mime = net
-        .headers
-        .iter()
-        .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
-        .and_then(|(_, vs)| vs.first().cloned())
-        .unwrap_or_else(|| "application/octet-stream".to_string());
-    let mime: String = raw_mime
-        .split(';')
-        .next()
-        .unwrap_or("")
-        .trim()
-        .to_lowercase();
-    if !mime.starts_with("image/") {
-        return Err(SkillError::UnexpectedMime {
-            expected: "image/*",
-            actual: mime,
-        });
-    }
-    if let Some(cl) = net
-        .headers
-        .iter()
-        .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
-        .and_then(|(_, vs)| vs.first())
-        .and_then(|v| v.trim().parse::<usize>().ok())
-    {
-        if cl > MAX_INPUT_BYTES {
-            return Err(SkillError::TooLarge {
-                kind: "input image",
-                bytes: cl,
-                cap: MAX_INPUT_BYTES,
-            });
-        }
-    }
-    if net.body.len() > MAX_INPUT_BYTES {
-        return Err(SkillError::TooLarge {
-            kind: "input image",
-            bytes: net.body.len(),
-            cap: MAX_INPUT_BYTES,
-        });
-    }
-    let filename = derive_filename(url, "image");
-    Ok((net.body, mime, filename))
-}
-
-#[cfg(target_arch = "wasm32")]
-fn load_image_from_attachment(id: &str) -> Result<(Vec<u8>, String, String), SkillError> {
-    let att = wafer_sdk::lookup_attachment(id)
-        .map_err(|e| SkillError::Serialize(e.to_string()))?
-        .ok_or_else(|| SkillError::AttachmentNotFound(id.to_string()))?;
-    if !att.mime.starts_with("image/") {
-        return Err(SkillError::UnexpectedMime {
-            expected: "image/* attachment",
-            actual: att.mime,
-        });
-    }
-    if att.bytes.len() > MAX_INPUT_BYTES {
-        return Err(SkillError::TooLarge {
-            kind: "input image",
-            bytes: att.bytes.len(),
-            cap: MAX_INPUT_BYTES,
-        });
-    }
-    let filename = att.filename.unwrap_or_else(|| "image".into());
-    Ok((att.bytes, att.mime, filename))
 }
 
 #[cfg(test)]

--- a/blocks/image-crop/src/lib.rs
+++ b/blocks/image-crop/src/lib.rs
@@ -5,15 +5,16 @@
 // full rationale.
 #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
 
-use std::collections::HashMap;
-
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use gizza_ai_block_utils::{
-    derive_filename, dispatch_ffmpeg_runtime, mime_to_ext, pick_source, Envelope, FfmpegReq,
-    FfmpegResp, ForUi, SkillError, SkillResultExt, Source,
+    dispatch_ffmpeg_runtime, mime_to_ext, pick_source, AssetKind, Envelope, FfmpegReq, FfmpegResp,
+    ForUi, SkillError, SkillResultExt, Source,
 };
 use serde::Deserialize;
 use wafer_sdk::*;
+
+#[cfg(target_arch = "wasm32")]
+use gizza_ai_block_utils::{fetch_from_url, load_from_attachment};
 
 const MAX_INPUT_BYTES: usize = 4 * 1024 * 1024;
 const MAX_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
@@ -95,8 +96,8 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
 
     let (input_bytes, mime, in_filename) =
         match pick_source(args.url.as_deref(), args.r#ref.as_deref()).invalid_args("image-crop")? {
-            Source::Url(u) => fetch_image_from_url(&u)?,
-            Source::Ref(id) => load_image_from_attachment(&id)?,
+            Source::Url(u) => fetch_from_url(&u, AssetKind::Image, MAX_INPUT_BYTES)?,
+            Source::Ref(id) => load_from_attachment(&id, AssetKind::Image, MAX_INPUT_BYTES)?,
         };
 
     let ext = mime_to_ext(&mime).ok_or_else(|| {
@@ -148,81 +149,6 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
         },
     };
     serde_json::to_vec(&env).map_err(|e| SkillError::Serialize(format!("serialize envelope: {e}")))
-}
-
-#[cfg(target_arch = "wasm32")]
-fn fetch_image_from_url(url: &str) -> Result<(Vec<u8>, String, String), SkillError> {
-    let net = wafer_sdk::clients::network::do_request("GET", url, &HashMap::new(), None)?;
-    if net.status_code >= 400 {
-        return Err(SkillError::HttpStatus {
-            status: net.status_code,
-            url: url.to_string(),
-        });
-    }
-    let raw_mime = net
-        .headers
-        .iter()
-        .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
-        .and_then(|(_, vs)| vs.first().cloned())
-        .unwrap_or_else(|| "application/octet-stream".to_string());
-    let mime: String = raw_mime
-        .split(';')
-        .next()
-        .unwrap_or("")
-        .trim()
-        .to_lowercase();
-    if !mime.starts_with("image/") {
-        return Err(SkillError::UnexpectedMime {
-            expected: "image/*",
-            actual: mime,
-        });
-    }
-    if let Some(cl) = net
-        .headers
-        .iter()
-        .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
-        .and_then(|(_, vs)| vs.first())
-        .and_then(|v| v.trim().parse::<usize>().ok())
-    {
-        if cl > MAX_INPUT_BYTES {
-            return Err(SkillError::TooLarge {
-                kind: "input image",
-                bytes: cl,
-                cap: MAX_INPUT_BYTES,
-            });
-        }
-    }
-    if net.body.len() > MAX_INPUT_BYTES {
-        return Err(SkillError::TooLarge {
-            kind: "input image",
-            bytes: net.body.len(),
-            cap: MAX_INPUT_BYTES,
-        });
-    }
-    let filename = derive_filename(url, "image");
-    Ok((net.body, mime, filename))
-}
-
-#[cfg(target_arch = "wasm32")]
-fn load_image_from_attachment(id: &str) -> Result<(Vec<u8>, String, String), SkillError> {
-    let att = wafer_sdk::lookup_attachment(id)
-        .map_err(|e| SkillError::Serialize(e.to_string()))?
-        .ok_or_else(|| SkillError::AttachmentNotFound(id.to_string()))?;
-    if !att.mime.starts_with("image/") {
-        return Err(SkillError::UnexpectedMime {
-            expected: "image/* attachment",
-            actual: att.mime,
-        });
-    }
-    if att.bytes.len() > MAX_INPUT_BYTES {
-        return Err(SkillError::TooLarge {
-            kind: "input image",
-            bytes: att.bytes.len(),
-            cap: MAX_INPUT_BYTES,
-        });
-    }
-    let filename = att.filename.unwrap_or_else(|| "image".into());
-    Ok((att.bytes, att.mime, filename))
 }
 
 #[cfg(test)]

--- a/blocks/image-resize/src/lib.rs
+++ b/blocks/image-resize/src/lib.rs
@@ -8,15 +8,16 @@
 // tests below can exercise them.
 #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
 
-use std::collections::HashMap;
-
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use gizza_ai_block_utils::{
-    derive_filename, dispatch_ffmpeg_runtime, mime_to_ext, pick_source, Envelope, FfmpegReq,
-    FfmpegResp, ForUi, SkillError, SkillResultExt, Source,
+    dispatch_ffmpeg_runtime, mime_to_ext, pick_source, AssetKind, Envelope, FfmpegReq, FfmpegResp,
+    ForUi, SkillError, SkillResultExt, Source,
 };
 use serde::Deserialize;
 use wafer_sdk::*;
+
+#[cfg(target_arch = "wasm32")]
+use gizza_ai_block_utils::{fetch_from_url, load_from_attachment};
 
 const MAX_INPUT_BYTES: usize = 4 * 1024 * 1024; // 4 MiB
 const MAX_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
@@ -142,8 +143,8 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
     // 2. Resolve source — URL fetch or attachment lookup.
     let (input_bytes, mime, in_filename) =
         match pick_source(args.url.as_deref(), args.r#ref.as_deref()).invalid_args("image-resize")? {
-            Source::Url(u) => fetch_image_from_url(&u)?,
-            Source::Ref(id) => load_image_from_attachment(&id)?,
+            Source::Url(u) => fetch_from_url(&u, AssetKind::Image, MAX_INPUT_BYTES)?,
+            Source::Ref(id) => load_from_attachment(&id, AssetKind::Image, MAX_INPUT_BYTES)?,
         };
 
     // 3. Build ffmpeg argv.
@@ -195,83 +196,6 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
         },
     };
     serde_json::to_vec(&env).map_err(|e| SkillError::Serialize(format!("serialize envelope: {e}")))
-}
-
-/// Fetch `url`, validate it's an image, return `(bytes, mime, filename)`.
-#[cfg(target_arch = "wasm32")]
-fn fetch_image_from_url(url: &str) -> Result<(Vec<u8>, String, String), SkillError> {
-    let net = wafer_sdk::clients::network::do_request("GET", url, &HashMap::new(), None)?;
-    if net.status_code >= 400 {
-        return Err(SkillError::HttpStatus {
-            status: net.status_code,
-            url: url.to_string(),
-        });
-    }
-    let raw_mime = net
-        .headers
-        .iter()
-        .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
-        .and_then(|(_, vs)| vs.first().cloned())
-        .unwrap_or_else(|| "application/octet-stream".to_string());
-    let mime: String = raw_mime
-        .split(';')
-        .next()
-        .unwrap_or("")
-        .trim()
-        .to_lowercase();
-    if !mime.starts_with("image/") {
-        return Err(SkillError::UnexpectedMime {
-            expected: "image/*",
-            actual: mime,
-        });
-    }
-    if let Some(cl) = net
-        .headers
-        .iter()
-        .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
-        .and_then(|(_, vs)| vs.first())
-        .and_then(|v| v.trim().parse::<usize>().ok())
-    {
-        if cl > MAX_INPUT_BYTES {
-            return Err(SkillError::TooLarge {
-                kind: "input image",
-                bytes: cl,
-                cap: MAX_INPUT_BYTES,
-            });
-        }
-    }
-    if net.body.len() > MAX_INPUT_BYTES {
-        return Err(SkillError::TooLarge {
-            kind: "input image",
-            bytes: net.body.len(),
-            cap: MAX_INPUT_BYTES,
-        });
-    }
-    let filename = derive_filename(url, "image");
-    Ok((net.body, mime, filename))
-}
-
-/// Look up attachment `id`, validate it's an image, return `(bytes, mime, filename)`.
-#[cfg(target_arch = "wasm32")]
-fn load_image_from_attachment(id: &str) -> Result<(Vec<u8>, String, String), SkillError> {
-    let att = wafer_sdk::lookup_attachment(id)
-        .map_err(|e| SkillError::Serialize(e.to_string()))?
-        .ok_or_else(|| SkillError::AttachmentNotFound(id.to_string()))?;
-    if !att.mime.starts_with("image/") {
-        return Err(SkillError::UnexpectedMime {
-            expected: "image/* attachment",
-            actual: att.mime,
-        });
-    }
-    if att.bytes.len() > MAX_INPUT_BYTES {
-        return Err(SkillError::TooLarge {
-            kind: "input image",
-            bytes: att.bytes.len(),
-            cap: MAX_INPUT_BYTES,
-        });
-    }
-    let filename = att.filename.unwrap_or_else(|| "image".into());
-    Ok((att.bytes, att.mime, filename))
 }
 
 #[cfg(test)]

--- a/blocks/video-frame-extract/src/lib.rs
+++ b/blocks/video-frame-extract/src/lib.rs
@@ -5,15 +5,16 @@
 // full rationale.
 #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
 
-use std::collections::HashMap;
-
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use gizza_ai_block_utils::{
-    derive_filename, dispatch_ffmpeg_runtime, mime_to_ext, pick_source, Envelope, FfmpegReq,
-    FfmpegResp, ForUi, SkillError, SkillResultExt, Source,
+    dispatch_ffmpeg_runtime, mime_to_ext, pick_source, AssetKind, Envelope, FfmpegReq, FfmpegResp,
+    ForUi, SkillError, SkillResultExt, Source,
 };
 use serde::Deserialize;
 use wafer_sdk::*;
+
+#[cfg(target_arch = "wasm32")]
+use gizza_ai_block_utils::{fetch_from_url, load_from_attachment};
 
 const MAX_INPUT_BYTES: usize = 10 * 1024 * 1024;
 const MAX_OUTPUT_BYTES: usize = 10 * 1024 * 1024;
@@ -96,8 +97,8 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
         match pick_source(args.url.as_deref(), args.r#ref.as_deref())
             .invalid_args("video-frame-extract")?
         {
-            Source::Url(u) => fetch_video_from_url(&u)?,
-            Source::Ref(id) => load_video_from_attachment(&id)?,
+            Source::Url(u) => fetch_from_url(&u, AssetKind::Video, MAX_INPUT_BYTES)?,
+            Source::Ref(id) => load_from_attachment(&id, AssetKind::Video, MAX_INPUT_BYTES)?,
         };
 
     let in_ext = mime_to_ext(&in_mime).unwrap_or("bin");
@@ -149,81 +150,6 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
         },
     };
     serde_json::to_vec(&env).map_err(|e| SkillError::Serialize(format!("serialize envelope: {e}")))
-}
-
-#[cfg(target_arch = "wasm32")]
-fn fetch_video_from_url(url: &str) -> Result<(Vec<u8>, String, String), SkillError> {
-    let net = wafer_sdk::clients::network::do_request("GET", url, &HashMap::new(), None)?;
-    if net.status_code >= 400 {
-        return Err(SkillError::HttpStatus {
-            status: net.status_code,
-            url: url.to_string(),
-        });
-    }
-    let raw_mime = net
-        .headers
-        .iter()
-        .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
-        .and_then(|(_, vs)| vs.first().cloned())
-        .unwrap_or_else(|| "application/octet-stream".to_string());
-    let mime: String = raw_mime
-        .split(';')
-        .next()
-        .unwrap_or("")
-        .trim()
-        .to_lowercase();
-    if !mime.starts_with("video/") {
-        return Err(SkillError::UnexpectedMime {
-            expected: "video/*",
-            actual: mime,
-        });
-    }
-    if let Some(cl) = net
-        .headers
-        .iter()
-        .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
-        .and_then(|(_, vs)| vs.first())
-        .and_then(|v| v.trim().parse::<usize>().ok())
-    {
-        if cl > MAX_INPUT_BYTES {
-            return Err(SkillError::TooLarge {
-                kind: "input video",
-                bytes: cl,
-                cap: MAX_INPUT_BYTES,
-            });
-        }
-    }
-    if net.body.len() > MAX_INPUT_BYTES {
-        return Err(SkillError::TooLarge {
-            kind: "input video",
-            bytes: net.body.len(),
-            cap: MAX_INPUT_BYTES,
-        });
-    }
-    let filename = derive_filename(url, "video");
-    Ok((net.body, mime, filename))
-}
-
-#[cfg(target_arch = "wasm32")]
-fn load_video_from_attachment(id: &str) -> Result<(Vec<u8>, String, String), SkillError> {
-    let att = wafer_sdk::lookup_attachment(id)
-        .map_err(|e| SkillError::Serialize(e.to_string()))?
-        .ok_or_else(|| SkillError::AttachmentNotFound(id.to_string()))?;
-    if !att.mime.starts_with("video/") {
-        return Err(SkillError::UnexpectedMime {
-            expected: "video/* attachment",
-            actual: att.mime,
-        });
-    }
-    if att.bytes.len() > MAX_INPUT_BYTES {
-        return Err(SkillError::TooLarge {
-            kind: "input video",
-            bytes: att.bytes.len(),
-            cap: MAX_INPUT_BYTES,
-        });
-    }
-    let filename = att.filename.unwrap_or_else(|| "video".into());
-    Ok((att.bytes, att.mime, filename))
 }
 
 #[cfg(test)]

--- a/blocks/video-transcode/src/lib.rs
+++ b/blocks/video-transcode/src/lib.rs
@@ -5,15 +5,16 @@
 // full rationale.
 #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
 
-use std::collections::HashMap;
-
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use gizza_ai_block_utils::{
-    derive_filename, dispatch_ffmpeg_runtime, mime_to_ext, pick_source, Envelope, FfmpegReq,
-    FfmpegResp, ForUi, SkillError, SkillResultExt, Source,
+    dispatch_ffmpeg_runtime, mime_to_ext, pick_source, AssetKind, Envelope, FfmpegReq, FfmpegResp,
+    ForUi, SkillError, SkillResultExt, Source,
 };
 use serde::Deserialize;
 use wafer_sdk::*;
+
+#[cfg(target_arch = "wasm32")]
+use gizza_ai_block_utils::{fetch_from_url, load_from_attachment};
 
 const MAX_INPUT_BYTES: usize = 10 * 1024 * 1024;
 const MAX_OUTPUT_BYTES: usize = 10 * 1024 * 1024;
@@ -139,8 +140,8 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
 
     let (input_bytes, in_mime, in_filename) =
         match pick_source(args.url.as_deref(), args.r#ref.as_deref()).invalid_args("video-transcode")? {
-            Source::Url(u) => fetch_video_from_url(&u)?,
-            Source::Ref(id) => load_video_from_attachment(&id)?,
+            Source::Url(u) => fetch_from_url(&u, AssetKind::Video, MAX_INPUT_BYTES)?,
+            Source::Ref(id) => load_from_attachment(&id, AssetKind::Video, MAX_INPUT_BYTES)?,
         };
 
     let in_ext = mime_to_ext(&in_mime).unwrap_or("bin");
@@ -190,81 +191,6 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
         },
     };
     serde_json::to_vec(&env).map_err(|e| SkillError::Serialize(format!("serialize envelope: {e}")))
-}
-
-#[cfg(target_arch = "wasm32")]
-fn fetch_video_from_url(url: &str) -> Result<(Vec<u8>, String, String), SkillError> {
-    let net = wafer_sdk::clients::network::do_request("GET", url, &HashMap::new(), None)?;
-    if net.status_code >= 400 {
-        return Err(SkillError::HttpStatus {
-            status: net.status_code,
-            url: url.to_string(),
-        });
-    }
-    let raw_mime = net
-        .headers
-        .iter()
-        .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
-        .and_then(|(_, vs)| vs.first().cloned())
-        .unwrap_or_else(|| "application/octet-stream".to_string());
-    let mime: String = raw_mime
-        .split(';')
-        .next()
-        .unwrap_or("")
-        .trim()
-        .to_lowercase();
-    if !mime.starts_with("video/") {
-        return Err(SkillError::UnexpectedMime {
-            expected: "video/*",
-            actual: mime,
-        });
-    }
-    if let Some(cl) = net
-        .headers
-        .iter()
-        .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
-        .and_then(|(_, vs)| vs.first())
-        .and_then(|v| v.trim().parse::<usize>().ok())
-    {
-        if cl > MAX_INPUT_BYTES {
-            return Err(SkillError::TooLarge {
-                kind: "input video",
-                bytes: cl,
-                cap: MAX_INPUT_BYTES,
-            });
-        }
-    }
-    if net.body.len() > MAX_INPUT_BYTES {
-        return Err(SkillError::TooLarge {
-            kind: "input video",
-            bytes: net.body.len(),
-            cap: MAX_INPUT_BYTES,
-        });
-    }
-    let filename = derive_filename(url, "video");
-    Ok((net.body, mime, filename))
-}
-
-#[cfg(target_arch = "wasm32")]
-fn load_video_from_attachment(id: &str) -> Result<(Vec<u8>, String, String), SkillError> {
-    let att = wafer_sdk::lookup_attachment(id)
-        .map_err(|e| SkillError::Serialize(e.to_string()))?
-        .ok_or_else(|| SkillError::AttachmentNotFound(id.to_string()))?;
-    if !att.mime.starts_with("video/") {
-        return Err(SkillError::UnexpectedMime {
-            expected: "video/* attachment",
-            actual: att.mime,
-        });
-    }
-    if att.bytes.len() > MAX_INPUT_BYTES {
-        return Err(SkillError::TooLarge {
-            kind: "input video",
-            bytes: att.bytes.len(),
-            cap: MAX_INPUT_BYTES,
-        });
-    }
-    let filename = att.filename.unwrap_or_else(|| "video".into());
-    Ok((att.bytes, att.mime, filename))
 }
 
 #[cfg(test)]

--- a/blocks/video-trim/src/lib.rs
+++ b/blocks/video-trim/src/lib.rs
@@ -5,15 +5,16 @@
 // full rationale.
 #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
 
-use std::collections::HashMap;
-
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use gizza_ai_block_utils::{
-    derive_filename, dispatch_ffmpeg_runtime, mime_to_ext, pick_source, Envelope, FfmpegReq,
-    FfmpegResp, ForUi, SkillError, SkillResultExt, Source,
+    dispatch_ffmpeg_runtime, mime_to_ext, pick_source, AssetKind, Envelope, FfmpegReq, FfmpegResp,
+    ForUi, SkillError, SkillResultExt, Source,
 };
 use serde::Deserialize;
 use wafer_sdk::*;
+
+#[cfg(target_arch = "wasm32")]
+use gizza_ai_block_utils::{fetch_from_url, load_from_attachment};
 
 const MAX_INPUT_BYTES: usize = 10 * 1024 * 1024;
 const MAX_OUTPUT_BYTES: usize = 10 * 1024 * 1024;
@@ -102,8 +103,8 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
 
     let (input_bytes, in_mime, in_filename) =
         match pick_source(args.url.as_deref(), args.r#ref.as_deref()).invalid_args("video-trim")? {
-            Source::Url(u) => fetch_video_from_url(&u)?,
-            Source::Ref(id) => load_video_from_attachment(&id)?,
+            Source::Url(u) => fetch_from_url(&u, AssetKind::Video, MAX_INPUT_BYTES)?,
+            Source::Ref(id) => load_from_attachment(&id, AssetKind::Video, MAX_INPUT_BYTES)?,
         };
 
     let in_ext = mime_to_ext(&in_mime).unwrap_or("bin");
@@ -153,81 +154,6 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
         },
     };
     serde_json::to_vec(&env).map_err(|e| SkillError::Serialize(format!("serialize envelope: {e}")))
-}
-
-#[cfg(target_arch = "wasm32")]
-fn fetch_video_from_url(url: &str) -> Result<(Vec<u8>, String, String), SkillError> {
-    let net = wafer_sdk::clients::network::do_request("GET", url, &HashMap::new(), None)?;
-    if net.status_code >= 400 {
-        return Err(SkillError::HttpStatus {
-            status: net.status_code,
-            url: url.to_string(),
-        });
-    }
-    let raw_mime = net
-        .headers
-        .iter()
-        .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
-        .and_then(|(_, vs)| vs.first().cloned())
-        .unwrap_or_else(|| "application/octet-stream".to_string());
-    let mime: String = raw_mime
-        .split(';')
-        .next()
-        .unwrap_or("")
-        .trim()
-        .to_lowercase();
-    if !mime.starts_with("video/") {
-        return Err(SkillError::UnexpectedMime {
-            expected: "video/*",
-            actual: mime,
-        });
-    }
-    if let Some(cl) = net
-        .headers
-        .iter()
-        .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
-        .and_then(|(_, vs)| vs.first())
-        .and_then(|v| v.trim().parse::<usize>().ok())
-    {
-        if cl > MAX_INPUT_BYTES {
-            return Err(SkillError::TooLarge {
-                kind: "input video",
-                bytes: cl,
-                cap: MAX_INPUT_BYTES,
-            });
-        }
-    }
-    if net.body.len() > MAX_INPUT_BYTES {
-        return Err(SkillError::TooLarge {
-            kind: "input video",
-            bytes: net.body.len(),
-            cap: MAX_INPUT_BYTES,
-        });
-    }
-    let filename = derive_filename(url, "video");
-    Ok((net.body, mime, filename))
-}
-
-#[cfg(target_arch = "wasm32")]
-fn load_video_from_attachment(id: &str) -> Result<(Vec<u8>, String, String), SkillError> {
-    let att = wafer_sdk::lookup_attachment(id)
-        .map_err(|e| SkillError::Serialize(e.to_string()))?
-        .ok_or_else(|| SkillError::AttachmentNotFound(id.to_string()))?;
-    if !att.mime.starts_with("video/") {
-        return Err(SkillError::UnexpectedMime {
-            expected: "video/* attachment",
-            actual: att.mime,
-        });
-    }
-    if att.bytes.len() > MAX_INPUT_BYTES {
-        return Err(SkillError::TooLarge {
-            kind: "input video",
-            bytes: att.bytes.len(),
-            cap: MAX_INPUT_BYTES,
-        });
-    }
-    let filename = att.filename.unwrap_or_else(|| "video".into());
-    Ok((att.bytes, att.mime, filename))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Each of the six image/video blocks carried a ~80-line copy-paste of `fetch_<asset>_from_url` and `load_<asset>_from_attachment` that only varied in four string constants ("image"/"video", "image/*"/"video/*", "input image"/"input video", default filename). Move the shared logic to block-utils as `fetch_from_url` / `load_from_attachment` keyed off a new `AssetKind` enum.

Net diff: -488 / +219 lines (-269 LOC) across image-resize, image-crop, image-convert, video-frame-extract, video-transcode, video-trim.

Behavior unchanged. block-utils gains two unit tests covering the `AssetKind` label mappings. The host-call sites stay wasm-gated since `wafer_sdk::clients::network` / `lookup_attachment` are wasm-only.