### PR TITLE
refactor(boot): fail fast on config errors + drop hardcoded auth secrets

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -3,20 +3,49 @@
 //! Mirrors the native `seed_and_load_variables()` / `load_block_settings()` from
 //! `solobase/src/main.rs`, but uses the JS bridge (`bridge::db_exec_raw` /
 //! `bridge::db_query_raw`) instead of `rusqlite`.
+//!
+//! All bootstrap fns are fallible (`Result<_, JsValue>`) so that a real SQL
+//! error at boot — schema create failure, OPFS quota, etc. — surfaces to
+//! the Service Worker instead of letting the runtime start with empty config.
 
 use std::collections::HashMap;
+use std::fmt::Write as _;
 
 #[cfg(target_arch = "wasm32")]
 use solobase_browser::bridge;
+use wasm_bindgen::JsValue;
 
-/// Run a write SQL statement, logging to the browser console on failure.
-/// Used for table creation and seed inserts where a SQL error is unexpected
-/// but should not crash the boot path — the next operation will surface the
-/// missing data.
+/// Run a write SQL statement, propagating any failure as a JsValue with the
+/// SQL snippet attached for debuggability. The bridge already raises on bad
+/// SQL; this just labels the error.
 #[cfg(target_arch = "wasm32")]
-fn exec_or_warn(sql: &str, params: &str) {
-    if let Err(e) = bridge::db_exec_raw(sql, params) {
-        web_sys::console::warn_1(&format!("config: db_exec_raw failed: {e:?} sql={sql}").into());
+fn exec_or_err(sql: &str, params: &str) -> Result<(), JsValue> {
+    bridge::db_exec_raw(sql, params).map(|_| ()).map_err(|e| {
+        JsValue::from_str(&format!(
+            "config: db_exec_raw failed: {e:?} sql={}",
+            short(sql)
+        ))
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+fn query_or_err(sql: &str, params: &str) -> Result<String, JsValue> {
+    bridge::db_query_raw(sql, params).map_err(|e| {
+        JsValue::from_str(&format!(
+            "config: db_query_raw failed: {e:?} sql={}",
+            short(sql)
+        ))
+    })
+}
+
+/// Trim a SQL string to its first 80 chars for error messages — full
+/// schema-create statements are too long to be useful in the console.
+fn short(sql: &str) -> String {
+    let trimmed = sql.trim();
+    if trimmed.len() <= 80 {
+        trimmed.to_string()
+    } else {
+        format!("{}…", &trimmed[..80])
     }
 }
 
@@ -30,9 +59,9 @@ fn exec_or_warn(sql: &str, params: &str) {
 /// This is the browser equivalent of the native `seed_and_load_variables()`.
 /// There are no env vars to seed from in the browser — only auto-generated
 /// secrets and previously-stored values.
-pub fn seed_and_load_variables() -> HashMap<String, String> {
+pub fn seed_and_load_variables() -> Result<HashMap<String, String>, JsValue> {
     // 1. Create variables table if it does not exist
-    exec_or_warn(
+    exec_or_err(
         "CREATE TABLE IF NOT EXISTS variables (
             id TEXT PRIMARY KEY,
             key TEXT NOT NULL UNIQUE,
@@ -46,35 +75,35 @@ pub fn seed_and_load_variables() -> HashMap<String, String> {
             updated_at TEXT DEFAULT (datetime('now'))
         )",
         "[]",
-    );
-    exec_or_warn(
+    )?;
+    exec_or_err(
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_variables_key ON variables (key)",
         "[]",
-    );
+    )?;
 
     // 2. Seed default admin account for browser build.
     //    Email: admin@solobase.local / Password: admin
     //    This is local-only (OPFS) so a simple default is acceptable.
-    exec_or_warn(
+    exec_or_err(
         "INSERT OR IGNORE INTO variables (id, key, name, description, value, sensitive, created_at, updated_at)
          VALUES ('var_admin_email', 'SUPPERS_AI__AUTH__ADMIN_EMAIL', 'Admin Email', 'Admin account email', 'admin@solobase.local', 0, datetime('now'), datetime('now'))",
         "[]",
-    );
-    exec_or_warn(
+    )?;
+    exec_or_err(
         "INSERT OR IGNORE INTO variables (id, key, name, description, value, sensitive, created_at, updated_at)
          VALUES ('var_admin_pass', 'SUPPERS_AI__AUTH__ADMIN_PASSWORD', 'Admin Password', 'Admin account password', 'admin', 1, datetime('now'), datetime('now'))",
         "[]",
-    );
+    )?;
 
     // Inject the framework's page-side WebLLM engine into every SSR-rendered
     // page served via solobase-core's layout (admin UI, etc.). gizza's own
     // /b/ui page has its own maud template that loads /webllm-engine.js
     // directly, so this seed is strictly for framework-rendered surfaces.
-    exec_or_warn(
+    exec_or_err(
         "INSERT OR IGNORE INTO variables (id, key, name, description, value, sensitive, created_at, updated_at)
          VALUES ('var_embedded_scripts', 'SOLOBASE_SHARED__EMBEDDED_SCRIPTS', 'Embedded Scripts', 'Module-script URLs injected into every SSR page', '/webllm-engine.js', 0, datetime('now'), datetime('now'))",
         "[]",
-    );
+    )?;
 
     // 2b. Seed placeholders for auth block's required OAuth + domain config.
     //     gizza-ai runs anonymously — it doesn't use OAuth sign-in — but the
@@ -98,18 +127,35 @@ pub fn seed_and_load_variables() -> HashMap<String, String> {
             key,
             val
         );
-        exec_or_warn(&sql, "[]");
+        exec_or_err(&sql, "[]")?;
     }
 
-    // 3. Auto-generate secrets for config vars marked with auto_generate
-    seed_auto_generated();
+    // 2c. Seed per-browser random secrets for auth-runtime keys.
+    //     JWT_SECRET and INTERNAL_SECRET aren't declared as ConfigVars
+    //     upstream (see auth_ui/mod.rs:124-130: "auth identity infra used by
+    //     AuthServiceImpl, not UI"), so the generic `seed_auto_generated()`
+    //     pass below would skip them. We seed them explicitly here with the
+    //     same 32-byte-hex pattern. INSERT OR IGNORE means user-changed
+    //     values stick.
+    seed_random_secret(
+        "var_auth_jwt_secret",
+        "SUPPERS_AI__AUTH__JWT_SECRET",
+        "JWT signing secret (gizza-local)",
+    )?;
+    seed_random_secret(
+        "var_auth_internal_secret",
+        "SUPPERS_AI__AUTH__INTERNAL_SECRET",
+        "Internal-endpoint shared secret (gizza-local)",
+    )?;
 
-    // 3. Load all variables
-    let json = bridge::db_query_raw("SELECT key, value FROM variables", "[]").unwrap_or_else(|e| {
-        web_sys::console::warn_1(&format!("config: db_query_raw(variables) failed: {e:?}").into());
-        String::new()
-    });
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap_or_default();
+    // 3. Auto-generate secrets for config vars marked with auto_generate
+    seed_auto_generated()?;
+
+    // 4. Load all variables
+    let json = query_or_err("SELECT key, value FROM variables", "[]")?;
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&json).map_err(|e| {
+        JsValue::from_str(&format!("config: parse variables result failed: {e}"))
+    })?;
 
     let mut vars = HashMap::new();
     for row in rows {
@@ -123,7 +169,35 @@ pub fn seed_and_load_variables() -> HashMap<String, String> {
         }
     }
 
-    vars
+    Ok(vars)
+}
+
+/// Generate 32 random bytes, hex-encode, and `INSERT OR IGNORE` into the
+/// variables table. Used for keys solobase's upstream config-var machinery
+/// doesn't yet auto-generate. Sensitive bit is forced on.
+#[cfg(target_arch = "wasm32")]
+fn seed_random_secret(id: &str, key: &str, description: &str) -> Result<(), JsValue> {
+    let mut bytes = [0u8; 32];
+    getrandom::getrandom(&mut bytes)
+        .map_err(|e| JsValue::from_str(&format!("config: getrandom for {key}: {e}")))?;
+    let mut secret = String::with_capacity(bytes.len() * 2);
+    for b in &bytes {
+        // write! on a String never fails — but we still propagate to keep
+        // the function clean of .expect() panics on wasm32.
+        write!(&mut secret, "{b:02x}")
+            .map_err(|e| JsValue::from_str(&format!("config: hex encode for {key}: {e}")))?;
+    }
+    let params = serde_json::json!([id, key, key, description, secret]);
+    exec_or_err(
+        "INSERT OR IGNORE INTO variables (id, key, name, description, value, sensitive, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, 1, datetime('now'), datetime('now'))",
+        &params.to_string(),
+    )
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn seed_random_secret(_id: &str, _key: &str, _description: &str) -> Result<(), JsValue> {
+    Ok(())
 }
 
 /// Auto-generate values for config vars marked with `auto_generate: true`.
@@ -131,7 +205,7 @@ pub fn seed_and_load_variables() -> HashMap<String, String> {
 /// Reads all block config var declarations, finds those needing auto-generation,
 /// and generates random hex values for any that don't already exist in the
 /// variables table.
-fn seed_auto_generated() {
+fn seed_auto_generated() -> Result<(), JsValue> {
     let block_infos = solobase_core::blocks::all_block_infos();
     let all_vars = solobase_core::config_vars::collect_all_config_vars(&block_infos);
 
@@ -142,16 +216,14 @@ fn seed_auto_generated() {
 
         // Generate a random 32-byte hex secret
         let mut bytes = [0u8; 32];
-        if let Err(e) = getrandom::getrandom(&mut bytes) {
-            web_sys::console::warn_1(
-                &format!("solobase: getrandom failed for {}: {e}", var.key).into(),
-            );
-            continue;
-        }
-        use std::fmt::Write as _;
+        getrandom::getrandom(&mut bytes).map_err(|e| {
+            JsValue::from_str(&format!("config: getrandom for {}: {e}", var.key))
+        })?;
         let mut secret = String::with_capacity(bytes.len() * 2);
         for b in &bytes {
-            write!(&mut secret, "{b:02x}").expect("writing to String never fails");
+            write!(&mut secret, "{b:02x}").map_err(|e| {
+                JsValue::from_str(&format!("config: hex encode for {}: {e}", var.key))
+            })?;
         }
 
         let id = format!("var_{}", uuid::Uuid::new_v4());
@@ -167,12 +239,14 @@ fn seed_auto_generated() {
             var.warning,
             sensitive
         ]);
-        exec_or_warn(
+        exec_or_err(
             "INSERT OR IGNORE INTO variables (id, key, name, description, value, warning, sensitive, created_at, updated_at)
              VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))",
             &params.to_string(),
-        );
+        )?;
     }
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -183,9 +257,9 @@ fn seed_auto_generated() {
 ///
 /// Reads the `suppers_ai__admin__block_settings` table (creating it if needed)
 /// and returns a `BlockSettings` with the enabled/disabled state of each block.
-pub fn load_block_settings() -> solobase_core::features::BlockSettings {
+pub fn load_block_settings() -> Result<solobase_core::features::BlockSettings, JsValue> {
     // Ensure table exists
-    exec_or_warn(
+    exec_or_err(
         "CREATE TABLE IF NOT EXISTS suppers_ai__admin__block_settings (
             block_name TEXT PRIMARY KEY,
             enabled INTEGER DEFAULT 1,
@@ -193,7 +267,7 @@ pub fn load_block_settings() -> solobase_core::features::BlockSettings {
             updated_at TEXT DEFAULT (datetime('now'))
         )",
         "[]",
-    );
+    )?;
 
     // Seed defaults for known blocks — gizza-ai only uses auth, llm,
     // local-llm, and messages. Everything else is explicitly disabled
@@ -215,24 +289,20 @@ pub fn load_block_settings() -> solobase_core::features::BlockSettings {
 
     for &(name, default) in defaults {
         let params = serde_json::json!([name, default as i32]);
-        exec_or_warn(
+        exec_or_err(
             "INSERT OR IGNORE INTO suppers_ai__admin__block_settings (block_name, enabled) VALUES (?, ?)",
             &params.to_string(),
-        );
+        )?;
     }
 
     // Read all settings
-    let json = bridge::db_query_raw(
+    let json = query_or_err(
         "SELECT block_name, enabled FROM suppers_ai__admin__block_settings",
         "[]",
-    )
-    .unwrap_or_else(|e| {
-        web_sys::console::warn_1(
-            &format!("config: db_query_raw(block_settings) failed: {e:?}").into(),
-        );
-        String::new()
-    });
-    let rows: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap_or_default();
+    )?;
+    let rows: Vec<serde_json::Value> = serde_json::from_str(&json).map_err(|e| {
+        JsValue::from_str(&format!("config: parse block_settings result failed: {e}"))
+    })?;
 
     let mut map = HashMap::new();
     for row in rows {
@@ -247,5 +317,5 @@ pub fn load_block_settings() -> solobase_core::features::BlockSettings {
         }
     }
 
-    solobase_core::features::BlockSettings::from_map(map)
+    Ok(solobase_core::features::BlockSettings::from_map(map))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,15 +61,17 @@ pub async fn initialize() -> Result<(), JsValue> {
     // 1. Load sql.js WASM + open/create the OPFS database.
     solobase_browser::db_init().await;
 
-    // 2. Seed variables and load config.
-    let vars = config::seed_and_load_variables();
+    // 2. Seed variables and load config. Failures here mean the OPFS
+    //    schema-create or seed write itself errored — there is no useful
+    //    runtime state to recover into, so propagate to the Service Worker.
+    let vars = config::seed_and_load_variables()?;
     web_sys::console::log_1(
         &format!("gizza-ai: {} variables loaded from database", vars.len()).into(),
     );
 
     // 3. Load feature flag settings (curated for gizza — only auth/llm/
     //    local-llm/messages are enabled).
-    let features = config::load_block_settings();
+    let features = config::load_block_settings()?;
 
     // 4. Extract JWT secret.
     let jwt_secret = vars
@@ -131,15 +133,14 @@ pub async fn initialize() -> Result<(), JsValue> {
                 )
             }),
         )
-        .block_config(
-            "suppers-ai/auth",
-            serde_json::json!({
-                "SUPPERS_AI__AUTH__JWT_SECRET": "gizza-mvp-dev-jwt-secret-not-for-production",
-                "SUPPERS_AI__AUTH__ADMIN_EMAIL": "admin@gizza.local",
-                "SUPPERS_AI__AUTH__ADMIN_PASSWORD": "admin",
-                "SUPPERS_AI__AUTH__INTERNAL_SECRET": "gizza-mvp-dev-internal-secret",
-            }),
-        )
+        // The auth block reads its config (JWT_SECRET, ADMIN_EMAIL,
+        // ADMIN_PASSWORD, INTERNAL_SECRET) from the config service we just
+        // populated from `vars`. The DB seed in `config.rs` is the single
+        // source of truth: admin email/password from the `INSERT OR IGNORE`
+        // seed, JWT/INTERNAL secrets from the per-browser random `seed_random_secret`
+        // call. No `.block_config("suppers-ai/auth", ...)` override here —
+        // historically that override silently shipped the same hardcoded MVP
+        // values to every user, defeating the auto-generate path.
         .block_config(
             "suppers-ai/llm",
             serde_json::json!({


### PR DESCRIPTION
Two related bootstrap problems, fixed together:

1. config.rs silently no-opped on every SQL failure. `exec_or_warn` logged a warning and returned; `db_query_raw` errors fell back to an empty string → empty vars → runtime started with zero config. A real OPFS quota or schema failure looked indistinguishable from a healthy boot. All bootstrap fns now return `Result<_, JsValue>`. `initialize()` propagates with `?` and the Service Worker surfaces a real error.

2. lib.rs:134-142 set a `.block_config("suppers-ai/auth", { … })` override with hardcoded JWT_SECRET / INTERNAL_SECRET / ADMIN_EMAIL / ADMIN_PASSWORD. The override silently shipped the same MVP values to every browser, defeating the auto-generate path that already exists in `config.rs::seed_auto_generated()`. Worse: ADMIN_EMAIL was set to "admin@gizza.local" in lib.rs but "admin@solobase.local" in the DB seed — the override always won, making the DB seed dead code.

   The override block is removed entirely. The auth block now reads its config from the populated config service:
   - ADMIN_EMAIL / ADMIN_PASSWORD — from the existing `INSERT OR IGNORE` DB seed in config.rs (admin@solobase.local / admin)
   - JWT_SECRET / INTERNAL_SECRET — from a new `seed_random_secret()` pass in config.rs that hex-encodes 32 random bytes per browser. `auth_ui/mod.rs:124-130` notes those keys aren't yet declared as ConfigVars upstream, so the generic auto-generate pass skips them; we explicitly seed both here as a local fill-in.

Both changes share the same goal: the config that reaches the auth block matches what `config.rs` actually wrote, and bootstrap failures surface instead of hiding.

Existing OPFS sessions tied to the leaked dev JWT secret will need to re-authenticate on first load after this change — that's the intended outcome.

Verified: cargo check clean on host + wasm32; 32/32 unit tests pass.