### PR TITLE
test: add host-runnable unit tests to 6 untested blocks

### DIFF
--- a/blocks/calculator/src/lib.rs
+++ b/blocks/calculator/src/lib.rs
@@ -5,6 +5,11 @@
 //! parse/eval failure. No host calls — runs entirely inside the WASM
 //! sandbox.
 
+// The #[wafer_block] macro emits wasm-only registration code; supporting
+// imports + the Args type are only used inside that impl. See image-resize
+// for the rationale.
+#![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
+
 use serde::Deserialize;
 use wafer_sdk::*;
 
@@ -13,8 +18,21 @@ struct Args {
     expr: String,
 }
 
+/// Evaluate an arithmetic expression. Returns `Err` if meval fails to parse
+/// it, or if the result is non-finite (NaN/Inf) — typically division by
+/// zero or overflow.
+fn evaluate_expr(expr: &str) -> Result<f64, String> {
+    let v = meval::eval_str(expr).map_err(|e| format!("eval failed: {e}"))?;
+    if !v.is_finite() {
+        return Err(format!("eval failed: non-finite result ({v})"));
+    }
+    Ok(v)
+}
+
+#[cfg(target_arch = "wasm32")]
 struct Calculator;
 
+#[cfg(target_arch = "wasm32")]
 #[wafer_block(
     name = "gizza-ai/calculator",
     version = "0.1.0",
@@ -38,20 +56,51 @@ impl Calculator {
             Ok(a) => a,
             Err(e) => return respond_error(format!("invalid args: {e}")),
         };
-        match meval::eval_str(&args.expr) {
+        match evaluate_expr(&args.expr) {
             Ok(v) => {
-                if !v.is_finite() {
-                    return respond_error(format!("eval failed: non-finite result ({v})"));
-                }
                 let body = serde_json::json!({ "result": v });
                 GuestResult::respond(serde_json::to_vec(&body).unwrap_or_default())
             }
-            Err(e) => respond_error(format!("eval failed: {e}")),
+            Err(e) => respond_error(e),
         }
     }
 }
 
+#[cfg(target_arch = "wasm32")]
 fn respond_error(msg: String) -> GuestResult {
     let body = serde_json::json!({ "error": msg });
     GuestResult::respond(serde_json::to_vec(&body).unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evaluates_simple_arithmetic() {
+        assert_eq!(evaluate_expr("2+2").unwrap(), 4.0);
+        assert_eq!(evaluate_expr("2+2*3").unwrap(), 8.0);
+    }
+
+    #[test]
+    fn evaluates_named_functions() {
+        assert_eq!(evaluate_expr("sqrt(16)").unwrap(), 4.0);
+        // 3.14 * 2^2 — meval uses ^ for power.
+        let v = evaluate_expr("3.14 * 2^2").unwrap();
+        assert!((v - 12.56).abs() < 1e-9, "got {v}");
+    }
+
+    #[test]
+    fn rejects_non_finite_results() {
+        // Division by zero yields Inf in IEEE 754; the explicit non-finite
+        // check is what protects users from `"result": null` in the JSON.
+        let err = evaluate_expr("1/0").unwrap_err();
+        assert!(err.contains("non-finite"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_invalid_syntax() {
+        let err = evaluate_expr("nonsense === ===").unwrap_err();
+        assert!(err.contains("eval failed"), "got: {err}");
+    }
 }

--- a/blocks/clock/src/lib.rs
+++ b/blocks/clock/src/lib.rs
@@ -1,9 +1,24 @@
 //! gizza-ai/clock — returns current UTC time as JSON.
 
+// The #[wafer_block] macro emits wasm-only registration; the response
+// builder below is testable on host.
+#![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
+
 use wafer_sdk::*;
 
+/// Build the JSON response body for a clock reading. Extracted so host
+/// tests can pin the shape against a known timestamp.
+fn build_response(now: chrono::DateTime<chrono::Utc>) -> serde_json::Value {
+    serde_json::json!({
+        "time": now.to_rfc3339(),
+        "tz": "UTC",
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
 struct Clock;
 
+#[cfg(target_arch = "wasm32")]
 #[wafer_block(
     name = "gizza-ai/clock",
     version = "0.1.0",
@@ -20,12 +35,33 @@ struct Clock;
 )]
 impl Clock {
     fn handle(_msg: Message, _body: Vec<u8>) -> GuestResult {
-        let now = chrono::Utc::now().to_rfc3339();
-        let body = serde_json::json!({
-            "time": now,
-            "tz": "UTC",
-        });
+        let body = build_response(chrono::Utc::now());
         let bytes = serde_json::to_vec(&body).unwrap_or_default();
         GuestResult::respond(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone as _;
+
+    #[test]
+    fn response_pins_iso_timestamp_and_utc_tz() {
+        let now = chrono::Utc.with_ymd_and_hms(2026, 4, 20, 12, 0, 0).unwrap();
+        let v = build_response(now);
+        assert_eq!(v["time"], "2026-04-20T12:00:00+00:00");
+        assert_eq!(v["tz"], "UTC");
+    }
+
+    #[test]
+    fn response_serializes_to_compact_json() {
+        let now = chrono::Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        let v = build_response(now);
+        let s = serde_json::to_string(&v).unwrap();
+        // Object key order isn't part of the contract — just spot-check
+        // both fields are present.
+        assert!(s.contains(r#""time":"2026-01-01T00:00:00+00:00""#));
+        assert!(s.contains(r#""tz":"UTC""#));
     }
 }

--- a/blocks/ffmpeg/src/lib.rs
+++ b/blocks/ffmpeg/src/lib.rs
@@ -1,6 +1,11 @@
 //! gizza-ai/ffmpeg — fetch a URL, run `ffmpeg -i input` on the bytes,
 //! return the log.
 
+// The #[wafer_block] macro emits wasm-only registration; supporting imports
+// and the Args type are only used inside that impl. See image-resize for
+// the full rationale.
+#![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
+
 use std::collections::HashMap;
 
 use gizza_ai_block_utils::{
@@ -22,8 +27,16 @@ struct ToolResp {
     info: String,
 }
 
+/// argv for an ffprobe-style inspection — read `input` from ffmpeg's
+/// virtual FS, emit format/stream metadata on stderr, no output file.
+fn build_inspect_argv() -> Vec<String> {
+    vec!["-i".into(), "input".into()]
+}
+
+#[cfg(target_arch = "wasm32")]
 struct FfmpegSkill;
 
+#[cfg(target_arch = "wasm32")]
 #[wafer_block(
     name = "gizza-ai/ffmpeg",
     version = "0.1.0",
@@ -51,6 +64,7 @@ impl FfmpegSkill {
     }
 }
 
+#[cfg(target_arch = "wasm32")]
 fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
     let args: Args = serde_json::from_slice(&body).invalid_args("ffmpeg")?;
 
@@ -72,7 +86,7 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
     // Hand bytes to gizza-ai/ffmpeg-runtime (consumer-controlled JSON
     // protocol, NOT a wafer-run service — must encode via serde_json).
     let ffreq = serde_json::to_vec(&FfmpegReq {
-        args: vec!["-i".into(), "input".into()],
+        args: build_inspect_argv(),
         inputs: vec![("input".into(), net.body)],
         output: String::new(),
     })
@@ -89,4 +103,26 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
     };
     serde_json::to_vec(&tool)
         .map_err(|e| SkillError::Serialize(format!("serialize tool response: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn argv_uses_input_filename_with_dash_i() {
+        let argv = build_inspect_argv();
+        assert_eq!(argv, vec!["-i", "input"]);
+    }
+
+    #[test]
+    fn tool_resp_serializes_url_and_info() {
+        let tool = ToolResp {
+            url: "https://x.test/a.mp4".to_string(),
+            info: "Stream #0: Video".to_string(),
+        };
+        let json: serde_json::Value = serde_json::from_slice(&serde_json::to_vec(&tool).unwrap()).unwrap();
+        assert_eq!(json["url"], "https://x.test/a.mp4");
+        assert_eq!(json["info"], "Stream #0: Video");
+    }
 }

--- a/blocks/image-fetch/src/lib.rs
+++ b/blocks/image-fetch/src/lib.rs
@@ -5,6 +5,10 @@
 //! agent block recognises the envelope and bifurcates LLM history (gets
 //! `_for_llm`) from UI rendering (gets `_for_ui` with the data: URL).
 
+// The #[wafer_block] macro emits wasm-only registration; supporting imports
+// and the Args type are only used inside that impl.
+#![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
+
 use std::collections::HashMap;
 
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
@@ -19,8 +23,26 @@ struct Args {
     url: String,
 }
 
+/// Pull the lowercased MIME class out of an HTTP `Content-Type` header
+/// value (e.g. `"image/png; charset=binary"` → `"image/png"`). Falls back
+/// to `application/octet-stream` when absent / malformed.
+fn parse_content_type_mime(headers: &HashMap<String, Vec<String>>) -> String {
+    let raw = headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+        .and_then(|(_, vs)| vs.first().cloned())
+        .unwrap_or_else(|| "application/octet-stream".to_string());
+    raw.split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_lowercase()
+}
+
+#[cfg(target_arch = "wasm32")]
 struct ImageFetch;
 
+#[cfg(target_arch = "wasm32")]
 #[wafer_block(
     name = "gizza-ai/image-fetch",
     version = "0.1.0",
@@ -48,6 +70,7 @@ impl ImageFetch {
     }
 }
 
+#[cfg(target_arch = "wasm32")]
 fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
     let args: Args = serde_json::from_slice(&body).invalid_args("image-fetch")?;
 
@@ -59,19 +82,7 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
         });
     }
 
-    // Content-type check (case-insensitive header lookup, first value, strip ; params).
-    let raw_mime = resp
-        .headers
-        .iter()
-        .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
-        .and_then(|(_, vs)| vs.first().cloned())
-        .unwrap_or_else(|| "application/octet-stream".to_string());
-    let mime: String = raw_mime
-        .split(';')
-        .next()
-        .unwrap_or("")
-        .trim()
-        .to_lowercase();
+    let mime = parse_content_type_mime(&resp.headers);
     if !mime.starts_with("image/") {
         return Err(SkillError::UnexpectedMime {
             expected: "image/*",
@@ -119,4 +130,35 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
         },
     };
     serde_json::to_vec(&env).map_err(|e| SkillError::Serialize(format!("serialize envelope: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_content_type_strips_params_and_lowercases() {
+        let mut headers = HashMap::new();
+        headers.insert(
+            "Content-Type".to_string(),
+            vec!["IMAGE/PNG; charset=binary".to_string()],
+        );
+        assert_eq!(parse_content_type_mime(&headers), "image/png");
+    }
+
+    #[test]
+    fn parse_content_type_handles_case_insensitive_header_name() {
+        let mut headers = HashMap::new();
+        headers.insert(
+            "content-type".to_string(),
+            vec!["image/jpeg".to_string()],
+        );
+        assert_eq!(parse_content_type_mime(&headers), "image/jpeg");
+    }
+
+    #[test]
+    fn parse_content_type_falls_back_when_header_missing() {
+        let headers: HashMap<String, Vec<String>> = HashMap::new();
+        assert_eq!(parse_content_type_mime(&headers), "application/octet-stream");
+    }
 }

--- a/blocks/imagine/src/lib.rs
+++ b/blocks/imagine/src/lib.rs
@@ -11,11 +11,17 @@
 //! and bifurcates LLM history (sees `_for_llm`) from UI rendering (sees
 //! `_for_ui` with the data: URL), matching `gizza-ai/image-fetch`.
 
+// The #[wafer_block] macro emits wasm-only registration; supporting imports
+// and the Args type are only used inside that impl.
+#![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
+
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use gizza_ai_block_utils::{Envelope, ForUi, SkillError, SkillResultExt};
 use serde::Deserialize;
-use wafer_sdk::clients::image::{ImageParams, ImageRequest};
 use wafer_sdk::*;
+
+#[cfg(target_arch = "wasm32")]
+use wafer_sdk::clients::image::{ImageParams, ImageRequest};
 
 const BACKEND_ID: &str = "browser";
 const MODEL_ID: &str = "onnx-community/Janus-Pro-1B-ONNX";
@@ -25,8 +31,23 @@ struct Args {
     prompt: String,
 }
 
+/// Normalize and validate a prompt — trim surrounding whitespace and
+/// reject empty / whitespace-only input. The error is the user-facing
+/// `SkillError::InvalidArgs` so the agent can surface it directly.
+fn validate_prompt(prompt: &str) -> Result<String, SkillError> {
+    let trimmed = prompt.trim();
+    if trimmed.is_empty() {
+        return Err(SkillError::InvalidArgs(
+            "imagine: prompt must not be empty".into(),
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+#[cfg(target_arch = "wasm32")]
 struct Imagine;
 
+#[cfg(target_arch = "wasm32")]
 #[wafer_block(
     name = "gizza-ai/imagine",
     version = "0.1.0",
@@ -55,20 +76,15 @@ impl Imagine {
     }
 }
 
+#[cfg(target_arch = "wasm32")]
 fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
     let args: Args = serde_json::from_slice(&body).invalid_args("imagine")?;
-
-    let trimmed = args.prompt.trim();
-    if trimmed.is_empty() {
-        return Err(SkillError::InvalidArgs(
-            "imagine: prompt must not be empty".into(),
-        ));
-    }
+    let trimmed = validate_prompt(&args.prompt)?;
 
     let req = ImageRequest {
         backend_id: BACKEND_ID.to_string(),
         model: MODEL_ID.to_string(),
-        prompt: trimmed.to_string(),
+        prompt: trimmed.clone(),
         params: ImageParams::default(),
         extra: serde_json::Value::Null,
     };
@@ -96,4 +112,31 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
         },
     };
     serde_json::to_vec(&env).map_err(|e| SkillError::Serialize(format!("serialize envelope: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_prompt_trims_surrounding_whitespace() {
+        assert_eq!(validate_prompt("  a cat  ").unwrap(), "a cat");
+        assert_eq!(validate_prompt("\ta cat\n").unwrap(), "a cat");
+    }
+
+    #[test]
+    fn validate_prompt_rejects_empty() {
+        let err = validate_prompt("").unwrap_err();
+        assert!(matches!(err, SkillError::InvalidArgs(ref s) if s.contains("must not be empty")));
+    }
+
+    #[test]
+    fn validate_prompt_rejects_whitespace_only() {
+        for s in ["   ", "\t\t", "\n\n", " \t \n "] {
+            assert!(
+                matches!(validate_prompt(s), Err(SkillError::InvalidArgs(_))),
+                "expected InvalidArgs for {s:?}"
+            );
+        }
+    }
 }

--- a/blocks/web-fetch/src/lib.rs
+++ b/blocks/web-fetch/src/lib.rs
@@ -1,5 +1,9 @@
 //! gizza-ai/web-fetch — fetches a URL via wafer-run/network.
 
+// The #[wafer_block] macro emits wasm-only registration; supporting imports
+// and the Args type are only used inside that impl.
+#![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
+
 use std::collections::HashMap;
 
 use gizza_ai_block_utils::{SkillError, SkillResultExt};
@@ -24,8 +28,28 @@ struct ToolResp {
     truncated: bool,
 }
 
+/// Trim a body to `max_bytes`. Returns `(prefix, was_truncated)`.
+fn maybe_truncate(body: &[u8], max_bytes: usize) -> (&[u8], bool) {
+    if body.len() > max_bytes {
+        (&body[..max_bytes], true)
+    } else {
+        (body, false)
+    }
+}
+
+/// Extract a `Content-Type` header value (case-insensitive name match,
+/// first value in the multi-value list). Returns `None` if absent.
+fn extract_content_type(headers: &HashMap<String, Vec<String>>) -> Option<String> {
+    headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+        .and_then(|(_, vs)| vs.first().cloned())
+}
+
+#[cfg(target_arch = "wasm32")]
 struct WebFetch;
 
+#[cfg(target_arch = "wasm32")]
 #[wafer_block(
     name = "gizza-ai/web-fetch",
     version = "0.1.0",
@@ -54,23 +78,15 @@ impl WebFetch {
     }
 }
 
+#[cfg(target_arch = "wasm32")]
 fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
     let args: Args = serde_json::from_slice(&body).invalid_args("web-fetch")?;
     let max_bytes = args.max_bytes.unwrap_or(DEFAULT_MAX_BYTES);
 
     let resp = wafer_sdk::clients::network::do_request("GET", &args.url, &HashMap::new(), None)?;
 
-    let content_type = resp
-        .headers
-        .iter()
-        .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
-        .and_then(|(_, vs)| vs.first().cloned());
-    let truncated = resp.body.len() > max_bytes;
-    let bytes = if truncated {
-        &resp.body[..max_bytes]
-    } else {
-        &resp.body[..]
-    };
+    let content_type = extract_content_type(&resp.headers);
+    let (bytes, truncated) = maybe_truncate(&resp.body, max_bytes);
     let body_str = String::from_utf8_lossy(bytes).into_owned();
 
     let tool = ToolResp {
@@ -81,4 +97,69 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
         truncated,
     };
     serde_json::to_vec(&tool).map_err(|e| SkillError::Serialize(format!("serialize tool response: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maybe_truncate_clips_when_over_limit() {
+        let body = b"abcdefghij";
+        let (prefix, was) = maybe_truncate(body, 4);
+        assert_eq!(prefix, b"abcd");
+        assert!(was);
+    }
+
+    #[test]
+    fn maybe_truncate_passes_through_when_within_limit() {
+        let body = b"abc";
+        let (prefix, was) = maybe_truncate(body, 10);
+        assert_eq!(prefix, b"abc");
+        assert!(!was);
+    }
+
+    #[test]
+    fn maybe_truncate_handles_exact_limit() {
+        let body = b"abcd";
+        let (prefix, was) = maybe_truncate(body, 4);
+        assert_eq!(prefix, b"abcd");
+        assert!(!was, "len == cap should not truncate");
+    }
+
+    #[test]
+    fn extract_content_type_matches_case_insensitively() {
+        let mut headers = HashMap::new();
+        headers.insert(
+            "Content-Type".to_string(),
+            vec!["text/html; charset=utf-8".to_string()],
+        );
+        assert_eq!(
+            extract_content_type(&headers).as_deref(),
+            Some("text/html; charset=utf-8"),
+        );
+    }
+
+    #[test]
+    fn extract_content_type_returns_none_when_absent() {
+        let mut headers = HashMap::new();
+        headers.insert("X-Other".to_string(), vec!["v".to_string()]);
+        assert!(extract_content_type(&headers).is_none());
+    }
+
+    #[test]
+    fn extract_content_type_picks_first_value_when_multiple() {
+        let mut headers = HashMap::new();
+        headers.insert(
+            "content-type".to_string(),
+            vec![
+                "application/json".to_string(),
+                "text/plain".to_string(),
+            ],
+        );
+        assert_eq!(
+            extract_content_type(&headers).as_deref(),
+            Some("application/json"),
+        );
+    }
 }


### PR DESCRIPTION
Six blocks shipped with zero #[cfg(test)] coverage: calculator, clock, ffmpeg, imagine, web-fetch, image-fetch. The other image-/video-* blocks already follow a pattern where the #[wafer_block]-decorated impl is gated #[cfg(target_arch = "wasm32")] (the macro generates host-import registration that only compiles on wasm32) and pure helpers live in the non-gated section with #[cfg(test)] tests. Apply that pattern to all six.

Extracted helpers + tests per block:

  calculator   evaluate_expr — meval wrapper + non-finite check (4 tests:
               simple arithmetic, sqrt/^, 1/0 → non-finite, parse error)
  clock        build_response — pins {time, tz} shape for a fixed timestamp
               (2 tests)
  ffmpeg       build_inspect_argv — ["-i", "input"] for ffprobe-style inspect
               (2 tests: argv shape + ToolResp serialization)
  imagine      validate_prompt — trim + non-empty check (3 tests: trims
               whitespace, rejects "", rejects whitespace-only)
  web-fetch    maybe_truncate + extract_content_type (6 tests: under/at/over
               cap, case-insensitive header match, missing header, picks
               first value of multi-value)
  image-fetch  parse_content_type_mime — strip params, lowercase, fallback
               to application/octet-stream (3 tests)

Total: 20 new unit tests. No behavior change in production code paths. All six blocks: cargo test green on host, cargo check clean on wasm32-unknown-unknown.