### PR TITLE
chore: drop dead unsafe Send/Sync + spell out .is_none_or()

### DIFF
--- a/src/blocks/agent/slash.rs
+++ b/src/blocks/agent/slash.rs
@@ -96,10 +96,13 @@ pub(super) async fn build_skill_params(
     if trimmed.is_empty() {
         // No args. Only OK when the schema accepts an empty object — i.e. no
         // required fields. Otherwise the caller will emit an empty-arg error.
+        // Equivalent to `.is_none_or(|arr| arr.is_empty())`, but spelled
+        // out for compatibility with Rust < 1.82 (the rest of this crate
+        // is conservative about MSRV-affecting APIs).
         let no_required = schema
             .get("required")
             .and_then(|r| r.as_array())
-            .is_none_or(|arr| arr.is_empty());
+            .map_or(true, |arr| arr.is_empty());
         return if no_required {
             ParamExtraction::Extracted(serde_json::json!({}))
         } else {

--- a/src/ffmpeg.rs
+++ b/src/ffmpeg.rs
@@ -50,17 +50,13 @@ pub trait FfmpegService: wafer_block::MaybeSend + wafer_block::MaybeSync + 'stat
 /// Browser-side ffmpeg service. Uses `@ffmpeg/ffmpeg` from jsdelivr via
 /// the wasm-bindgen module at `js/ffmpeg.js`. wasm32-only — native tests
 /// substitute their own `FfmpegService` impl.
+///
+/// Note: no explicit `unsafe impl Send + Sync` is needed. `FfmpegService`'s
+/// `MaybeSend + MaybeSync` bound is a blanket no-op on wasm32 (any `?Sized`
+/// type satisfies it — see `wafer_block::compat`), and this unit struct
+/// holds no fields. The FFmpeg instance lives in the JS module.
 #[cfg(target_arch = "wasm32")]
 pub struct BrowserFfmpegService;
-
-// SAFETY: wasm32 is single-threaded; this is a unit struct holding no JS handles.
-// The FFmpeg instance lives in the JS module, not in this Rust value. Required
-// because the FfmpegService trait bound is MaybeSend + MaybeSync. Mirrors
-// BrowserNetworkService in solobase-browser.
-#[cfg(target_arch = "wasm32")]
-unsafe impl Send for BrowserFfmpegService {}
-#[cfg(target_arch = "wasm32")]
-unsafe impl Sync for BrowserFfmpegService {}
 
 #[cfg(target_arch = "wasm32")]
 #[derive(Serialize)]


### PR DESCRIPTION
Two unrelated nice-to-haves from the audit:

#14: `src/ffmpeg.rs` had `unsafe impl Send/Sync for BrowserFfmpegService` with a "single-threaded wasm" justification. The justification is true but the impl is dead code — on wasm32, `MaybeSend`/`MaybeSync` (the trait bound that triggered the manual impl) are blanket-implemented for ANY `?Sized` type in `wafer_block::compat`, so a unit struct trivially satisfies them. Removing the unsafe impl + replacing with a short comment explaining why no impl is needed. Mechanically equivalent; removes a misleading `unsafe` block that suggests there's something subtle about thread safety here.

#13: `agent/slash.rs:102` used `.is_none_or(|arr| arr.is_empty())` — stabilized in Rust 1.82 (Oct 2024). The rest of the crate is conservative about MSRV-affecting APIs (no rust-version is declared in Cargo.toml, so the implicit MSRV is whatever stable was at first build). Swap for `.map_or(true, |arr| arr.is_empty())` — semantically identical, works on any reasonable stable.

cargo test --lib 32/32 green; cargo check --target wasm32-unknown-unknown --lib clean.