### PR TITLE
fix(initialize): rename wafer.start_without_bind() → wafer.seal()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub fn module_start() {
 ///
 /// Must be called exactly once when the Service Worker starts, before any
 /// `handle_request()` call. Async because it awaits `solobase_browser::db_init()`
-/// and `wafer.start_without_bind()`.
+/// and `wafer.seal()`.
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub async fn initialize() -> Result<(), JsValue> {
@@ -210,9 +210,9 @@ pub async fn initialize() -> Result<(), JsValue> {
         web_sys::console::log_1(&format!("gizza-ai: skill '{name}' registered").into());
     }
 
-    // 7. Start runtime.
+    // 7. Seal the runtime (lazy init — blocks Init on first dispatch).
     wafer
-        .start_without_bind()
+        .seal()
         .await
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
 


### PR DESCRIPTION
## Summary

- wafer-run PR #98 (lazy block init, 2026-05-16) removed `Wafer::start_without_bind()` in favor of `seal()`. Same semantics: prepare blocks for dispatch without binding listeners; lazy init defers Init to first invocation.
- gizza-ai's `initialize()` still called the removed method, breaking `CI Main` (Test + Deploy) on every push since the runtime dep was bumped.

## Test plan
- [x] `cargo check --target wasm32-unknown-unknown -p gizza-ai --lib` clean
- [ ] CI Test + Deploy go green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)