### PR TITLE
refactor(agent): UTF-8 truncate, SSE JSON escaping, AgentRequest default

### DIFF
--- a/src/blocks/agent.rs
+++ b/src/blocks/agent.rs
@@ -67,7 +67,7 @@ enum AgentError {
 
 pub struct AgentBlock;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, PartialEq, Deserialize)]
 struct AgentRequest {
     #[serde(default)]
     user_message: String,
@@ -88,13 +88,13 @@ struct AgentRequest {
     confirm_yes: Option<ConfirmYes>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, PartialEq, Deserialize)]
 struct ConfirmYes {
     cmd: String,
     params: serde_json::Value,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, PartialEq, Deserialize)]
 struct UploadEntry {
     id: String,
     mime: String,
@@ -197,13 +197,7 @@ fn list_skill_commands(blocks: &[BlockInfo]) -> Vec<(String, String)> {
 async fn handle_chat(ctx: &dyn Context, input: InputStream) -> OutputStream {
     let body_bytes = input.collect_to_bytes().await;
     let req: AgentRequest = if body_bytes.is_empty() {
-        AgentRequest {
-            user_message: String::new(),
-            messages: Vec::new(),
-            model_id: None,
-            uploads: Vec::new(),
-            confirm_yes: None,
-        }
+        AgentRequest::default()
     } else {
         match serde_json::from_slice(&body_bytes) {
             Ok(v) => v,
@@ -372,5 +366,17 @@ mod tests {
         let bare = BlockInfo::new("gizza-ai/x", "0.1.0", "handler@v1", "").role(SkillRole::Skill);
         let cmds = list_skill_commands(&[bare]);
         assert!(cmds.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // AgentRequest — fix #8: Default must match parsing an empty JSON object
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn agent_request_default_matches_empty_object_parse() {
+        let from_default = AgentRequest::default();
+        let from_empty: AgentRequest =
+            serde_json::from_str("{}").expect("empty object parses");
+        assert_eq!(from_default, from_empty);
     }
 }

--- a/src/blocks/agent/dispatch.rs
+++ b/src/blocks/agent/dispatch.rs
@@ -41,6 +41,16 @@ pub(super) fn parse_skill_response(body: &str) -> ToolOutcome {
     }
 }
 
+/// Build a valid JSON string representing a `tool_failed` error payload.
+///
+/// Avoids the `format!("... \"{e}\" ...")` footgun — if the error message
+/// contains `"` or `\n`, the raw format produces invalid JSON. serde_json
+/// handles all escaping correctly.
+pub(super) fn build_tool_failed_payload(message: &str) -> String {
+    serde_json::to_string(&serde_json::json!({"error": "tool_failed", "message": message}))
+        .expect("serializing static struct never fails")
+}
+
 /// Dispatch one skill and emit the resulting `tool_result` + `done` SSE
 /// events into `sse`. `invocation` is a short string used to mint the
 /// `tool_result.id` (e.g. "slash", "confirmed") to avoid id collisions with
@@ -99,7 +109,7 @@ pub(super) async fn run_skill_dispatch(
             parse_skill_response(&result_text)
         }
         Err(e) => ToolOutcome {
-            for_llm: format!("{{\"error\": \"tool_failed\", \"message\": \"{e}\"}}"),
+            for_llm: build_tool_failed_payload(&e.to_string()),
             for_ui: None,
         },
     };
@@ -155,5 +165,18 @@ mod tests {
         let outcome = parse_skill_response(body);
         assert_eq!(outcome.for_llm, "ok");
         assert!(outcome.for_ui.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // tool_failed_payload — fix #7: must produce valid JSON even with special chars
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn tool_failed_payload_escapes_special_chars() {
+        let payload = build_tool_failed_payload("oops \"quoted\" and\nnewline");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&payload).expect("must be valid JSON");
+        assert_eq!(parsed["error"], "tool_failed");
+        assert_eq!(parsed["message"], "oops \"quoted\" and\nnewline");
     }
 }

--- a/src/blocks/agent/slash.rs
+++ b/src/blocks/agent/slash.rs
@@ -252,10 +252,9 @@ fn strip_to_json(text: &str) -> Option<String> {
 }
 
 fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
-        s.to_string()
-    } else {
-        format!("{}…", &s[..max])
+    match s.char_indices().nth(max) {
+        Some((i, _)) => format!("{}…", &s[..i]),
+        None => s.to_string(),
     }
 }
 
@@ -398,5 +397,23 @@ mod tests {
     fn strip_to_json_returns_none_when_no_object() {
         assert!(strip_to_json("just text").is_none());
         assert!(strip_to_json("{unbalanced").is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // truncate — fix #12: must not panic on multibyte UTF-8
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn truncate_does_not_panic_on_multibyte() {
+        // `é` is 2 bytes in UTF-8; max=3 must NOT slice mid-codepoint.
+        // "café" is [c, a, f, é(2 bytes)] = 5 bytes; 3 chars = "caf".
+        let s = "café apartment";
+        assert_eq!(truncate(s, 3), "caf…");
+        // max exactly matches string length (4 chars) — no ellipsis appended.
+        assert_eq!(truncate("café", 4), "café");
+        // max past the end — return as-is.
+        assert_eq!(truncate("ab", 10), "ab");
+        // max=0 — return ellipsis only.
+        assert_eq!(truncate("hello", 0), "…");
     }
 }


### PR DESCRIPTION
## Summary
Three small fixes in the agent block:

- **truncate (slash.rs)** — was byte-slicing `&s[..max]`, could panic on multibyte UTF-8. Now uses `char_indices().nth(max)`.
- **SSE tool_failed payload (dispatch.rs)** — was `format!()` with manual JSON escaping, broke on any quote or newline in error messages. Now via `serde_json::json!` + `to_string` in a new `build_tool_failed_payload` helper.
- **AgentRequest empty-body fallback (agent.rs)** — 12-line manual struct literal duplicated `#[serde(default)]`. Now `#[derive(Default)]` + `AgentRequest::default()`.

## Audit
2026-05-20 deep-dive audit, gizza-ai findings #7, #8, #12.

## Test plan
- [x] `cargo test` — 35 pass (3 new)
- [x] Pre-existing `dead_code` warning on `DEFAULT_MODEL_ID` exists on `main` and is unrelated (Wave 4 will fix by making it a `ConfigVar`).