### PR TITLE
refactor(block-utils): centralize filename_with_suffix and format_to_mime_and_ext

### DIFF
--- a/block-utils/src/lib.rs
+++ b/block-utils/src/lib.rs
@@ -241,6 +241,40 @@ pub fn replace_extension(filename: &str, new_ext: &str) -> String {
     format!("{base}.{new_ext}")
 }
 
+/// Strip a filename's last extension, append `suffix`, then add `new_ext`.
+///
+/// ```text
+/// filename_with_suffix("cat.png", "-resized", "jpg")  → "cat-resized.jpg"
+/// filename_with_suffix("cat",     "-resized", "jpg")  → "cat-resized.jpg"
+/// filename_with_suffix("a.b.mp4", "-trimmed", "mp4")  → "a.b-trimmed.mp4"
+/// ```
+pub fn filename_with_suffix(input: &str, suffix: &str, new_ext: &str) -> String {
+    let stem = match input.rsplit_once('.') {
+        Some((s, _)) => s,
+        None => input,
+    };
+    format!("{stem}{suffix}.{new_ext}")
+}
+
+/// Map a `(kind, format-string)` pair to `(mime, extension)`.
+///
+/// Returns `None` for unrecognised format strings. The format strings are the
+/// user-facing API values each block accepts (e.g. `"jpeg"` not `"jpg"`).
+///
+/// Supported:
+/// - `AssetKind::Image`: `"jpeg"` → `("image/jpeg", "jpg")`, `"png"`, `"webp"`
+/// - `AssetKind::Video`: `"mp4"` → `("video/mp4", "mp4")`, `"webm"`
+pub fn format_to_mime_and_ext(kind: AssetKind, fmt: &str) -> Option<(&'static str, &'static str)> {
+    match (kind, fmt) {
+        (AssetKind::Image, "jpeg") => Some(("image/jpeg", "jpg")),
+        (AssetKind::Image, "png")  => Some(("image/png",  "png")),
+        (AssetKind::Image, "webp") => Some(("image/webp", "webp")),
+        (AssetKind::Video, "mp4")  => Some(("video/mp4",  "mp4")),
+        (AssetKind::Video, "webm") => Some(("video/webm", "webm")),
+        _ => None,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // AssetKind — image vs video, controls MIME prefix, expected-label, kind-label,
 // and default filename used by `fetch_from_url` / `load_from_attachment`.
@@ -677,6 +711,36 @@ mod tests {
     #[test]
     fn replace_extension_appends_when_no_dot() {
         assert_eq!(replace_extension("cat", "png"), "cat.png");
+    }
+
+    #[test]
+    fn filename_with_suffix_replaces_extension() {
+        assert_eq!(filename_with_suffix("cat.png", "-resized", "jpg"), "cat-resized.jpg");
+    }
+
+    #[test]
+    fn filename_with_suffix_no_extension() {
+        assert_eq!(filename_with_suffix("cat", "-resized", "jpg"), "cat-resized.jpg");
+    }
+
+    #[test]
+    fn filename_with_suffix_multiple_dots() {
+        // Only the LAST dot-segment is treated as the extension
+        assert_eq!(filename_with_suffix("video.tmp.mp4", "-trimmed", "mp4"), "video.tmp-trimmed.mp4");
+    }
+
+    #[test]
+    fn format_to_mime_and_ext_image() {
+        assert_eq!(format_to_mime_and_ext(AssetKind::Image, "jpeg"), Some(("image/jpeg", "jpg")));
+        assert_eq!(format_to_mime_and_ext(AssetKind::Image, "png"),  Some(("image/png",  "png")));
+        assert_eq!(format_to_mime_and_ext(AssetKind::Image, "webp"), Some(("image/webp", "webp")));
+        assert_eq!(format_to_mime_and_ext(AssetKind::Image, "bogus"), None);
+    }
+
+    #[test]
+    fn format_to_mime_and_ext_video() {
+        assert_eq!(format_to_mime_and_ext(AssetKind::Video, "mp4"),  Some(("video/mp4",  "mp4")));
+        assert_eq!(format_to_mime_and_ext(AssetKind::Video, "webm"), Some(("video/webm", "webm")));
     }
 
     #[test]

--- a/blocks/image-convert/src/lib.rs
+++ b/blocks/image-convert/src/lib.rs
@@ -7,8 +7,9 @@
 
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use gizza_ai_block_utils::{
-    dispatch_ffmpeg_runtime, mime_to_ext, replace_extension, validate_quality_1_100, AssetKind,
-    Envelope, FfmpegReq, FfmpegResp, ForUi, SkillError, SkillResultExt, Source, SourceFields,
+    dispatch_ffmpeg_runtime, format_to_mime_and_ext, mime_to_ext, replace_extension,
+    validate_quality_1_100, AssetKind, Envelope, FfmpegReq, FfmpegResp, ForUi, SkillError,
+    SkillResultExt, Source, SourceFields,
 };
 use serde::Deserialize;
 use wafer_sdk::*;
@@ -36,14 +37,6 @@ fn quality_to_qv(q: u8) -> u8 {
     qv.round().clamp(2.0, 31.0) as u8
 }
 
-fn format_to_mime_and_ext(fmt: &str) -> Option<(&'static str, &'static str)> {
-    match fmt {
-        "jpeg" => Some(("image/jpeg", "jpg")),
-        "png"  => Some(("image/png",  "png")),
-        "webp" => Some(("image/webp", "webp")),
-        _ => None,
-    }
-}
 
 fn build_argv(in_name: &str, out_name: &str, format: &str, quality: u8) -> Vec<String> {
     let mut argv = vec!["-i".to_string(), in_name.to_string()];
@@ -95,7 +88,7 @@ impl ImageConvert {
 #[cfg(target_arch = "wasm32")]
 fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
     let args: Args = serde_json::from_slice(&body).invalid_args("image-convert")?;
-    let (out_mime, out_ext) = format_to_mime_and_ext(&args.format).ok_or_else(|| {
+    let (out_mime, out_ext) = format_to_mime_and_ext(AssetKind::Image, &args.format).ok_or_else(|| {
         SkillError::InvalidArgs(format!(
             "invalid image-convert args: format {:?} not supported (jpeg|png|webp)",
             args.format

--- a/blocks/image-crop/src/lib.rs
+++ b/blocks/image-crop/src/lib.rs
@@ -7,8 +7,8 @@
 
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use gizza_ai_block_utils::{
-    dispatch_ffmpeg_runtime, mime_to_ext, AssetKind, Envelope, FfmpegReq, FfmpegResp, ForUi,
-    SkillError, SkillResultExt, Source, SourceFields,
+    dispatch_ffmpeg_runtime, filename_with_suffix, mime_to_ext, AssetKind, Envelope, FfmpegReq,
+    FfmpegResp, ForUi, SkillError, SkillResultExt, Source, SourceFields,
 };
 use serde::Deserialize;
 use wafer_sdk::*;
@@ -39,10 +39,6 @@ fn build_argv(in_name: &str, out_name: &str, x: u32, y: u32, w: u32, h: u32) -> 
     ]
 }
 
-fn output_filename(input_filename: &str, ext: &str) -> String {
-    let base = input_filename.rsplitn(2, '.').last().unwrap_or(input_filename);
-    format!("{base}-cropped.{ext}")
-}
 
 #[cfg(target_arch = "wasm32")]
 struct ImageCrop;
@@ -133,7 +129,7 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
     let output_size = ff.output.len();
     let encoded = B64.encode(&ff.output);
     let data_url = format!("data:{mime};base64,{encoded}");
-    let filename = output_filename(&in_filename, ext);
+    let filename = filename_with_suffix(&in_filename, "-cropped", ext);
     let env = Envelope {
         for_llm: format!(
             "cropped {} at ({},{}) {}x{} ({} {})",
@@ -166,6 +162,6 @@ mod tests {
 
     #[test]
     fn output_filename_appends_cropped_suffix() {
-        assert_eq!(output_filename("cat.png", "png"), "cat-cropped.png");
+        assert_eq!(filename_with_suffix("cat.png", "-cropped", "png"), "cat-cropped.png");
     }
 }

--- a/blocks/image-resize/src/lib.rs
+++ b/blocks/image-resize/src/lib.rs
@@ -10,8 +10,8 @@
 
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use gizza_ai_block_utils::{
-    dispatch_ffmpeg_runtime, mime_to_ext, AssetKind, Envelope, FfmpegReq, FfmpegResp, ForUi,
-    SkillError, SkillResultExt, Source, SourceFields,
+    dispatch_ffmpeg_runtime, filename_with_suffix, mime_to_ext, AssetKind, Envelope, FfmpegReq,
+    FfmpegResp, ForUi, SkillError, SkillResultExt, Source, SourceFields,
 };
 use serde::Deserialize;
 use wafer_sdk::*;
@@ -59,14 +59,6 @@ fn build_argv(in_name: &str, out_name: &str, w: Option<u32>, h: Option<u32>, fit
     vec!["-i".into(), in_name.into(), "-vf".into(), vf, out_name.into()]
 }
 
-fn output_filename(input_filename: &str, w: Option<u32>, h: Option<u32>, ext: &str) -> String {
-    let base = input_filename.rsplitn(2, '.').last().unwrap_or(input_filename);
-    let suffix = match (w, h) {
-        (Some(w), Some(h)) => format!("-{}x{}", w, h),
-        _ => "-resized".to_string(),
-    };
-    format!("{base}{suffix}.{ext}")
-}
 
 fn summary(source: &str, w: Option<u32>, h: Option<u32>, output_size: usize, mime: &str) -> String {
     match (w, h) {
@@ -183,7 +175,11 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
     let output_size = ff.output.len();
     let encoded = B64.encode(&ff.output);
     let data_url = format!("data:{mime};base64,{encoded}");
-    let filename = output_filename(&in_filename, args.width, args.height, ext);
+    let dim_suffix = match (args.width, args.height) {
+        (Some(w), Some(h)) => format!("-{}x{}", w, h),
+        _ => "-resized".to_string(),
+    };
+    let filename = filename_with_suffix(&in_filename, &dim_suffix, ext);
     let env = Envelope {
         for_llm: summary(&in_filename, args.width, args.height, output_size, &mime),
         for_ui: ForUi {
@@ -249,11 +245,11 @@ mod tests {
 
     #[test]
     fn output_filename_uses_dim_suffix_when_both_given() {
-        assert_eq!(output_filename("cat.png", Some(640), Some(480), "png"), "cat-640x480.png");
+        assert_eq!(filename_with_suffix("cat.png", "-640x480", "png"), "cat-640x480.png");
     }
 
     #[test]
     fn output_filename_uses_resized_suffix_when_one_dim() {
-        assert_eq!(output_filename("cat.png", Some(640), None, "png"), "cat-resized.png");
+        assert_eq!(filename_with_suffix("cat.png", "-resized", "png"), "cat-resized.png");
     }
 }

--- a/blocks/video-frame-extract/src/lib.rs
+++ b/blocks/video-frame-extract/src/lib.rs
@@ -7,8 +7,8 @@
 
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use gizza_ai_block_utils::{
-    dispatch_ffmpeg_runtime, mime_to_ext, AssetKind, Envelope, FfmpegReq, FfmpegResp, ForUi,
-    SkillError, SkillResultExt, Source, SourceFields,
+    dispatch_ffmpeg_runtime, filename_with_suffix, mime_to_ext, AssetKind, Envelope, FfmpegReq,
+    FfmpegResp, ForUi, SkillError, SkillResultExt, Source, SourceFields,
 };
 use serde::Deserialize;
 use wafer_sdk::*;
@@ -26,9 +26,6 @@ struct Args {
     timestamp: f64,
 }
 
-fn in_filename_stem(name: &str) -> &str {
-    name.rsplit_once('.').map(|(s, _)| s).unwrap_or(name)
-}
 
 fn build_argv(in_name: &str, out_name: &str, timestamp: f64) -> Vec<String> {
     vec![
@@ -130,8 +127,7 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
     let output_size = ff.output.len();
     let encoded = B64.encode(&ff.output);
     let data_url = format!("data:image/png;base64,{encoded}");
-    let stem = in_filename_stem(&in_filename);
-    let filename = format!("{stem}-frame-{}.png", args.timestamp);
+    let filename = filename_with_suffix(&in_filename, &format!("-frame-{}", args.timestamp), "png");
 
     let env = Envelope {
         for_llm: format!(

--- a/blocks/video-transcode/src/lib.rs
+++ b/blocks/video-transcode/src/lib.rs
@@ -7,8 +7,9 @@
 
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use gizza_ai_block_utils::{
-    dispatch_ffmpeg_runtime, mime_to_ext, replace_extension, validate_quality_1_100, AssetKind,
-    Envelope, FfmpegReq, FfmpegResp, ForUi, SkillError, SkillResultExt, Source, SourceFields,
+    dispatch_ffmpeg_runtime, format_to_mime_and_ext, mime_to_ext, replace_extension,
+    validate_quality_1_100, AssetKind, Envelope, FfmpegReq, FfmpegResp, ForUi, SkillError,
+    SkillResultExt, Source, SourceFields,
 };
 use serde::Deserialize;
 use wafer_sdk::*;
@@ -36,13 +37,6 @@ fn quality_to_crf(q: u8) -> u8 {
     crf.round().clamp(0.0, 51.0) as u8
 }
 
-fn format_to_mime_and_ext(fmt: &str) -> Option<(&'static str, &'static str)> {
-    match fmt {
-        "mp4" => Some(("video/mp4", "mp4")),
-        "webm" => Some(("video/webm", "webm")),
-        _ => None,
-    }
-}
 
 fn build_argv(in_name: &str, out_name: &str, format: &str, crf: u8) -> Vec<String> {
     match format {
@@ -116,7 +110,7 @@ impl VideoTranscode {
 #[cfg(target_arch = "wasm32")]
 fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
     let args: Args = serde_json::from_slice(&body).invalid_args("video-transcode")?;
-    let (out_mime, out_ext) = format_to_mime_and_ext(&args.format).ok_or_else(|| {
+    let (out_mime, out_ext) = format_to_mime_and_ext(AssetKind::Video, &args.format).ok_or_else(|| {
         SkillError::InvalidArgs(format!(
             "invalid video-transcode args: format {:?} not supported (mp4|webm)",
             args.format

--- a/blocks/video-trim/src/lib.rs
+++ b/blocks/video-trim/src/lib.rs
@@ -7,8 +7,8 @@
 
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use gizza_ai_block_utils::{
-    dispatch_ffmpeg_runtime, mime_to_ext, AssetKind, Envelope, FfmpegReq, FfmpegResp, ForUi,
-    SkillError, SkillResultExt, Source, SourceFields,
+    dispatch_ffmpeg_runtime, mime_to_ext, replace_extension, AssetKind, Envelope, FfmpegReq,
+    FfmpegResp, ForUi, SkillError, SkillResultExt, Source, SourceFields,
 };
 use serde::Deserialize;
 use wafer_sdk::*;
@@ -41,10 +41,6 @@ fn build_argv(in_name: &str, out_name: &str, start: f64, duration: f64) -> Vec<S
     ]
 }
 
-fn output_filename(in_filename: &str, out_ext: &str) -> String {
-    let stem = in_filename.rsplit_once('.').map(|(s, _)| s).unwrap_or(in_filename);
-    format!("{stem}.{out_ext}")
-}
 
 #[cfg(target_arch = "wasm32")]
 struct VideoTrim;
@@ -138,7 +134,7 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
     let output_size = ff.output.len();
     let encoded = B64.encode(&ff.output);
     let data_url = format!("data:video/mp4;base64,{encoded}");
-    let filename = output_filename(&in_filename, "mp4");
+    let filename = replace_extension(&in_filename, "mp4");
     let env = Envelope {
         for_llm: format!(
             "trimmed {} to [{}s, {}s+{}s] ({} bytes mp4)",


### PR DESCRIPTION
## Summary
- `filename_with_suffix(input, suffix, new_ext)` added to `block-utils/src/lib.rs`; four blocks (`image-crop`, `image-resize`, `video-trim`, `video-frame-extract`) had near-identical idioms for this and now consume the shared helper.
- `format_to_mime_and_ext(AssetKind, fmt)` unifies the two per-block format→mime tables (`image-convert` and `video-transcode`).
- `video-trim`'s local helper was a verbatim copy of the existing `replace_extension`, so it uses `replace_extension` directly (no suffix).

## Audit
2026-05-20 deep-dive audit, gizza-ai findings #2 and #10.

## Test plan
- [x] All 7 block crates pass tests + clippy
- [x] 5 new unit tests for the two helpers (multi-dot, no-extension, format-bogus → None cases)