### PR TITLE
docs: trim NEXT.md to open work + living gotchas

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -1,134 +1,90 @@
 # Next Steps
 
-Short handoff note — captures what's still to do after the Plan B MVP
-merge. `FUTURE.md` is the long-term catalogue; this file is "what I'd
-actually pick up next session."
+Short handoff note — what's still open to pick up next session. `FUTURE.md`
+is the long-term catalogue; this file is the near-term queue plus the
+operational gotchas worth keeping at hand. Historical merge logs were
+dropped 2026-06-03 (they live in git history); only open work and living
+reference remain.
 
-## Audit closeout follow-ups (2026-05-15 — post PR #61)
+## Pending work
 
-`docs/rust-review-2026-05-14.md` was deleted in PR #61 after closing the
-deferred items (rustfmt config, rust-version=1.82, `is_none_or`,
-`Result<_, String>` → `SkillError` / `ExtractionError`, agent module-doc
-→ `docs/architecture/agent-block.md`, type-state `SourceFields` across 6
-image/video blocks). A few items from that audit were left on the floor:
+### Blocked on a producer-side (solobase) change
 
-- **Pre-merge clippy on the wasm32-wasip1 sub-workspaces.** The host
-  crate is clippy-clean; each block crate has its own `Cargo.toml` and
+- [ ] **Conversation persistence** — write user/assistant turns to
+  `suppers-ai/messages`; load prior entries on page init. **Blocked**: the
+  `suppers-ai/messages` list endpoint requires authentication and gizza-ai
+  runs anonymous. Either an anonymous list path or a server-side helper that
+  synthesizes auth needs to land in solobase first.
+- [ ] **`gizza-ai/search-messages`** — calls `suppers-ai/messages` via
+  `ctx.call_block` to search past conversation. Blocked on conversation
+  persistence above (no chat history is persisted today).
+
+### Operator items (your action only)
+
+- [ ] Configure GitHub Pages for the repo (Settings → Pages → source:
+  `gh-pages`).
+- [ ] DNS: CNAME `gizza.ai` → `gizza-ai.github.io` (and `www.` if desired).
+
+### CI / quality
+
+- [ ] **Pre-merge clippy on the wasm32-wasip1 sub-workspaces.** The host
+  crate is clippy-clean, but each block crate has its own `Cargo.toml` and
   is never linted by CI. Add a `justfile` recipe that loops `cargo +nightly
   clippy --target wasm32-wasip1 --all-targets` over `block-utils/` and
   `blocks/*/`, and wire it into the GH Actions `test` workflow.
-- **Trim remaining module-doc rationale.** `src/lib.rs:1-9` and
+- [ ] Make the Playwright e2e suite reliable in CI (model caching across
+  runs via persistent context, OR an LLM-free dispatch path). Low priority —
+  `cargo test --test dispatch_skills` covers the bulk of regressions cheaply.
+
+### Smaller paper-cuts
+
+- [ ] `security-headers` block reads CSP from flow-step config, not from
+  `block_configs` (filed in Plan B commit `d83d657`). Clean fix is upstream:
+  have the block also consult `block_configs`, or expose
+  `SolobaseBuilder::csp(...)`.
+- [ ] Error taxonomy for `AssetLoadError` could split `LoaderNotConfigured`
+  from `UnknownLoader`, and `Bridge(String)` from `Unknown(String)` (both
+  noted in Plan A reviews). Low urgency.
+- [ ] Trim remaining module-doc rationale: `src/lib.rs:1-9` and
   `src/blocks/ui.rs:1-5` still describe high-level architecture in `//!`
-  comments. Either keep (they're short) or move to
-  `docs/architecture/`. Also: the 5–10 line `//` blocks inside
-  `handle_chat`'s confirmation round-trip path (`agent.rs:~239`,
-  `~285`) are protocol-flavor — fine to keep, but flagging.
-- **let-else / .clone audit** — intentionally skipped. let-else doesn't
-  cleanly bind `Err` variants, and the `Attachment` clone path is gated
-  to 10 MiB once-per-dispatch (audit itself rated "low magnitude").
-  Revisit if either pattern becomes a hotspot.
+  comments — either keep (they're short) or move to `docs/architecture/`.
 
-## Resume here (2026-05-05 — post sub-project 5 image-ops merge)
+_let-else / `.clone` audit was intentionally skipped: let-else doesn't
+cleanly bind `Err` variants, and the `Attachment` clone path is gated to
+10 MiB once-per-dispatch (rated "low magnitude"). Revisit only if either
+becomes a hotspot._
 
-A productive day across three repos. Stack of merges, top to bottom:
+## Operational gotchas (living reference)
 
-- **gizza-ai #33** (this PR) — SP3 drag-drop file upload UI. User drops image/video onto the chat; appears as removable chips above the textarea; on send, files become attachments under `upload_N` ids and the LLM sees them as synthetic prior tool_results matching the Phase A chaining hint format. Uses the same `{ref}` mechanism as chained skill outputs. 10 MiB per-file cap, image/video only, multi-file, paperclip fallback for mobile/a11y.
-- **wafer-run #36 / #37 / #38** — attachment ABI (per-call host helpers `__wafer_host_stream_attach` + `__wafer_host_lookup_attachment` + `Context::lookup_attachment` + `Attachment` type), `#[wafer_block(skill(...))]` macro attribute for LLM tool schemas, and wafer-cli validator stubs for the new imports.
-- **gizza-ai #32** (this PR) — SP5 video slice. Three new skills: `gizza-ai/video-transcode` (mp4/webm with quality knob), `gizza-ai/video-trim` (stream-copy to mp4), `gizza-ai/video-frame-extract` (single-frame PNG, naturally chainable into image-* skills via the SP4 envelope). 10 MiB symmetric caps. All accept `{url|ref}`. The `dispatch_chains_video_frame_extract_then_image_resize_via_ref` test proves the cross-modality chain.
-- **gizza-ai #31** (this PR) — skill-output chaining. Agent block stashes `_for_ui` attachments per request and appends a ref hint to `_for_llm`; image-resize / image-crop / image-convert accept `{ref: "<call-id>"}` as an alternative to `{url}`. **Also fixes a pre-existing gap:** every gizza-ai skill block (clock, calculator, web-fetch, image-fetch, ffmpeg, image-resize, image-crop, image-convert) now uses the new `skill(...)` macro attribute, so the LLM finally sees them in the tool list. Before this PR, `Context::registered_blocks()` had `role: None` and `tool: None` on every wasmi-built skill; the agent's `build_tools()` returned an empty `Vec<ToolDefinition>` on every chat request.
-- **wafer-run #34** — binary transport overhaul (streaming ABI + MessagePack + shared `wafer_block::wire::*` types).
-- **solobase #63** — consumer migration to the new transport.
-- **gizza-ai #27** — bridge `Result<String, JsValue>` fix + pin bump.
-- **gizza-ai #29** — gizza-ai consumer migration (web-fetch / image-fetch / ffmpeg → typed clients).
-- **gizza-ai #30** (this PR) — sub-project 5 image-ops slice: `gizza-ai/image-resize`, `gizza-ai/image-crop`, `gizza-ai/image-convert`. Uses `wafer_sdk::clients::network::do_request` for the network call and a small `dispatch_ffmpeg_runtime` helper (raw streaming ABI + serde_json for the consumer-controlled FfmpegReq/Resp protocol) for the ffmpeg-runtime call. 4 MiB caps both directions (now safe — no wasmi 6× JSON inflation).
-- Sub-project 4 (inline media rendering) is on main from earlier in the day in PR #26, with the SP4 envelope `{_for_llm, _for_ui}` already in production.
-
-**Top of the queue:**
-
-1. **Operator items below — your action only.** Unblock the live site.
-2. **Conversation persistence** — still blocked on producer-side solobase change.
-
-**Cross-repo news from the 2026-05-03 session:**
-
-- **solobase #47 (browser vector + embedding backend) is MERGED.** Ships
-  `BrowserVectorService` (sql.js + FTS5) + `BrowserEmbeddingService`
-  (Transformers.js bridge) + `suppers-ai/transformers-embed` block, all
-  wired through `SolobaseBuilder::vector_service(...)` /
-  `embedding_service(...)`. If gizza-ai wants to bump `solobase-pin.txt`
-  to pick up the new vector backend (relevant for `search-messages` and
-  any future RAG skill), the SHA is on solobase `main` post-#47. Nothing
-  in gizza-ai breaks without bumping — the pin is opt-in.
-- **Smoke test infrastructure on solobase is now reliable.** PR #48/#49/
-  #51 fixed the SW-registration smoke (lazy WebLLM ESM import,
-  waitUntil:`commit`, waitForURL instead of racing goto). If you copy
-  any of solobase-web's smoke patterns into gizza-ai's e2e, those are
-  the green ones to imitate.
-- **A real product bug was caught and fixed in solobase #47**:
-  `scripts/build-sql-js-fts5.sh` had been overriding sql.js's full
-  `SQLITE_COMPILATION_FLAGS` with just our 4 flags, dropping
-  `-DSQLITE_OMIT_LOAD_EXTENSION` (the killer — leaves dlopen stubs as
-  null function pointers in wasm and traps with "null function" the
-  first time `new SQL.Database()` runs in a Service Worker). The
-  rebuilt FTS5 wasm is 761 KB (vs the broken 1.3 MB one). **Lesson for
-  any future custom-emcc builds in this repo: never override an
-  upstream `*_COMPILATION_FLAGS` macro without preserving the defaults
-  — extend the list, don't replace it.**
-
-**Operator items (your action) — still outstanding from Plan C:**
-
-- Configure GitHub Pages for the repo (Settings → Pages → source: `gh-pages`).
-- DNS: CNAME `gizza.ai` → `gizza-ai.github.io` (and `www.` if desired).
-
-**Operational gotchas that bit us in past sessions:**
-
-- `solobase` on `$PATH` is the wrong binary (Go-based). Use the full path `/home/joris/Programs/suppers-ai/workspace/solobase/target/release/solobase`.
-- `~/.cargo/bin/wafer` can be stale relative to `wafer-run/main`. Symptom: `wafer build` fails with "function type mismatch for import wafer::__wafer_host_call_block". Fix: `cd wafer-run && cargo install --path crates/wafer-cli --force`.
-- Always `--no-track` when creating a new branch: `git worktree add --no-track -b NEW ../path origin/main`. Plain `git checkout -b NEW origin/main` silently sets upstream to `origin/main` and a later `git push` pushes to main.
-- The Playwright e2e (`tests/e2e_smoke.spec.ts`) is gated on headed Chromium (WebGPU) and a 1.2 GB WebLLM download; it's a manual smoke, not CI. The deterministic CI gate is `cargo test --test dispatch_skills` (see `tests/README.md`).
-- **Debugging Service Worker tests in Playwright**: `page.on('console')` only captures the page's console, NOT the SW's. To see SW logs, hook `context.on('serviceworker', sw => sw.on('console', ...))`. The 2026-05-03 solobase smoke debug took several CI cycles to find this — saved the diagnostic snippet in solobase's git history if you need it.
-- **Rebuilding sql.js FTS5**: Docker Desktop must be running. Run `bash scripts/build-sql-js-fts5.sh` (in solobase) — takes ~5 min in the `emscripten/emsdk:3.1.74` container. The script now passes the FULL upstream `SQLITE_COMPILATION_FLAGS` plus `-DSQLITE_ENABLE_FTS5`; do NOT shorten that list (see #47 commit `1373975` for why).
-- **Skill blocks must use `#[wafer_block(skill(...))]` to appear in tool-calling.** Without the `skill(...)` attribute, `BlockInfo` carries `role: None` and `tool: None`, so `build_tools()` silently returns an empty list. Any new skill block that omits the attribute will be invisible to the LLM. Fixed for all existing blocks in gizza-ai #31.
-
----
-
-## Recommended order
-
-### 1. Deploy (Plan C — DONE, two operator items remain)
-
-- [x] GitHub Actions workflow: run `solobase build` on push to `main`, deploy `pkg/` to `gh-pages` branch.
-- [x] Add `CNAME` with `gizza.ai` to the deploy artifact.
-- [ ] Configure GitHub Pages for the repo (Settings → Pages → source: gh-pages). _Operator action._
-- [ ] DNS: CNAME `gizza.ai` to `gizza-ai.github.io` (and www. if desired). _Operator action._
-- [x] Switch `.cargo/config.toml` patches off by default — moved to `.cargo/config.toml.example` and gitignored.
-- [x] Bump `Cargo.toml` deps to pin specific merged commit SHAs (via `solobase-pin.txt` for the deploy job).
-- [ ] Optional: auto-reload on `navigator.serviceWorker.oncontrollerchange` in `loader.js` — zero-reload updates. _Moved to a follow-up in solobase since `loader.js` lives in `solobase-browser`._
-
-### 2. Full v1 skill set (Plan D)
-
-- [x] `gizza-ai/web-fetch` — fetch a URL via `call_block("wafer-run/network", …)`.
-- [x] `gizza-ai/calculator` — eval arithmetic via `meval`. Zero deps.
-- [~] `gizza-ai/ffmpeg` — flagship. Decomposed into sub-projects (see specs). Status:
-  - [x] **Sub-project 1** — ffmpeg-runtime invocation primitive (PR #21). Native `FfmpegBlock` registered as `gizza-ai/ffmpeg-runtime`, JS bridge at `js/ffmpeg.js` lazy-loads `@ffmpeg/ffmpeg` from jsdelivr.
-  - [x] **Sub-project 2** — ffprobe-scope skill (PR #22). Two-hop `call_block` (network → bytes → ffmpeg-runtime → log). Tool surface: `{url}` only; returns `{url, info}` JSON.
-  - [x] **Sub-project 3** — file drag-drop UI shipped in PR #33. Image/video files drop onto the page → chips → on send, the LLM sees `upload_N` refs alongside chained-call refs.
-  - [x] **Sub-project 4** — inline `<img>`/`<video>` rendering (PR #26). Envelope wire format `{_for_llm, _for_ui}` bifurcates LLM history from UI rendering. Demonstrating skill `gizza-ai/image-fetch` proves the path. Renders inside the tool-call row. Sub-project 5 inherits the envelope; image transcoding can ship without further wire changes (video transcoding uses the `media-src` CSP entry added here).
-  - [x] **Sub-project 5** — resize/transcode/crop/trim. Image slice (image-resize/crop/convert) shipped in PR #30. Video slice (video-transcode/trim/frame-extract) shipped in PR #32 — same SP5 template, 10 MiB caps, chainable via {url|ref}.
-- [ ] `gizza-ai/search-messages` — calls `suppers-ai/messages` via `ctx.call_block` to search past conversation. **Blocked**: chat history isn't persisted to `suppers-ai/messages` today, and persistence itself is blocked on a producer-side change (see Plan E).
-
-### 3. UX polish (Plan E)
-
-- [x] **Markdown rendering** — shipped in PR #14. `marked.parse(raw, { breaks: true, gfm: true })` in `gizza-app.js::renderAssistantContent`; CDN load via `<script src="...marked@13.0.0/marked.min.js">` in `src/blocks/ui.rs`. Re-renders on each token; HTML-escape-by-default.
-- [ ] **Conversation persistence** — write user/assistant turns to `suppers-ai/messages`; load prior entries on page init. **Blocked on producer-side (solobase) change**: the `suppers-ai/messages` list endpoint requires authentication and gizza-ai runs anonymous. Either an anonymous list path or a server-side helper that synthesizes auth needs to land in solobase first.
-- [x] **Code syntax highlighting** — shipped in PR #14. `hljs.highlightElement` over `pre code` blocks inside `renderAssistantContent`; github-dark theme + highlight.min.js loaded via cdn.jsdelivr.net (also added to CSP `style-src`).
-- [x] **Model picker UI** — shipped in PR #14. `<select id="model-picker">` populated client-side from WebLLM's `prebuiltAppConfig.model_list` via dynamic import; selection persists in `localStorage` under `gizza.selectedModel`; tool-supporting families (Hermes-2/3, Qwen2.5, Llama-3-Groq, functionary) get a 🔧 marker.
-
-## Smaller paper-cuts
-
-- [ ] `security-headers` block reads CSP from flow-step config, not from block_configs. Filed in Plan B commit message (`d83d657`). The clean fix is upstream: have the block also consult `block_configs`, or expose `SolobaseBuilder::csp(...)`.
-- [ ] Error taxonomy for `AssetLoadError` could split `LoaderNotConfigured` from `UnknownLoader` (noted in Plan A code-quality review) and `Bridge(String)` from `Unknown(String)` (noted in Plan A Task 5 review). Low urgency.
-- [x] `ExternalAsset::timeout_ms` field — shipped as wafer-run #29.
-- [x] Dev server (`python3 -m http.server`) doesn't set `Cache-Control: no-cache` on `sw.js`. Resolved as well as it can be: `static/_headers` ships a `Cache-Control: no-cache` rule for `/sw.js` (PR #15) and `loader.js` registers the SW with `updateViaCache: 'none'`. Note: GitHub Pages doesn't honor `_headers` (Netlify/Cloudflare convention), so the file is dead weight on the current target — the real fix is the client-side `updateViaCache: 'none'`. If we ever switch hosts to Cloudflare/Netlify the file is already in place.
-- [ ] Make Playwright e2e suite reliable in CI (model caching across runs via persistent context, OR an LLM-free dispatch path). Tracked as a future item; the current `dispatch_skills.rs` covers the bulk of regressions cheaply, so this is low priority.
+- `solobase` on `$PATH` is the wrong binary (Go-based). Use the full path
+  `/home/joris/Programs/suppers-ai/workspace/solobase/target/release/solobase`.
+- `~/.cargo/bin/wafer` can be stale relative to `wafer-run/main`. Symptom:
+  `wafer build` fails with "function type mismatch for import
+  wafer::__wafer_host_call_block". Fix: `cd wafer-run && cargo install --path
+  crates/wafer-cli --force`.
+- Always `--no-track` when creating a new branch: `git worktree add
+  --no-track -b NEW ../path origin/main`. Plain `git checkout -b NEW
+  origin/main` silently sets upstream to `origin/main` and a later
+  `git push` pushes to main.
+- The Playwright e2e (`tests/e2e_smoke.spec.ts`) is gated on headed Chromium
+  (WebGPU) and a 1.2 GB WebLLM download; it's a manual smoke, not CI. The
+  deterministic CI gate is `cargo test --test dispatch_skills` (see
+  `tests/README.md`).
+- **Debugging Service Worker tests in Playwright**: `page.on('console')`
+  only captures the page's console, NOT the SW's. To see SW logs, hook
+  `context.on('serviceworker', sw => sw.on('console', ...))`.
+- **Rebuilding sql.js FTS5**: Docker Desktop must be running. Run `bash
+  scripts/build-sql-js-fts5.sh` (in solobase) — ~5 min in the
+  `emscripten/emsdk:3.1.74` container. The script passes the FULL upstream
+  `SQLITE_COMPILATION_FLAGS` plus `-DSQLITE_ENABLE_FTS5`; do NOT shorten that
+  list (see solobase #47 commit `1373975` — dropping
+  `-DSQLITE_OMIT_LOAD_EXTENSION` leaves dlopen stubs as null function
+  pointers in wasm and traps with "null function" on first
+  `new SQL.Database()` in a Service Worker).
+- **Skill blocks must use `#[wafer_block(skill(...))]` to appear in
+  tool-calling.** Without the `skill(...)` attribute, `BlockInfo` carries
+  `role: None` and `tool: None`, so `build_tools()` silently returns an empty
+  list — the block is invisible to the LLM.
 
 ## References
 
@@ -136,8 +92,4 @@ A productive day across three repos. Stack of merges, top to bottom:
 - Plan A (upstream enablers, merged): `docs/superpowers/plans/2026-04-18-gizza-ai-plan-a-upstream.md`
 - Plan B (MVP, merged): `docs/superpowers/plans/2026-04-18-gizza-ai-plan-b-mvp.md`
 - Plan C campaign (NEXT.md execution): `docs/superpowers/plans/2026-04-30-gizza-ai-next-md-implementation.md`
-- web-fetch: spec `2026-05-01-gizza-ai-web-fetch-design.md`, plan `2026-05-01-gizza-ai-web-fetch.md`
-- LLM-free dispatch test: spec `2026-05-01-gizza-ai-llm-free-dispatch-test-design.md`, plan `2026-05-01-gizza-ai-llm-free-dispatch-test.md`
-- ffmpeg sub-project 1 (runtime): spec `2026-05-01-gizza-ai-ffmpeg-invocation-primitive-design.md`, plan `2026-05-01-gizza-ai-ffmpeg-invocation-primitive.md`
-- ffmpeg sub-project 2 (ffprobe skill): spec `2026-05-01-gizza-ai-ffmpeg-skill-ffprobe-design.md`, plan `2026-05-01-gizza-ai-ffmpeg-skill-ffprobe.md`
 - Deferred features catalogue: `FUTURE.md`


### PR DESCRIPTION
## Summary
`NEXT.md` had accreted dated merge-log narrative — the 2026-05-03 / 05-05 session logs and the Plan C/D/E checklists (all `[x]` shipped). That content is now just git history. This trims the file down to:

- **Pending work** — conversation persistence + `search-messages` (both blocked on a solobase producer-side change), operator GitHub Pages/DNS items, wasm32-wasip1 clippy CI gap, and the open smaller paper-cuts.
- **Operational gotchas** (living reference) — kept verbatim; these are still useful (solobase binary path, `wafer` reinstall, `--no-track` footgun, SW console hooking, sql.js FTS5 rebuild, the `skill(...)` attribute requirement).
- **References** — pruned to the still-relevant design/plan links.

No open `[ ]` item was dropped.

## Test plan
- Docs-only change; no code or build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)