### PR TITLE
refactor(agent): drop dead SkillRole; gate skills on tool presence

### DIFF
--- a/src/blocks/agent.rs
+++ b/src/blocks/agent.rs
@@ -27,7 +27,7 @@ use wafer_block::{
     core_types::{LifecycleEvent, Message, MetaEntry, WaferError},
     meta::{META_RESP_CONTENT_TYPE, META_RESP_STATUS},
     streams::{input::InputStream, output::OutputStream},
-    types::{BlockInfo, SkillRole},
+    types::BlockInfo,
 };
 
 /// The agent block's chat endpoint.
@@ -148,7 +148,7 @@ impl Block for AgentBlock {
 // ---------------------------------------------------------------------------
 
 /// Enumerate every registered block whose name starts with `gizza-ai/` and
-/// has `role == Some(SkillRole::Skill)` with a tool descriptor. Returns the
+/// exposes a tool descriptor (i.e. is an agent-callable skill). Returns the
 /// list as a JSON body for the frontend slash-autocomplete dropdown (PR 6).
 fn handle_commands(ctx: &dyn Context) -> OutputStream {
     let entries: Vec<serde_json::Value> = list_skill_commands(&ctx.registered_blocks())
@@ -178,12 +178,10 @@ fn handle_commands(ctx: &dyn Context) -> OutputStream {
 fn list_skill_commands(blocks: &[BlockInfo]) -> Vec<(String, String)> {
     let mut out: Vec<(String, String)> = blocks
         .iter()
-        .filter_map(|info| match (&info.role, &info.tool) {
-            (Some(SkillRole::Skill), Some(tool)) => {
-                let cmd = info.name.strip_prefix(SKILL_PREFIX)?;
-                Some((cmd.to_string(), tool.description.clone()))
-            }
-            _ => None,
+        .filter_map(|info| {
+            let tool = info.tool.as_ref()?;
+            let cmd = info.name.strip_prefix(SKILL_PREFIX)?;
+            Some((cmd.to_string(), tool.description.clone()))
         })
         .collect();
     out.sort_by(|a, b| a.0.cmp(&b.0));
@@ -333,20 +331,17 @@ mod tests {
     #[test]
     fn list_skill_commands_filters_to_skills_strips_prefix_and_sorts() {
         let skill_a = BlockInfo::new("gizza-ai/imagine", "0.1.0", "handler@v1", "")
-            .role(SkillRole::Skill)
             .tool(SkillTool {
                 description: "Generate image".into(),
                 parameters: serde_json::json!({}),
             });
         let skill_b = BlockInfo::new("gizza-ai/clock", "0.1.0", "handler@v1", "")
-            .role(SkillRole::Skill)
             .tool(SkillTool {
                 description: "Current time".into(),
                 parameters: serde_json::json!({}),
             });
         let non_skill = BlockInfo::new("gizza-ai/ui", "0.1.0", "handler@v1", "");
         let other_prefix = BlockInfo::new("suppers-ai/other", "0.1.0", "handler@v1", "")
-            .role(SkillRole::Skill)
             .tool(SkillTool {
                 description: "should be filtered".into(),
                 parameters: serde_json::json!({}),
@@ -359,13 +354,6 @@ mod tests {
                 ("imagine".to_string(), "Generate image".to_string()),
             ]
         );
-    }
-
-    #[test]
-    fn list_skill_commands_skips_skills_without_tool() {
-        let bare = BlockInfo::new("gizza-ai/x", "0.1.0", "handler@v1", "").role(SkillRole::Skill);
-        let cmds = list_skill_commands(&[bare]);
-        assert!(cmds.is_empty());
     }
 
     // -----------------------------------------------------------------------

--- a/src/blocks/agent/slash.rs
+++ b/src/blocks/agent/slash.rs
@@ -5,7 +5,7 @@ use futures::{pin_mut, StreamExt};
 use wafer_block::{
     context::Context,
     core_types::WaferError,
-    types::{BlockInfo, SkillRole, SkillTool},
+    types::{BlockInfo, SkillTool},
 };
 use wafer_core::clients::llm::{
     ChatChunk, ChatContent, ChatMessage, ChatParams, ChatRequest, ChatRole, ChunkDelta,
@@ -31,13 +31,13 @@ pub(super) fn parse_slash(user_message: &str) -> Option<(&str, &str)> {
     Some((cmd, args))
 }
 
-/// Find the `SkillTool` descriptor for `gizza-ai/<cmd>` in the registry,
-/// requiring `role == SkillRole::Skill`.
+/// Find the `SkillTool` descriptor for `gizza-ai/<cmd>` in the registry.
+/// A block is an agent-callable skill iff it carries a `tool` descriptor.
 pub(super) fn lookup_skill_tool<'a>(blocks: &'a [BlockInfo], cmd: &str) -> Option<&'a SkillTool> {
     let full = format!("{SKILL_PREFIX}{cmd}");
     blocks
         .iter()
-        .find(|info| info.name == full && matches!(info.role, Some(SkillRole::Skill)))
+        .find(|info| info.name == full)
         .and_then(|info| info.tool.as_ref())
 }
 
@@ -348,12 +348,10 @@ mod tests {
     #[test]
     fn lookup_skill_tool_resolves_short_name() {
         let blocks = [
-            BlockInfo::new("gizza-ai/imagine", "0.1.0", "handler@v1", "")
-                .role(SkillRole::Skill)
-                .tool(SkillTool {
-                    description: "Generate image".into(),
-                    parameters: serde_json::json!({}),
-                }),
+            BlockInfo::new("gizza-ai/imagine", "0.1.0", "handler@v1", "").tool(SkillTool {
+                description: "Generate image".into(),
+                parameters: serde_json::json!({}),
+            }),
         ];
         let tool = lookup_skill_tool(&blocks, "imagine").expect("found");
         assert_eq!(tool.description, "Generate image");


### PR DESCRIPTION
## Why

wafer-block removes the single-variant `SkillRole` enum (wafer-run paired PR). It carried **zero information** beyond `tool.is_some()` — the `#[wafer_block]` macro always set `.role(Skill)` and `.tool(...)` together, and this agent block always required both. So `role` was provably dead.

## What

- `list_skill_commands` (agent.rs) and `lookup_skill_tool` (agent/slash.rs) now key off `info.tool` alone — a block is an agent-callable skill iff it carries a `SkillTool` descriptor.
- Drop the `SkillRole` imports and the `.role(SkillRole::Skill)` calls in test setup (agent.rs + agent/slash.rs).
- Delete `list_skill_commands_skips_skills_without_tool` — its premise (a skill with `role` set but `tool` unset) is now unrepresentable. The no-tool-skip behavior remains covered by the `gizza-ai/ui` (no-tool) case in `list_skill_commands_filters_to_skills_strips_prefix_and_sorts`.

## Sequencing

**Merge this consumer PR first**, then the wafer-run producer PR. This change removes *usage* of a type that still exists in wafer-run `main`, so it compiles against both the pre- and post-removal producer (forward-compatible). gizza CI builds against wafer-run `main`, so consumer-first means there is **no broken window** — whereas merging the producer first would briefly red gizza `main`.

Producer PR: wafer-run#240.

## Verification

`cargo test --lib` in the gizza worktree (against wafer-run `main` git dep, still defining `SkillRole`): **35 passed, 0 failed** — incl. `lookup_skill_tool_*`, `list_skill_commands_filters_to_skills_strips_prefix_and_sorts`, all `parse_slash_*`/`is_prompt_shaped_*`. (`tests/dispatch_skills.rs` needs the `solobase build` block wasms, produced in CI's "Build skill wasms" step; it has no `SkillRole` references.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)