### PR TITLE
ci: pin wasm-pack to v0.15.0 (stop flaky fallback to ancient v0.9.1)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,14 @@ jobs:
 
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          # Pin explicitly. With no version the action resolves "latest" via
+          # the GitHub API and falls back to its ancient hardcoded default
+          # (v0.9.1) whenever that lookup flakes/rate-limits — and v0.9.1
+          # cannot parse workspace-inherited manifest fields like
+          # `license.workspace = true`, failing with "invalid type: map,
+          # expected a string for key `package.license`".
+          version: 'v0.15.0'
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,14 @@ jobs:
 
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          # Pin explicitly. With no version the action resolves "latest" via
+          # the GitHub API and falls back to its ancient hardcoded default
+          # (v0.9.1) whenever that lookup flakes/rate-limits — and v0.9.1
+          # cannot parse workspace-inherited manifest fields like
+          # `license.workspace = true`, failing with "invalid type: map,
+          # expected a string for key `package.license`".
+          version: 'v0.15.0'
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Problem

`jetli/wasm-pack-action@v0.4.0` is used with **no `version:` input** in both `test.yml` and `deploy.yml`. With no version it resolves "latest" via the GitHub API and **falls back to its hardcoded default `v0.9.1`** whenever that lookup flakes or rate-limits.

wasm-pack **v0.9.1 predates Cargo workspace inheritance** and cannot parse `license.workspace = true` (line 5 of the solobase pin's `crates/solobase-web/Cargo.toml`). The "Build solobase-web wasm" step then dies with:

```
failed to parse manifest: crates/solobase-web/Cargo.toml
Caused by: invalid type: map, expected a string for key `package.license`
```

This is **non-deterministic and code-independent**. Concrete evidence from a single push to `main`:
- the **Test** job installed `wasm-pack v0.15.0` and proceeded;
- the **Deploy** job (concurrent, same commit) installed `wasm-pack v0.9.1` and failed at 25s.

It is unrelated to any source change — it fails while wasm-pack *parses the manifest*, before anything compiles.

## Fix

Pin `version: 'v0.15.0'` (the version that demonstrably works in passing runs) on the `jetli/wasm-pack-action` step in both workflows, so the toolchain is deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)