### PR TITLE
ci: target the production environment in the deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,14 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    # CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID are scoped to the
+    # `production` GitHub environment, so the job must target it — otherwise
+    # `secrets.*` resolves to empty and wrangler fails with "necessary to set
+    # a CLOUDFLARE_API_TOKEN". (The environment's deployment-branch policy
+    # must allow `main`, which is the only branch this workflow runs on.)
+    environment:
+      name: production
+      url: https://gizza.ai
     steps:
       - name: Checkout gizza-ai
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The Cloudflare deploy job fails at the final step with:

```
✘ [ERROR] In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work.
```

`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` were added to the **`production` GitHub environment**. A job that does not declare `environment:` only sees *repository-level* secrets, so `${{ secrets.CLOUDFLARE_API_TOKEN }}` resolved to empty.

(The build now reaches the deploy step cleanly — the wasm-pack pin in #75 fixed the earlier `license.workspace` parse failure.)

## Fix

Declare `environment: { name: production, url: https://gizza.ai }` on the `build-and-deploy` job so the env-scoped secrets are injected. No change to the `secrets.*` references is needed — environment secrets override repo secrets of the same name when the job targets that environment.

## ⚠️ Required GitHub setting (not in this PR)

The `production` environment's **deployment-branch policy must allow `main`** (the only branch this workflow runs on). If it's set to "Selected branches and tags" without `main`, the merged run is blocked by environment protection rules. Set it to "No restriction" or add a `main` rule under *Settings → Environments → production → Deployment branches and tags*.

## Validation

`deploy.yml` only triggers on `push: [main]` + `workflow_dispatch`, so this can only be exercised after merge to `main` (or via `gh workflow run`). The PR's `test` job is unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)