### PR TITLE
ci: auto-create the gizza-ai Pages project if missing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,6 +95,24 @@ jobs:
           done
           cargo run --manifest-path tools/generator/Cargo.toml -- .
 
+      - name: Ensure Pages project exists
+        # `pages deploy` does NOT create the project — a fresh account fails
+        # with "Project not found ... [code: 8000007]". Create it once if
+        # missing (idempotent: skipped when it already exists). Requires the
+        # API token to carry the "Cloudflare Pages: Edit" permission; a
+        # read-only token will fail loudly here rather than at the deploy step.
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if npx --yes wrangler@4.100.0 pages project list \
+               | grep -qE '(^|[^A-Za-z0-9_-])gizza-ai([^A-Za-z0-9_-]|$)'; then
+            echo "Pages project 'gizza-ai' already exists — skipping create."
+          else
+            echo "Pages project 'gizza-ai' not found — creating it."
+            npx --yes wrangler@4.100.0 pages project create gizza-ai --production-branch=main
+          fi
+
       - name: Deploy to Cloudflare Pages
         # workingDirectory is gizza-ai so wrangler finds the sibling `functions/`
         # directory (the Pages Functions middleware that does the *.gizza.ai


### PR DESCRIPTION
## Problem

After wiring `environment: production` (#76), the deploy reaches Cloudflare and authenticates, but fails:

```
✘ A request to the Cloudflare API (/accounts/***/pages/projects/gizza-ai) failed.
  Project not found. The specified project name does not match any of your existing projects. [code: 8000007]
```

`wrangler pages deploy --project-name=gizza-ai` does **not** create the project — it must already exist. (404, not 403 — the token can read the Pages API; there's just no `gizza-ai` project in that account.)

## Fix

Idempotent pre-deploy step: list projects and create `gizza-ai` (production branch `main`) only if absent, so the first deploy bootstraps itself and re-runs are no-ops.

**Requires the API token to have "Cloudflare Pages: Edit"** (create) permission — a read-only token now fails loudly at this step rather than confusingly at deploy. Deploy itself needs Edit anyway, so an existing valid deploy token already satisfies this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)