### PR TITLE
ci: size-optimized release profile (fix 25 MiB Cloudflare Pages limit)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,16 @@ gloo-timers = { version = "0.3", features = ["futures"] }
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }
 async-trait = "0.1"
+
+# Size-optimized release profile for the Cloudflare-Pages wasm bundle.
+# `solobase build` compiles this crate to wasm with `--release`; without
+# these settings the app wasm is ~29 MB and Cloudflare Pages rejects it
+# ("Pages only supports files up to 25 MiB in size"). With them it drops
+# to a few MB. Mirrors solobase's and site's release profiles (and is what
+# solobase's own cloudflare `profile_check` recommends).
+[profile.release]
+opt-level = "z"
+lto = true
+codegen-units = 1
+strip = true
+panic = "abort"


### PR DESCRIPTION
## Problem

With the deploy now reaching the upload stage (project created, auth OK), Cloudflare Pages rejects it:

```
✨ Compiled Worker successfully
✘ [ERROR] Error: Pages only supports files up to 25 MiB in size
```

The offending file is the app bundle `pkg/gizza_ai_bg-<hash>.wasm` at **~29 MB**. gizza-ai's `Cargo.toml` had **no `[profile.release]`**, so `solobase build --release` used cargo defaults (`opt-level=3`, no LTO, no strip).

## Fix

Add the same size-optimized release profile solobase and site already ship (and that solobase's cloudflare `profile_check` explicitly recommends):

```toml
[profile.release]
opt-level = "z"
lto = true
codegen-units = 1
strip = true
panic = "abort"
```

This is the deferred *"surface `profile.release` requirement to other consumers"* item — gizza was the consumer that never adopted it. An optimized build of this exact crate is ~3.7 MB locally, well under the 25 MiB limit; per-tool web wasms are already tiny (21K–130K).

🤖 Generated with [Claude Code](https://claude.com/claude-code)