### PR TITLE
ci: build the site wasm with --release for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,7 +82,13 @@ jobs:
 
       - name: Build site
         working-directory: gizza-ai
-        run: solobase build
+        # `--release` is required: without it `solobase build` runs
+        # `wasm-pack build --dev`, producing an unoptimized ~29 MB app wasm
+        # that Cloudflare Pages rejects (25 MiB/file limit). With `--release`
+        # (+ the size-optimized [profile.release] in Cargo.toml) the bundle
+        # drops to a few MB. The per-tool wasm-pack builds below already use
+        # `--release`.
+        run: solobase build --release
 
       - name: Build tool pages
         # Per-tool web wasm + rendered standalone pages into pkg/tools/.


### PR DESCRIPTION
## Root cause

`solobase build` defaults to **debug** (`wasm-pack build --dev`, "default is debug for fast iteration"). The deploy's "Build site" step ran plain `solobase build`, so the app bundle `gizza_ai_bg-<hash>.wasm` was an unoptimized **~29 MB debug** wasm — over Cloudflare Pages' 25 MiB/file limit.

This is also why the `[profile.release]` size opts (#78) didn't help: the build wasn't a release build at all.

## Fix

`solobase build` → `solobase build --release`. Combined with the size profile (#78), the app wasm drops to a few MB (an optimized build of this crate is ~3.7 MB locally). The per-tool `wasm-pack build` steps already pass `--release`.

This is the final layer in the deploy chain (wasm-pack pin #75 → environment #76 → auto-create project #77 → size profile #78 → this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)