### PR TITLE
ci: enable bulk-memory in wasm-opt for the Cloudflare --release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,3 +81,19 @@ lto = true
 codegen-units = 1
 strip = true
 panic = "abort"
+
+# wasm-opt flags for the `--release` build that `solobase build --release`
+# runs via `wasm-pack`. Two things matter here:
+#   * `--all-features` — rustc emits bulk-memory ops (memory.copy/fill) by
+#     default, but wasm-pack's bundled `wasm-opt` rejects them unless the
+#     feature is enabled ("Bulk memory operations require bulk memory
+#     [--enable-bulk-memory]"), so the default `wasm-opt -O` aborts validation.
+#   * `-Oz` — size-optimize, which (with `[profile.release]` above) keeps the
+#     bundle under Cloudflare Pages' 25 MiB per-file limit.
+# Mirrors solobase-web / solobase-browser, the proven Cloudflare wasm build.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-Oz", "--all-features"]
+
+# Debug builds skip wasm-opt entirely (fast iteration; size doesn't matter).
+[package.metadata.wasm-pack.profile.dev]
+wasm-opt = false


### PR DESCRIPTION
## Problem

The Cloudflare Pages deploy (run `27544339607`, on `ae7b3c3`) got past the 25 MiB limit (#78/#79) only to fail one layer deeper, at **Build site**:

```
[wasm-validator error in function …] Bulk memory operations require bulk memory [--enable-bulk-memory]
Fatal: error validating input
Error: failed to execute `wasm-opt`: … "-O"
error: wasm-pack build failed
```

`solobase build --release` runs `wasm-pack build --release`, which — unlike `--dev` — post-processes the app wasm with `wasm-opt`. Modern rustc emits **bulk-memory** ops (`memory.copy`/`memory.fill`) by default, but wasm-pack's bundled `wasm-opt` rejects them under its default `-O` run, so validation aborts.

## Fix

Add the wasm-pack release metadata so wasm-opt runs `-Oz --all-features`:

- `--all-features` enables bulk-memory (and the rest), so wasm-opt accepts the input.
- `-Oz` size-optimizes, keeping the bundle under Cloudflare Pages' 25 MiB per-file limit.
- `--dev` skips wasm-opt entirely (fast iteration).

This **mirrors `solobase-web` / `solobase-browser`**, the proven Cloudflare wasm build — the last consumer to adopt the pattern.

## Verification

Ran the exact wasm-pack-bundled `wasm-opt` binary (`~/.cache/.wasm-pack/wasm-opt-1ceaaea8b7b5f7e0/bin/wasm-opt`, same path/hash as CI) with `-Oz --all-features` on the app wasm → **exit 0**, valid output, comfortably under 25 MiB. (The local debug artifact predates the bulk-memory-emitting toolchain, so the rejection itself reproduces only in CI; merging exercises the real path.)

Final layer of the gizza Cloudflare deploy chain (#75–#79).

🤖 Generated with [Claude Code](https://claude.com/claude-code)