### PR TITLE
feat(md-tool-pages): per-tool index.md twin for LLMs

### DIFF
--- a/docs/superpowers/plans/2026-06-17-markdown-tool-pages.md
+++ b/docs/superpowers/plans/2026-06-17-markdown-tool-pages.md
@@ -1,50 +1,53 @@
-# Markdown-for-LLMs tool pages Implementation Plan
+# Markdown tool-page twins Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Emit a clean markdown twin (`index.md`) of every tool page plus a root `/llms.txt` index, single-sourced from the `meta.toml` + `content.md` the generator already reads, so web-browsing LLMs can read tools without parsing HTML.
+**Goal:** Emit a clean markdown twin (`index.md`) of every tool page, single-sourced from the `meta.toml` + `content.md` the generator already reads, so web-browsing LLMs can read tools without parsing HTML.
 
-**Architecture:** Add a `markdown` module to the existing `tools/generator` static pass. For each tool it writes `pkg/tools/<slug>/index.md` (a generated header — description, run-it, inputs, output — followed by the tool's `content.md` prose). Once per run it writes `pkg/llms.txt` (a title + summary + link list to each `index.md`). The HTML head gains a `<link rel="alternate" type="text/markdown">`, and `/llms.txt` is added to the SW fetch-bypass. No runtime/block/SW-template changes. See the design: `docs/superpowers/specs/2026-06-17-markdown-tool-pages-design.md`.
+**Architecture:** Add a `markdown` module to the existing `tools/generator` static pass. For each tool it writes `pkg/tools/<slug>/index.md` — a generated header (description, run-it, inputs, output) followed by the tool's `content.md` prose. The HTML head gains a `<link rel="alternate" type="text/markdown">`. No runtime/block/SW changes, and explicitly **no** `/llms.txt`/`sitemap`/`robots` work — that belongs to the separate `feat/seo-discoverability-and-chrome` effort. See the design: `docs/superpowers/specs/2026-06-17-markdown-tool-pages-design.md`.
 
-**Tech Stack:** Rust (`tools/generator`, a static binary `gizza-tool-pages`), `toml`/`serde` (already used by `meta.rs`), `node:test` for the SW-bypass assertion.
+**Tech Stack:** Rust (`tools/generator`, a static binary `gizza-tool-pages`), `toml`/`serde` (already used by `meta.rs`).
 
 ---
 
 ## Commands (run from `gizza-ai/`)
 
 - Generator unit tests (CI gate): `cargo test --manifest-path tools/generator/Cargo.toml`
-- Generator compiles: `cargo build --manifest-path tools/generator/Cargo.toml`
-- App build (regenerates `pkg/sw.js`): `solobase build`
-- SW-bypass JS test: `node --test js/sw-bypass.test.js`
+- Just the markdown/template tests: `cargo test --manifest-path tools/generator/Cargo.toml markdown` / `… --lib`
 
-Note: producing the *actual* `index.md`/`llms.txt` files requires running the
-`gizza-tool-pages` binary, which first needs each tool's `blocks/<slug>/web/pkg/`
-wasm built (the deploy pipeline does this). The **unit tests** prove
-`tool_markdown`/`llms_txt` correctness deterministically without that heavy step.
-
-## Reference: `ToolMeta` fields (from `tools/generator/src/meta.rs`)
+## Reference: `ToolMeta` (from `tools/generator/src/meta.rs`)
 
 `slug, title, description, tags, h1, hero_subtitle, wasm, export, live,
 interval_ms, output_label, format, runtime, inputs: Vec<Input>` where
-`Input { name, source, label, placeholder, accept }` and `source ∈
+`Input { name, source, label, placeholder, accept }`, `source ∈
 {"field","clock","file"}`.
+
+## Coordination note
+
+This branch (`feat/md-tool-pages`) currently carries the SEO effort's design-doc
+commit `bc18942` in its base (an artifact of the shared-tree branch tangle). That
+is harmless — it's the same commit `feat/seo-discoverability-and-chrome` will
+merge — and resolves itself on merge to `main`. Do **not** rebase it off
+`bc18942` while other sessions are live (that would disturb the shared working
+tree). Before each commit, run `git branch --show-current` and confirm it reads
+`feat/md-tool-pages` (the shared tree can be switched by another session).
 
 ---
 
-### Task 1: `markdown::tool_markdown` (per-tool `index.md` body)
+### Task 1: `markdown::tool_markdown` (per-tool `index.md`)
 
 **Files:**
 - Create: `tools/generator/src/markdown.rs`
+- Modify: `tools/generator/src/main.rs:8` (add `mod markdown;`)
 
-- [ ] **Step 1: Write the module with failing tests**
+- [ ] **Step 1: Create the module with its tests**
 
 Create `tools/generator/src/markdown.rs`:
 
 ```rust
-//! Markdown twin of each tool page + the root /llms.txt index.
-//!
-//! Single-sourced from the same `ToolMeta` (meta.toml) + content.md that drive
-//! the HTML page, so web-browsing LLMs can read tools without parsing HTML.
+//! Markdown twin of each tool page (`index.md`), single-sourced from the same
+//! `ToolMeta` (meta.toml) + content.md that drive the HTML page, so web-browsing
+//! LLMs can read a tool without parsing HTML.
 
 use crate::meta::{Input, ToolMeta};
 
@@ -200,7 +203,7 @@ source = "clock"
     }
 
     #[test]
-    fn live_tool_takes_no_arguments() {
+    fn live_tool_takes_no_manual_arguments() {
         let md = tool_markdown(&live_tool(), "prose");
         assert!(md.contains("`gizza tool clock`"), "no-arg CLI example");
         assert!(md.contains("_no manual inputs — runs automatically_"), "no manual inputs note");
@@ -208,7 +211,7 @@ source = "clock"
 }
 ```
 
-- [ ] **Step 2: Add the module declaration**
+- [ ] **Step 2: Declare the module**
 
 In `tools/generator/src/main.rs`, after `mod index;` (line 8), add:
 
@@ -216,99 +219,28 @@ In `tools/generator/src/main.rs`, after `mod index;` (line 8), add:
 mod markdown;
 ```
 
-- [ ] **Step 3: Run tests to verify they pass**
+- [ ] **Step 3: Run the tests to verify they pass**
 
 Run: `cargo test --manifest-path tools/generator/Cargo.toml markdown`
 Expected: PASS — `field_tool_has_header_runit_inputs_output_prose`,
-`file_tool_uses_path_example_and_accept`, `live_tool_takes_no_arguments`.
+`file_tool_uses_path_example_and_accept`, `live_tool_takes_no_manual_arguments`.
 
-(If `mod markdown;` is missing the module won't compile — that's the red state.)
-
-- [ ] **Step 4: Commit**
+- [ ] **Step 4: Commit** (first confirm the branch — shared tree)
 
 ```bash
+test "$(git branch --show-current)" = "feat/md-tool-pages" || { echo "WRONG BRANCH"; exit 1; }
 git add tools/generator/src/markdown.rs tools/generator/src/main.rs
 git commit -m "feat(md-tool-pages): markdown::tool_markdown renders per-tool index.md"
 ```
 
 ---
 
-### Task 2: `markdown::llms_txt` (root `/llms.txt` index)
+### Task 2: Write `index.md` per tool in the generator pass
 
 **Files:**
-- Modify: `tools/generator/src/markdown.rs`
+- Modify: `tools/generator/src/main.rs:44-45` (after the `index.html` write)
 
-- [ ] **Step 1: Write the failing test**
-
-In `tools/generator/src/markdown.rs`, inside `mod tests`, add:
-
-```rust
-    #[test]
-    fn llms_txt_lists_each_tool_with_absolute_md_link() {
-        let out = llms_txt(&[field_tool(), live_tool()]);
-        assert!(out.contains("# gizza.ai"), "title");
-        assert!(out.contains("## Tools"), "tools section");
-        assert!(
-            out.contains("- [Free Online Calculator — gizza.ai](https://gizza.ai/tools/calculator/index.md): Evaluate expressions instantly."),
-            "calculator entry with absolute .md link",
-        );
-        assert!(
-            out.contains("- [Clock — gizza.ai](https://gizza.ai/tools/clock/index.md): The current time, live."),
-            "clock entry",
-        );
-    }
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `cargo test --manifest-path tools/generator/Cargo.toml llms_txt`
-Expected: FAIL — `cannot find function llms_txt in this scope`.
-
-- [ ] **Step 3: Implement `llms_txt`**
-
-In `tools/generator/src/markdown.rs`, after `tool_markdown` (before `fn cli_example`), add:
-
-```rust
-/// Render the root `/llms.txt`: a title, a summary blockquote, and a link list
-/// to each tool's markdown twin (an index, not a full dump).
-pub fn llms_txt(metas: &[ToolMeta]) -> String {
-    let mut s = String::new();
-    s.push_str("# gizza.ai — browser-native tools\n\n");
-    s.push_str(
-        "> Free, single-purpose tools that run entirely in your browser. Many also \
-run headlessly via `gizza tool <name>` (see the CLI + SKILL.md in the repo).\n\n",
-    );
-    s.push_str("## Tools\n\n");
-    for m in metas {
-        s.push_str(&format!(
-            "- [{}]({}/tools/{}/index.md): {}\n",
-            m.title, SITE, m.slug, m.description
-        ));
-    }
-    s
-}
-```
-
-- [ ] **Step 4: Run test to verify it passes**
-
-Run: `cargo test --manifest-path tools/generator/Cargo.toml llms_txt`
-Expected: PASS.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add tools/generator/src/markdown.rs
-git commit -m "feat(md-tool-pages): markdown::llms_txt renders the root /llms.txt index"
-```
-
----
-
-### Task 3: Wire `markdown` into the generator pass
-
-**Files:**
-- Modify: `tools/generator/src/main.rs:44-45` (write `index.md`), `:76-77` (write `llms.txt`)
-
-- [ ] **Step 1: Write `index.md` per tool**
+- [ ] **Step 1: Add the `index.md` write**
 
 In `tools/generator/src/main.rs`, immediately after the `index.html` write
 (currently lines 44-45):
@@ -325,48 +257,33 @@ add:
             .map_err(|e| format!("write index.md: {e}"))?;
 ```
 
-- [ ] **Step 2: Write `llms.txt` once at pkg root**
+(`out`, `m`, and `content_md` are all in scope in this loop.)
 
-In `tools/generator/src/main.rs`, immediately after the `robots.txt` write
-(currently lines 76-77):
-
-```rust
-    fs::write(pkg.join("robots.txt"), seo::robots())
-        .map_err(|e| format!("write robots.txt: {e}"))?;
-```
-
-add:
-
-```rust
-    fs::write(pkg.join("llms.txt"), markdown::llms_txt(&metas_only))
-        .map_err(|e| format!("write llms.txt: {e}"))?;
-```
-
-(`metas_only` is already built at line 65; `pkg` at line 73 — both in scope here.)
-
-- [ ] **Step 3: Verify the generator still compiles + all generator tests pass**
+- [ ] **Step 2: Verify the generator compiles + all generator tests pass**
 
 Run: `cargo test --manifest-path tools/generator/Cargo.toml`
-Expected: PASS — all existing tests plus the new markdown tests; no compile errors.
+Expected: PASS — existing `index`/`meta`/`seo`/`template` tests plus the new
+`markdown` tests; no compile errors.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 3: Commit**
 
 ```bash
+test "$(git branch --show-current)" = "feat/md-tool-pages" || { echo "WRONG BRANCH"; exit 1; }
 git add tools/generator/src/main.rs
-git commit -m "feat(md-tool-pages): generator writes index.md per tool + pkg/llms.txt"
+git commit -m "feat(md-tool-pages): generator writes index.md next to index.html per tool"
 ```
 
 ---
 
-### Task 4: HTML discovery link (`<link rel="alternate">`)
+### Task 3: HTML discovery link (`<link rel="alternate">`)
 
 **Files:**
-- Modify: `tools/generator/src/template.rs` (head, near the canonical link ~line 38; test ~line 147)
+- Modify: `tools/generator/src/template.rs` (head near the canonical link ~line 38; existing head test ~line 147)
 
 - [ ] **Step 1: Add the failing assertion to the existing head test**
 
 In `tools/generator/src/template.rs`, inside the test that already renders a page
-and asserts the canonical link (after the line
+and asserts the canonical link (right after the line
 `assert!(html.contains(r#"<link rel="canonical" href="https://gizza.ai/tools/calculator/">"#));`),
 add:
 
@@ -399,96 +316,38 @@ Expected: PASS.
 - [ ] **Step 5: Commit**
 
 ```bash
+test "$(git branch --show-current)" = "feat/md-tool-pages" || { echo "WRONG BRANCH"; exit 1; }
 git add tools/generator/src/template.rs
 git commit -m "feat(md-tool-pages): link rel=alternate text/markdown in each page head"
 ```
 
 ---
 
-### Task 5: Serve + SW-bypass `/llms.txt`
-
-**Files:**
-- Modify: `js/sw-bypass.test.js` (add assertion), `solobase.toml` (`extra_bypass_prefix`)
-
-- [ ] **Step 1: Write the failing bypass assertion**
-
-In `js/sw-bypass.test.js`, after the existing `/tools/` test, append:
-
-```js
-test('sw.js bypasses /llms.txt so the agent index serves statically in-browser', () => {
-  assert.ok(existsSync(swPath), 'pkg/sw.js missing — run `solobase build` first');
-  const src = readFileSync(swPath, 'utf8');
-  assert.match(
-    src,
-    /startsWith\(['"]\/llms\.txt['"]\)/,
-    'sw.js is missing the /llms.txt bypass — check extra_bypass_prefix in solobase.toml',
-  );
-});
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `node --test js/sw-bypass.test.js`
-Expected: FAIL — current `pkg/sw.js` has no `/llms.txt` bypass.
-
-- [ ] **Step 3: Add `/llms.txt` to the bypass list**
-
-In `solobase.toml`, append `"/llms.txt"` to the `[assets].extra_bypass_prefix`
-array (keep all existing entries):
-
-```toml
-extra_bypass_prefix = ["/gizza-app.js", "/gizza.css", "/render.js", "/pending.js", "/gis.png", "/gis_no_eyes.png", "/gis_a_job_no_eyes.png", "/eye.png", "/gis_video_idle.mp4", "/gis_video_typing_loop.mp4", "/gis_video_typing_finish.mp4", "/favicon.ico", "/favicon-32.png", "/apple-touch-icon.png", "/logo.webp", "/model-picker.js", "/model-picker.css", "/tool.js", "/tool.css", "/tools/", "/tools-modal.js", "/tools-modal.css", "/llms.txt"]
-```
-
-- [ ] **Step 4: Rebuild so `pkg/sw.js` regenerates**
-
-Run: `solobase build`
-Expected: build succeeds; `pkg/sw.js` now contains the `/llms.txt` bypass clause.
-
-- [ ] **Step 5: Run the bypass test to verify it passes**
-
-Run: `node --test js/sw-bypass.test.js`
-Expected: PASS.
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add solobase.toml js/sw-bypass.test.js
-git commit -m "build(md-tool-pages): SW-bypass /llms.txt so it serves statically"
-```
-
----
-
-### Task 6: Final verification
+### Task 4: Final verification
 
 - [ ] **Step 1: Run the generator CI-gate suite**
 
 Run: `cargo test --manifest-path tools/generator/Cargo.toml`
 Expected: PASS — all generator tests (markdown + template + index + seo + meta).
 
-- [ ] **Step 2: Sanity-check the rendered output shape (no per-tool wasm needed)**
-
-Add a throwaway check by running the markdown unit assertions only (already
-covered in Tasks 1-2); confirm by eye that a sample `tool_markdown` output reads
-well as markdown (header, Run it, Inputs, Output, `---`, prose). No code change.
-
-- [ ] **Step 3: (Optional, deploy-pipeline) full generation**
+- [ ] **Step 2: (Optional, deploy pipeline) full generation**
 
 When per-tool wasms exist (`blocks/<slug>/web/pkg/` built — the deploy pipeline
-does this), running `gizza-tool-pages` (`cargo run --manifest-path
+does this), `gizza-tool-pages` (`cargo run --manifest-path
 tools/generator/Cargo.toml -- .`) writes `pkg/tools/<slug>/index.md` for every
-tool and `pkg/llms.txt`. Confirm `pkg/llms.txt` lists every tool and a sample
-`pkg/tools/calculator/index.md` looks right. This is exercised by the existing
-deploy build; no new pipeline step is required.
+tool. Confirm a sample `pkg/tools/calculator/index.md` reads well as markdown
+(header, Run it, Inputs, Output, `---`, prose) and that `index.html` links it via
+the `<link rel="alternate">`. No new pipeline step is required.
 
-- [ ] **Step 4: Record completion in the spec**
+- [ ] **Step 3: Record completion in the spec**
 
 In `docs/superpowers/specs/2026-06-17-markdown-tool-pages-design.md`, update the
 **Status** line to note the feature is implemented + unit-tested.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 4: Commit**
 
 ```bash
+test "$(git branch --show-current)" = "feat/md-tool-pages" || { echo "WRONG BRANCH"; exit 1; }
 git add docs/superpowers/specs/2026-06-17-markdown-tool-pages-design.md
 git commit -m "docs(md-tool-pages): mark design implemented"
 ```
@@ -498,21 +357,18 @@ git commit -m "docs(md-tool-pages): mark design implemented"
 ## Self-review
 
 **Spec coverage:**
-- Per-tool `index.md` (header: description, run-it, inputs, output + prose) → Task 1 (`tool_markdown`) + Task 3 (wired). ✓
-- Root `/llms.txt` index (title + summary + link list, not full dump) → Task 2 (`llms_txt`) + Task 3 (wired). ✓
-- Schema from `meta.toml` → Tasks 1-2 read only `ToolMeta`; no runtime/CLI call. ✓
-- Field / file / live (auto) variants → Task 1 tests all three. ✓
-- `<link rel="alternate">` discovery → Task 4. ✓
-- `/llms.txt` SW-bypass → Task 5. ✓
-- Single-source / no-drift → derived entirely from `ToolMeta` + `content_md`; adding a tool auto-produces both. ✓
+- Per-tool `index.md` (header: description, run-it, inputs, output + prose) → Task 1 (`tool_markdown`) + Task 2 (wired). ✓
+- Schema from `meta.toml` → Task 1 reads only `ToolMeta`; no runtime/CLI call. ✓
+- Field / file / auto-only variants → Task 1 tests all three. ✓
+- `<link rel="alternate">` discovery → Task 3. ✓
+- **No** `/llms.txt`/`sitemap`/`robots`/`seo.rs` changes → nothing in any task touches them (owned by `feat/seo-discoverability-and-chrome`). ✓
+- Single-source / no-drift → derived entirely from `ToolMeta` + `content_md`. ✓
 
 **Placeholder scan:** No TBD/TODO/"add error handling"/"similar to" — every code and command step is concrete. ✓
 
 **Type/name consistency:** `tool_markdown(meta: &ToolMeta, content_md: &str)`,
-`llms_txt(metas: &[ToolMeta])`, `cli_example(meta)`, `SITE`, and the `Input`
-fields (`name`/`source`/`label`/`placeholder`/`accept`) match `meta.rs`. The
-generator variables `m`, `content_md`, `metas_only`, `pkg`, `out` match
-`main.rs`. Absolute `https://gizza.ai/...index.md` links are used consistently in
-`llms_txt` and tested as such. ✓
+`cli_example(meta)`, `SITE`, and the `Input` fields
+(`name`/`source`/`label`/`placeholder`/`accept`) match `meta.rs`. The generator
+variables `m`, `content_md`, `out` match `main.rs`. ✓
 
-**Note (spec refinement):** `llms_txt` uses **absolute** `https://gizza.ai/tools/<slug>/index.md` links (not the root-relative form sketched in the spec) — absolute is correct for an `llms.txt` fetched standalone via WebFetch. Spec example updated to match.
+**Collision check:** This plan touches only `tools/generator/src/{markdown.rs,main.rs,template.rs}`. The SEO effort touches `main.rs` too (it *removes* the sitemap/robots writes + `mod seo`); the only shared file is `main.rs`, where this plan adds one `index.md` write line and one `mod markdown;` — a trivial merge against that effort's removals. No shared function or struct.

--- a/docs/superpowers/plans/2026-06-17-markdown-tool-pages.md
+++ b/docs/superpowers/plans/2026-06-17-markdown-tool-pages.md
@@ -1,0 +1,518 @@
+# Markdown-for-LLMs tool pages Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Emit a clean markdown twin (`index.md`) of every tool page plus a root `/llms.txt` index, single-sourced from the `meta.toml` + `content.md` the generator already reads, so web-browsing LLMs can read tools without parsing HTML.
+
+**Architecture:** Add a `markdown` module to the existing `tools/generator` static pass. For each tool it writes `pkg/tools/<slug>/index.md` (a generated header — description, run-it, inputs, output — followed by the tool's `content.md` prose). Once per run it writes `pkg/llms.txt` (a title + summary + link list to each `index.md`). The HTML head gains a `<link rel="alternate" type="text/markdown">`, and `/llms.txt` is added to the SW fetch-bypass. No runtime/block/SW-template changes. See the design: `docs/superpowers/specs/2026-06-17-markdown-tool-pages-design.md`.
+
+**Tech Stack:** Rust (`tools/generator`, a static binary `gizza-tool-pages`), `toml`/`serde` (already used by `meta.rs`), `node:test` for the SW-bypass assertion.
+
+---
+
+## Commands (run from `gizza-ai/`)
+
+- Generator unit tests (CI gate): `cargo test --manifest-path tools/generator/Cargo.toml`
+- Generator compiles: `cargo build --manifest-path tools/generator/Cargo.toml`
+- App build (regenerates `pkg/sw.js`): `solobase build`
+- SW-bypass JS test: `node --test js/sw-bypass.test.js`
+
+Note: producing the *actual* `index.md`/`llms.txt` files requires running the
+`gizza-tool-pages` binary, which first needs each tool's `blocks/<slug>/web/pkg/`
+wasm built (the deploy pipeline does this). The **unit tests** prove
+`tool_markdown`/`llms_txt` correctness deterministically without that heavy step.
+
+## Reference: `ToolMeta` fields (from `tools/generator/src/meta.rs`)
+
+`slug, title, description, tags, h1, hero_subtitle, wasm, export, live,
+interval_ms, output_label, format, runtime, inputs: Vec<Input>` where
+`Input { name, source, label, placeholder, accept }` and `source ∈
+{"field","clock","file"}`.
+
+---
+
+### Task 1: `markdown::tool_markdown` (per-tool `index.md` body)
+
+**Files:**
+- Create: `tools/generator/src/markdown.rs`
+
+- [ ] **Step 1: Write the module with failing tests**
+
+Create `tools/generator/src/markdown.rs`:
+
+```rust
+//! Markdown twin of each tool page + the root /llms.txt index.
+//!
+//! Single-sourced from the same `ToolMeta` (meta.toml) + content.md that drive
+//! the HTML page, so web-browsing LLMs can read tools without parsing HTML.
+
+use crate::meta::{Input, ToolMeta};
+
+/// Public site origin — matches the literal used in `seo.rs` + `template.rs`.
+const SITE: &str = "https://gizza.ai";
+
+/// Render a tool's `index.md`: a generated header (description, run-it, inputs,
+/// output) followed by the tool's prose `content.md`, verbatim.
+pub fn tool_markdown(meta: &ToolMeta, content_md: &str) -> String {
+    let mut s = String::new();
+    s.push_str(&format!("# {}\n\n", meta.h1));
+    s.push_str(&format!("{}\n\n", meta.description));
+
+    s.push_str("## Run it\n\n");
+    s.push_str(&format!("- **CLI:** `{}`\n", cli_example(meta)));
+    s.push_str(&format!("- **Web:** {}/tools/{}/\n\n", SITE, meta.slug));
+
+    s.push_str("## Inputs\n\n");
+    let manual: Vec<&Input> = meta
+        .inputs
+        .iter()
+        .filter(|i| i.source == "field" || i.source == "file")
+        .collect();
+    if manual.is_empty() {
+        s.push_str("- _no manual inputs — runs automatically_\n\n");
+    } else {
+        for i in &manual {
+            let label = if i.label.is_empty() { i.name.as_str() } else { i.label.as_str() };
+            let mut note = i.source.clone();
+            if !i.accept.is_empty() {
+                note.push_str(&format!("; accept: {}", i.accept));
+            }
+            s.push_str(&format!("- `{}` — {} _({})_\n", i.name, label, note));
+        }
+        s.push('\n');
+    }
+
+    s.push_str("## Output\n\n");
+    s.push_str(&format!("- {} ({})\n\n", meta.output_label, meta.format));
+
+    s.push_str("---\n\n");
+    s.push_str(content_md.trim_end());
+    s.push('\n');
+    s
+}
+
+/// The example CLI invocation: field tools use the first field input's
+/// placeholder as the example arg; file tools take a path; auto-only tools
+/// (e.g. clock) take no args.
+fn cli_example(meta: &ToolMeta) -> String {
+    if let Some(field) = meta.inputs.iter().find(|i| i.source == "field") {
+        let arg = if field.placeholder.is_empty() { "..." } else { field.placeholder.as_str() };
+        format!("gizza tool {} \"{}\"", meta.slug, arg)
+    } else if meta.inputs.iter().any(|i| i.source == "file") {
+        format!("gizza tool {} <path>", meta.slug)
+    } else {
+        format!("gizza tool {}", meta.slug)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn field_tool() -> ToolMeta {
+        ToolMeta::from_toml(
+            r#"
+slug          = "calculator"
+title         = "Free Online Calculator — gizza.ai"
+description   = "Evaluate expressions instantly."
+tags          = ["math"]
+h1            = "Free Online Calculator"
+hero_subtitle = "Type a math expression."
+wasm          = "gizza_ai_calculator_web"
+export        = "evaluate"
+live          = false
+output_label  = "Result"
+format        = "number"
+
+[[input]]
+name        = "expr"
+label       = "Expression"
+placeholder = "2 + 2 * 3"
+source      = "field"
+"#,
+        )
+        .unwrap()
+    }
+
+    fn file_tool() -> ToolMeta {
+        ToolMeta::from_toml(
+            r#"
+slug          = "image-grayscale"
+title         = "Grayscale an Image — gizza.ai"
+description   = "Convert an image to grayscale in your browser."
+h1            = "Grayscale an Image"
+hero_subtitle = "Upload an image."
+wasm          = "gizza_ai_image_grayscale_web"
+export        = "build_argv"
+output_label  = "Image"
+format        = "image"
+runtime       = "ffmpeg"
+
+[[input]]
+name   = "file"
+label  = "Image"
+source = "file"
+accept = "image/*"
+"#,
+        )
+        .unwrap()
+    }
+
+    fn live_tool() -> ToolMeta {
+        ToolMeta::from_toml(
+            r#"
+slug          = "clock"
+title         = "Clock — gizza.ai"
+description   = "The current time, live."
+h1            = "Clock"
+hero_subtitle = "Live time."
+wasm          = "gizza_ai_clock_web"
+export        = "now"
+live          = true
+output_label  = "Time"
+format        = "text"
+
+[[input]]
+name   = "now"
+label  = "Now"
+source = "clock"
+"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn field_tool_has_header_runit_inputs_output_prose() {
+        let md = tool_markdown(&field_tool(), "Some **prose** about the calculator.");
+        assert!(md.contains("# Free Online Calculator"));
+        assert!(md.contains("`gizza tool calculator \"2 + 2 * 3\"`"), "CLI example");
+        assert!(md.contains("https://gizza.ai/tools/calculator/"), "web URL");
+        assert!(md.contains("`expr` — Expression _(field)_"), "input listed");
+        assert!(md.contains("Result (number)"), "output listed");
+        assert!(md.contains("Some **prose** about the calculator."), "prose appended");
+    }
+
+    #[test]
+    fn file_tool_uses_path_example_and_accept() {
+        let md = tool_markdown(&file_tool(), "prose");
+        assert!(md.contains("`gizza tool image-grayscale <path>`"), "path CLI example");
+        assert!(md.contains("`file` — Image _(file; accept: image/*)_"), "accept shown");
+    }
+
+    #[test]
+    fn live_tool_takes_no_arguments() {
+        let md = tool_markdown(&live_tool(), "prose");
+        assert!(md.contains("`gizza tool clock`"), "no-arg CLI example");
+        assert!(md.contains("_no manual inputs — runs automatically_"), "no manual inputs note");
+    }
+}
+```
+
+- [ ] **Step 2: Add the module declaration**
+
+In `tools/generator/src/main.rs`, after `mod index;` (line 8), add:
+
+```rust
+mod markdown;
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `cargo test --manifest-path tools/generator/Cargo.toml markdown`
+Expected: PASS — `field_tool_has_header_runit_inputs_output_prose`,
+`file_tool_uses_path_example_and_accept`, `live_tool_takes_no_arguments`.
+
+(If `mod markdown;` is missing the module won't compile — that's the red state.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/generator/src/markdown.rs tools/generator/src/main.rs
+git commit -m "feat(md-tool-pages): markdown::tool_markdown renders per-tool index.md"
+```
+
+---
+
+### Task 2: `markdown::llms_txt` (root `/llms.txt` index)
+
+**Files:**
+- Modify: `tools/generator/src/markdown.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+In `tools/generator/src/markdown.rs`, inside `mod tests`, add:
+
+```rust
+    #[test]
+    fn llms_txt_lists_each_tool_with_absolute_md_link() {
+        let out = llms_txt(&[field_tool(), live_tool()]);
+        assert!(out.contains("# gizza.ai"), "title");
+        assert!(out.contains("## Tools"), "tools section");
+        assert!(
+            out.contains("- [Free Online Calculator — gizza.ai](https://gizza.ai/tools/calculator/index.md): Evaluate expressions instantly."),
+            "calculator entry with absolute .md link",
+        );
+        assert!(
+            out.contains("- [Clock — gizza.ai](https://gizza.ai/tools/clock/index.md): The current time, live."),
+            "clock entry",
+        );
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --manifest-path tools/generator/Cargo.toml llms_txt`
+Expected: FAIL — `cannot find function llms_txt in this scope`.
+
+- [ ] **Step 3: Implement `llms_txt`**
+
+In `tools/generator/src/markdown.rs`, after `tool_markdown` (before `fn cli_example`), add:
+
+```rust
+/// Render the root `/llms.txt`: a title, a summary blockquote, and a link list
+/// to each tool's markdown twin (an index, not a full dump).
+pub fn llms_txt(metas: &[ToolMeta]) -> String {
+    let mut s = String::new();
+    s.push_str("# gizza.ai — browser-native tools\n\n");
+    s.push_str(
+        "> Free, single-purpose tools that run entirely in your browser. Many also \
+run headlessly via `gizza tool <name>` (see the CLI + SKILL.md in the repo).\n\n",
+    );
+    s.push_str("## Tools\n\n");
+    for m in metas {
+        s.push_str(&format!(
+            "- [{}]({}/tools/{}/index.md): {}\n",
+            m.title, SITE, m.slug, m.description
+        ));
+    }
+    s
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --manifest-path tools/generator/Cargo.toml llms_txt`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/generator/src/markdown.rs
+git commit -m "feat(md-tool-pages): markdown::llms_txt renders the root /llms.txt index"
+```
+
+---
+
+### Task 3: Wire `markdown` into the generator pass
+
+**Files:**
+- Modify: `tools/generator/src/main.rs:44-45` (write `index.md`), `:76-77` (write `llms.txt`)
+
+- [ ] **Step 1: Write `index.md` per tool**
+
+In `tools/generator/src/main.rs`, immediately after the `index.html` write
+(currently lines 44-45):
+
+```rust
+        fs::write(out.join("index.html"), html)
+            .map_err(|e| format!("write index.html: {e}"))?;
+```
+
+add:
+
+```rust
+        fs::write(out.join("index.md"), markdown::tool_markdown(m, &content_md))
+            .map_err(|e| format!("write index.md: {e}"))?;
+```
+
+- [ ] **Step 2: Write `llms.txt` once at pkg root**
+
+In `tools/generator/src/main.rs`, immediately after the `robots.txt` write
+(currently lines 76-77):
+
+```rust
+    fs::write(pkg.join("robots.txt"), seo::robots())
+        .map_err(|e| format!("write robots.txt: {e}"))?;
+```
+
+add:
+
+```rust
+    fs::write(pkg.join("llms.txt"), markdown::llms_txt(&metas_only))
+        .map_err(|e| format!("write llms.txt: {e}"))?;
+```
+
+(`metas_only` is already built at line 65; `pkg` at line 73 — both in scope here.)
+
+- [ ] **Step 3: Verify the generator still compiles + all generator tests pass**
+
+Run: `cargo test --manifest-path tools/generator/Cargo.toml`
+Expected: PASS — all existing tests plus the new markdown tests; no compile errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/generator/src/main.rs
+git commit -m "feat(md-tool-pages): generator writes index.md per tool + pkg/llms.txt"
+```
+
+---
+
+### Task 4: HTML discovery link (`<link rel="alternate">`)
+
+**Files:**
+- Modify: `tools/generator/src/template.rs` (head, near the canonical link ~line 38; test ~line 147)
+
+- [ ] **Step 1: Add the failing assertion to the existing head test**
+
+In `tools/generator/src/template.rs`, inside the test that already renders a page
+and asserts the canonical link (after the line
+`assert!(html.contains(r#"<link rel="canonical" href="https://gizza.ai/tools/calculator/">"#));`),
+add:
+
+```rust
+        assert!(
+            html.contains(r#"<link rel="alternate" type="text/markdown" href="index.md">"#),
+            "markdown twin discovery link present",
+        );
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --manifest-path tools/generator/Cargo.toml --lib`
+Expected: FAIL on the head test — the alternate link isn't rendered yet.
+
+- [ ] **Step 3: Render the alternate link**
+
+In `tools/generator/src/template.rs`, in the `head { … }` maud block, immediately
+after the canonical link line (`link rel="canonical" href=(canonical);`), add:
+
+```rust
+                link rel="alternate" type="text/markdown" href="index.md";
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test --manifest-path tools/generator/Cargo.toml --lib`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/generator/src/template.rs
+git commit -m "feat(md-tool-pages): link rel=alternate text/markdown in each page head"
+```
+
+---
+
+### Task 5: Serve + SW-bypass `/llms.txt`
+
+**Files:**
+- Modify: `js/sw-bypass.test.js` (add assertion), `solobase.toml` (`extra_bypass_prefix`)
+
+- [ ] **Step 1: Write the failing bypass assertion**
+
+In `js/sw-bypass.test.js`, after the existing `/tools/` test, append:
+
+```js
+test('sw.js bypasses /llms.txt so the agent index serves statically in-browser', () => {
+  assert.ok(existsSync(swPath), 'pkg/sw.js missing — run `solobase build` first');
+  const src = readFileSync(swPath, 'utf8');
+  assert.match(
+    src,
+    /startsWith\(['"]\/llms\.txt['"]\)/,
+    'sw.js is missing the /llms.txt bypass — check extra_bypass_prefix in solobase.toml',
+  );
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test js/sw-bypass.test.js`
+Expected: FAIL — current `pkg/sw.js` has no `/llms.txt` bypass.
+
+- [ ] **Step 3: Add `/llms.txt` to the bypass list**
+
+In `solobase.toml`, append `"/llms.txt"` to the `[assets].extra_bypass_prefix`
+array (keep all existing entries):
+
+```toml
+extra_bypass_prefix = ["/gizza-app.js", "/gizza.css", "/render.js", "/pending.js", "/gis.png", "/gis_no_eyes.png", "/gis_a_job_no_eyes.png", "/eye.png", "/gis_video_idle.mp4", "/gis_video_typing_loop.mp4", "/gis_video_typing_finish.mp4", "/favicon.ico", "/favicon-32.png", "/apple-touch-icon.png", "/logo.webp", "/model-picker.js", "/model-picker.css", "/tool.js", "/tool.css", "/tools/", "/tools-modal.js", "/tools-modal.css", "/llms.txt"]
+```
+
+- [ ] **Step 4: Rebuild so `pkg/sw.js` regenerates**
+
+Run: `solobase build`
+Expected: build succeeds; `pkg/sw.js` now contains the `/llms.txt` bypass clause.
+
+- [ ] **Step 5: Run the bypass test to verify it passes**
+
+Run: `node --test js/sw-bypass.test.js`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add solobase.toml js/sw-bypass.test.js
+git commit -m "build(md-tool-pages): SW-bypass /llms.txt so it serves statically"
+```
+
+---
+
+### Task 6: Final verification
+
+- [ ] **Step 1: Run the generator CI-gate suite**
+
+Run: `cargo test --manifest-path tools/generator/Cargo.toml`
+Expected: PASS — all generator tests (markdown + template + index + seo + meta).
+
+- [ ] **Step 2: Sanity-check the rendered output shape (no per-tool wasm needed)**
+
+Add a throwaway check by running the markdown unit assertions only (already
+covered in Tasks 1-2); confirm by eye that a sample `tool_markdown` output reads
+well as markdown (header, Run it, Inputs, Output, `---`, prose). No code change.
+
+- [ ] **Step 3: (Optional, deploy-pipeline) full generation**
+
+When per-tool wasms exist (`blocks/<slug>/web/pkg/` built — the deploy pipeline
+does this), running `gizza-tool-pages` (`cargo run --manifest-path
+tools/generator/Cargo.toml -- .`) writes `pkg/tools/<slug>/index.md` for every
+tool and `pkg/llms.txt`. Confirm `pkg/llms.txt` lists every tool and a sample
+`pkg/tools/calculator/index.md` looks right. This is exercised by the existing
+deploy build; no new pipeline step is required.
+
+- [ ] **Step 4: Record completion in the spec**
+
+In `docs/superpowers/specs/2026-06-17-markdown-tool-pages-design.md`, update the
+**Status** line to note the feature is implemented + unit-tested.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-06-17-markdown-tool-pages-design.md
+git commit -m "docs(md-tool-pages): mark design implemented"
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- Per-tool `index.md` (header: description, run-it, inputs, output + prose) → Task 1 (`tool_markdown`) + Task 3 (wired). ✓
+- Root `/llms.txt` index (title + summary + link list, not full dump) → Task 2 (`llms_txt`) + Task 3 (wired). ✓
+- Schema from `meta.toml` → Tasks 1-2 read only `ToolMeta`; no runtime/CLI call. ✓
+- Field / file / live (auto) variants → Task 1 tests all three. ✓
+- `<link rel="alternate">` discovery → Task 4. ✓
+- `/llms.txt` SW-bypass → Task 5. ✓
+- Single-source / no-drift → derived entirely from `ToolMeta` + `content_md`; adding a tool auto-produces both. ✓
+
+**Placeholder scan:** No TBD/TODO/"add error handling"/"similar to" — every code and command step is concrete. ✓
+
+**Type/name consistency:** `tool_markdown(meta: &ToolMeta, content_md: &str)`,
+`llms_txt(metas: &[ToolMeta])`, `cli_example(meta)`, `SITE`, and the `Input`
+fields (`name`/`source`/`label`/`placeholder`/`accept`) match `meta.rs`. The
+generator variables `m`, `content_md`, `metas_only`, `pkg`, `out` match
+`main.rs`. Absolute `https://gizza.ai/...index.md` links are used consistently in
+`llms_txt` and tested as such. ✓
+
+**Note (spec refinement):** `llms_txt` uses **absolute** `https://gizza.ai/tools/<slug>/index.md` links (not the root-relative form sketched in the spec) — absolute is correct for an `llms.txt` fetched standalone via WebFetch. Spec example updated to match.

--- a/docs/superpowers/specs/2026-06-17-markdown-tool-pages-design.md
+++ b/docs/superpowers/specs/2026-06-17-markdown-tool-pages-design.md
@@ -1,7 +1,10 @@
 # Markdown tool-page twins (per-tool `index.md`)
 
 **Date:** 2026-06-17
-**Status:** Design approved (scope narrowed to per-tool `.md`); ready for plan.
+**Status:** Implemented + unit-tested (generator suite green) and verified by a
+real `gizza-tool-pages` run — `index.md` produced for all 5 page-tools
+(field/file/live variants correct) and each `index.html` links its twin via
+`<link rel="alternate" type="text/markdown">`. Branch `feat/md-tool-pages`.
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-06-17-markdown-tool-pages-design.md
+++ b/docs/superpowers/specs/2026-06-17-markdown-tool-pages-design.md
@@ -110,9 +110,12 @@ by the existing `/tools/` bypass.
 
   ## Tools
 
-  - [{title}](/tools/{slug}/index.md): {description}
+  - [{title}](https://gizza.ai/tools/{slug}/index.md): {description}
   … one per tool, in the generator's existing order
   ```
+
+  Links are **absolute** (`https://gizza.ai/...`) so an `llms.txt` fetched
+  standalone via WebFetch resolves them correctly.
 
 ### Modify: `tools/generator/src/main.rs`
 

--- a/docs/superpowers/specs/2026-06-17-markdown-tool-pages-design.md
+++ b/docs/superpowers/specs/2026-06-17-markdown-tool-pages-design.md
@@ -1,170 +1,132 @@
-# Markdown-for-LLMs tool pages
+# Markdown tool-page twins (per-tool `index.md`)
 
 **Date:** 2026-06-17
-**Status:** Design approved; ready for implementation plan.
+**Status:** Design approved (scope narrowed to per-tool `.md`); ready for plan.
 
 ## Problem
 
 gizza's per-tool standalone pages (`gizza.ai/tools/<slug>/index.html`) are
-HTML+JS — noisy for an LLM that fetches the page via WebFetch/crawl to learn what
-a tool does and how to call it. gizza already serves agent-facing surfaces (the
-`gizza` CLI, `SKILL.md`, `/tools/_index.json`, `block.info()` schemas), but none
-of those help an agent that simply lands on a tool page on the web. The emerging
-convention for this is a markdown twin of each page plus a root `/llms.txt`
-index. There is no markdown-for-agents surface today.
+HTML+JS — noisy for an LLM that fetches the page (via WebFetch/crawl) to learn
+what a tool does and how to call it. Every tool already authors its prose as
+`blocks/<slug>/page/content.md`, which the generator renders into the HTML; the
+clean markdown is the *source*, but it isn't served.
 
 ## Goal
 
-Emit, inside the existing `tools/generator` pass:
+Emit, inside the existing `tools/generator` pass, a clean **`index.md`** twin next
+to every tool's `index.html`, single-sourced from the same `meta.toml` +
+`content.md` that drive the HTML — so web-browsing LLMs can read a tool without
+parsing HTML, and so adding a tool yields its `.md` automatically with zero drift
+and no new build step.
 
-1. a clean **`index.md`** twin next to every tool's `index.html`, and
-2. a root **`/llms.txt`** index linking them,
+## Relationship to the SEO/discoverability effort (important)
 
-both single-sourced from the `meta.toml` + `content.md` the generator already
-reads — so adding a tool yields its `.md` + `llms.txt` line automatically, with
-zero drift and no new build step.
+A **separate, concurrent effort** (`feat/seo-discoverability-and-chrome`,
+design `2026-06-17-seo-discoverability-and-shared-chrome-design.md`) owns the
+root **`/llms.txt`**, `sitemap.xml`, and `robots.txt`, generated from `gizza
+list` (the live registry — all ~14 tools, not just the 5 with pages) via
+`scripts/gen-seo.sh`. That is the better home for the *index* surface (live
+registry = single source of truth; covers chat-only tools too).
 
-## Key decisions
+**This spec therefore does NOT produce `/llms.txt`.** The two efforts are
+complementary: that effort's `llms.txt` is the index over all tools; this
+effort's per-tool `index.md` is the per-page detail twin. The SEO effort's
+`llms.txt` entries for the 5 page-tools can link to `/tools/<slug>/index.md`
+(coordination note for that effort; no code dependency here).
 
-### Schema source = `meta.toml` (not `block.info()`)
+## Key decision: schema source = `meta.toml` (not `block.info()`)
 
 `meta.toml` already declares the page's I/O: each `[[input]]`
 (`name`/`source`/`label`/`accept`) plus `output_label`/`format`/`runtime`. The
-generator is a pure static pass over `meta.toml` + `content.md`, and the HTML
-page renders from the same `meta.toml`. Using it for the `.md` keeps the twin
+generator is a pure static pass over `meta.toml` + `content.md`, and the HTML page
+renders from the same `meta.toml`. Using it for the `.md` keeps the twin
 **consistent with the HTML page** and avoids invoking the runtime/CLI mid-build.
 The canonical *runtime* schema stays `gizza describe` / `block.info()`; the `.md`
 documents the page surface and points agents at the CLI for invocation.
-(Rejected: shelling out to `gizza describe` during generation — more coupling,
-risks page/HTML drift.)
-
-### `/llms.txt` is an index, not a full dump
-
-Per the llms.txt convention, `/llms.txt` is a title + summary + a link list to
-the per-tool `.md` files — **not** a concatenation of every tool's content. With
-gizza's tool backlog a full-dump file would balloon; the index + per-tool `.md`
-scales and matches the convention's index/`llms-full.txt` split. No
-`llms-full.txt` in this scope.
-
-### Serving (verified)
-
-The runtime SW (`sw.js`) intercepts **all** same-origin requests except its
-bypass list. Crawlers/agents fetch without a registered SW, so static files at
-the origin (Cloudflare Pages serving `pkg/`) are returned directly — `/llms.txt`
-works for web-fetching LLMs with **no** bypass needed. To also work in a real
-browser tab that already has the gizza SW registered, add `/llms.txt` to
-`extra_bypass_prefix`. Per-tool `index.md` lives under `/tools/`, already covered
-by the existing `/tools/` bypass.
-
-> Observed latent gap (out of scope, noted): `robots.txt` and `sitemap.xml` are
-> likewise **not** bypassed, so they 404 in a SW-registered browser tab (they
-> work for crawlers only). The plan may optionally add `/robots.txt` +
-> `/sitemap.xml` to the bypass in the same one-line change for consistency.
 
 ## Components (all inside `tools/generator`)
 
 ### New: `tools/generator/src/markdown.rs`
 
-- `tool_markdown(meta: &ToolMeta, content_md: &str) -> String` → the per-tool
-  `index.md`:
+`tool_markdown(meta: &ToolMeta, content_md: &str) -> String` → the per-tool
+`index.md`:
 
-  ```markdown
-  # {h1}
+```markdown
+# {h1}
 
-  {description}
+{description}
 
-  ## Run it
+## Run it
 
-  - **CLI:** `gizza tool {slug} "{first field input's placeholder}"`
-  - **Web:** https://gizza.ai/tools/{slug}/
+- **CLI:** `gizza tool {slug} "{first field input's placeholder}"`
+- **Web:** https://gizza.ai/tools/{slug}/
 
-  ## Inputs
+## Inputs
 
-  - `{name}` — {label} _( {source}{; accept: {accept}} )_
-  … one per [[input]]
+- `{name}` — {label} _( {source}{; accept: {accept}} )_
+… one per manual (field/file) [[input]]
 
-  ## Output
+## Output
 
-  - {output_label} ({format})
+- {output_label} ({format})
 
-  ---
+---
 
-  {content.md, verbatim}
-  ```
+{content.md, verbatim}
+```
 
-  Rules:
-  - The CLI line uses the first `source = "field"` input's `placeholder` as the
-    example arg; for tools whose only input is a `file`, render
-    `gizza tool {slug} <path>` instead (with a note the input is a file).
-  - The `accept` clause is omitted when empty.
-  - `live` tools (clock-style, no field inputs) render an `## Inputs` note that
-    the tool takes no arguments.
-
-- `llms_txt(metas: &[ToolMeta]) -> String` → the root `/llms.txt`:
-
-  ```markdown
-  # gizza.ai — browser-native tools
-
-  > Free, single-purpose tools that run entirely in your browser. Many also run
-  > headlessly via `gizza tool <name>` (see the CLI + SKILL.md in the repo).
-
-  ## Tools
-
-  - [{title}](https://gizza.ai/tools/{slug}/index.md): {description}
-  … one per tool, in the generator's existing order
-  ```
-
-  Links are **absolute** (`https://gizza.ai/...`) so an `llms.txt` fetched
-  standalone via WebFetch resolves them correctly.
+Rules:
+- The CLI line uses the first `source = "field"` input's `placeholder` as the
+  example arg; a file-only tool renders `gizza tool {slug} <path>`; an
+  auto-only tool (e.g. clock, whose only input is `source = "clock"`) renders
+  `gizza tool {slug}` and an `## Inputs` note that it takes no manual arguments.
+- The `accept` clause is omitted when empty.
 
 ### Modify: `tools/generator/src/main.rs`
 
-- After writing `index.html` per tool, also write
-  `out.join("index.md")` = `markdown::tool_markdown(&m, &content_md)`.
-- After the existing `_index.json` / `sitemap.xml` / `robots.txt` writes, write
-  `pkg.join("llms.txt")` = `markdown::llms_txt(&metas_only)`.
-- Register `mod markdown;`.
+After writing `index.html` per tool, also write
+`out.join("index.md")` = `markdown::tool_markdown(m, &content_md)`. Register
+`mod markdown;`. (No `llms.txt` write — that's the SEO effort's job.)
 
 ### Modify: `tools/generator/src/template.rs`
 
-- Add to each page `<head>`:
-  `<link rel="alternate" type="text/markdown" href="index.md">` (relative, so it
-  resolves to `/tools/<slug>/index.md`).
+Add to each page `<head>`:
+`<link rel="alternate" type="text/markdown" href="index.md">` (relative → resolves
+to `/tools/<slug>/index.md`).
 
-### Modify: `gizza-ai/solobase.toml`
+### No `solobase.toml` change
 
-- Append `"/llms.txt"` to `[assets].extra_bypass_prefix`. (Optionally
-  `"/robots.txt"`, `"/sitemap.xml"` per the noted gap.)
+`index.md` lives under `/tools/`, already covered by the existing `/tools/` SW
+fetch-bypass and served statically. (`/llms.txt` bypass, if any, belongs to the
+SEO effort.)
 
 ## Single source / no drift
 
 `meta.toml` (metadata + I/O schema) and `content.md` (prose) are the only
-sources. `index.html`, `index.md`, `_index.json`, `sitemap.xml`, and `llms.txt`
-all derive from them. Adding a tool automatically produces its `.md` and
-`llms.txt` entry — no per-tool maintenance.
+sources. `index.html`, `index.md`, and `_index.json` all derive from them.
+Adding a tool automatically produces its `.md` — no per-tool maintenance.
 
 ## Testing
 
 - **`tools/generator` unit tests** (mirror the existing `index.rs`/`meta.rs`
-  test style):
-  - `tool_markdown` for a field tool (calculator) contains: the `# {h1}` header,
+  style; run by `cargo test --manifest-path tools/generator/Cargo.toml`, a CI
+  gate):
+  - `tool_markdown` for a field tool (calculator) contains the `# {h1}` header,
     the `gizza tool calculator "2 + 2 * 3"` CLI line, the
     `https://gizza.ai/tools/calculator/` URL, the `expr` input line, the
     `Result (number)` output line, and the appended prose.
-  - `tool_markdown` for a file tool (e.g. image-grayscale) renders the
-    `gizza tool <slug> <path>` form and an `accept` clause.
-  - `tool_markdown` for a `live` tool (clock) renders the no-arguments inputs
-    note.
-  - `llms_txt` over multiple metas lists every tool as
-    `- [title](/tools/<slug>/index.md): description`, in order.
-- **Generator integration** (the generator's existing end-to-end test, if any):
-  assert `index.md` is written for each tool and `llms.txt` at pkg root.
-- **`sw-bypass.test.js`**: assert `/llms.txt` is bypassed in the built
-  `pkg/sw.js`.
+  - `tool_markdown` for a file tool renders `gizza tool <slug> <path>` and an
+    `accept` clause.
+  - `tool_markdown` for an auto-only (`live`/clock) tool renders the no-manual-
+    arguments note and `gizza tool <slug>` (no quoted arg).
+  - `template.rs` head test asserts the `<link rel="alternate" type="text/markdown" href="index.md">`.
+- **Full generation** (deploy pipeline / manual, once per-tool wasms exist):
+  running `gizza-tool-pages` writes `pkg/tools/<slug>/index.md` for every tool.
 
-## Scope boundary
+## Scope boundaries
 
-Separate track from the chat-ffmpeg page-side bridge work (that plan is parked,
-awaiting an execution-approach choice). This feature touches only
-`tools/generator` + one `solobase.toml` line; no runtime, block, or SW-template
-changes.
+- Separate track from the chat-ffmpeg page-side bridge (`feat/chat-ffmpeg-page-side-bridge`, parked).
+- Does **not** touch `/llms.txt`, `sitemap.xml`, `robots.txt`, or `seo.rs` — those
+  belong to `feat/seo-discoverability-and-chrome`. This feature only adds the
+  per-tool `index.md` + its discovery `<link>`, avoiding any collision with that
+  effort's generator changes.

--- a/docs/superpowers/specs/2026-06-17-markdown-tool-pages-design.md
+++ b/docs/superpowers/specs/2026-06-17-markdown-tool-pages-design.md
@@ -1,0 +1,167 @@
+# Markdown-for-LLMs tool pages
+
+**Date:** 2026-06-17
+**Status:** Design approved; ready for implementation plan.
+
+## Problem
+
+gizza's per-tool standalone pages (`gizza.ai/tools/<slug>/index.html`) are
+HTML+JS — noisy for an LLM that fetches the page via WebFetch/crawl to learn what
+a tool does and how to call it. gizza already serves agent-facing surfaces (the
+`gizza` CLI, `SKILL.md`, `/tools/_index.json`, `block.info()` schemas), but none
+of those help an agent that simply lands on a tool page on the web. The emerging
+convention for this is a markdown twin of each page plus a root `/llms.txt`
+index. There is no markdown-for-agents surface today.
+
+## Goal
+
+Emit, inside the existing `tools/generator` pass:
+
+1. a clean **`index.md`** twin next to every tool's `index.html`, and
+2. a root **`/llms.txt`** index linking them,
+
+both single-sourced from the `meta.toml` + `content.md` the generator already
+reads — so adding a tool yields its `.md` + `llms.txt` line automatically, with
+zero drift and no new build step.
+
+## Key decisions
+
+### Schema source = `meta.toml` (not `block.info()`)
+
+`meta.toml` already declares the page's I/O: each `[[input]]`
+(`name`/`source`/`label`/`accept`) plus `output_label`/`format`/`runtime`. The
+generator is a pure static pass over `meta.toml` + `content.md`, and the HTML
+page renders from the same `meta.toml`. Using it for the `.md` keeps the twin
+**consistent with the HTML page** and avoids invoking the runtime/CLI mid-build.
+The canonical *runtime* schema stays `gizza describe` / `block.info()`; the `.md`
+documents the page surface and points agents at the CLI for invocation.
+(Rejected: shelling out to `gizza describe` during generation — more coupling,
+risks page/HTML drift.)
+
+### `/llms.txt` is an index, not a full dump
+
+Per the llms.txt convention, `/llms.txt` is a title + summary + a link list to
+the per-tool `.md` files — **not** a concatenation of every tool's content. With
+gizza's tool backlog a full-dump file would balloon; the index + per-tool `.md`
+scales and matches the convention's index/`llms-full.txt` split. No
+`llms-full.txt` in this scope.
+
+### Serving (verified)
+
+The runtime SW (`sw.js`) intercepts **all** same-origin requests except its
+bypass list. Crawlers/agents fetch without a registered SW, so static files at
+the origin (Cloudflare Pages serving `pkg/`) are returned directly — `/llms.txt`
+works for web-fetching LLMs with **no** bypass needed. To also work in a real
+browser tab that already has the gizza SW registered, add `/llms.txt` to
+`extra_bypass_prefix`. Per-tool `index.md` lives under `/tools/`, already covered
+by the existing `/tools/` bypass.
+
+> Observed latent gap (out of scope, noted): `robots.txt` and `sitemap.xml` are
+> likewise **not** bypassed, so they 404 in a SW-registered browser tab (they
+> work for crawlers only). The plan may optionally add `/robots.txt` +
+> `/sitemap.xml` to the bypass in the same one-line change for consistency.
+
+## Components (all inside `tools/generator`)
+
+### New: `tools/generator/src/markdown.rs`
+
+- `tool_markdown(meta: &ToolMeta, content_md: &str) -> String` → the per-tool
+  `index.md`:
+
+  ```markdown
+  # {h1}
+
+  {description}
+
+  ## Run it
+
+  - **CLI:** `gizza tool {slug} "{first field input's placeholder}"`
+  - **Web:** https://gizza.ai/tools/{slug}/
+
+  ## Inputs
+
+  - `{name}` — {label} _( {source}{; accept: {accept}} )_
+  … one per [[input]]
+
+  ## Output
+
+  - {output_label} ({format})
+
+  ---
+
+  {content.md, verbatim}
+  ```
+
+  Rules:
+  - The CLI line uses the first `source = "field"` input's `placeholder` as the
+    example arg; for tools whose only input is a `file`, render
+    `gizza tool {slug} <path>` instead (with a note the input is a file).
+  - The `accept` clause is omitted when empty.
+  - `live` tools (clock-style, no field inputs) render an `## Inputs` note that
+    the tool takes no arguments.
+
+- `llms_txt(metas: &[ToolMeta]) -> String` → the root `/llms.txt`:
+
+  ```markdown
+  # gizza.ai — browser-native tools
+
+  > Free, single-purpose tools that run entirely in your browser. Many also run
+  > headlessly via `gizza tool <name>` (see the CLI + SKILL.md in the repo).
+
+  ## Tools
+
+  - [{title}](/tools/{slug}/index.md): {description}
+  … one per tool, in the generator's existing order
+  ```
+
+### Modify: `tools/generator/src/main.rs`
+
+- After writing `index.html` per tool, also write
+  `out.join("index.md")` = `markdown::tool_markdown(&m, &content_md)`.
+- After the existing `_index.json` / `sitemap.xml` / `robots.txt` writes, write
+  `pkg.join("llms.txt")` = `markdown::llms_txt(&metas_only)`.
+- Register `mod markdown;`.
+
+### Modify: `tools/generator/src/template.rs`
+
+- Add to each page `<head>`:
+  `<link rel="alternate" type="text/markdown" href="index.md">` (relative, so it
+  resolves to `/tools/<slug>/index.md`).
+
+### Modify: `gizza-ai/solobase.toml`
+
+- Append `"/llms.txt"` to `[assets].extra_bypass_prefix`. (Optionally
+  `"/robots.txt"`, `"/sitemap.xml"` per the noted gap.)
+
+## Single source / no drift
+
+`meta.toml` (metadata + I/O schema) and `content.md` (prose) are the only
+sources. `index.html`, `index.md`, `_index.json`, `sitemap.xml`, and `llms.txt`
+all derive from them. Adding a tool automatically produces its `.md` and
+`llms.txt` entry — no per-tool maintenance.
+
+## Testing
+
+- **`tools/generator` unit tests** (mirror the existing `index.rs`/`meta.rs`
+  test style):
+  - `tool_markdown` for a field tool (calculator) contains: the `# {h1}` header,
+    the `gizza tool calculator "2 + 2 * 3"` CLI line, the
+    `https://gizza.ai/tools/calculator/` URL, the `expr` input line, the
+    `Result (number)` output line, and the appended prose.
+  - `tool_markdown` for a file tool (e.g. image-grayscale) renders the
+    `gizza tool <slug> <path>` form and an `accept` clause.
+  - `tool_markdown` for a `live` tool (clock) renders the no-arguments inputs
+    note.
+  - `llms_txt` over multiple metas lists every tool as
+    `- [title](/tools/<slug>/index.md): description`, in order.
+- **Generator integration** (the generator's existing end-to-end test, if any):
+  assert `index.md` is written for each tool and `llms.txt` at pkg root.
+- **`sw-bypass.test.js`**: assert `/llms.txt` is bypassed in the built
+  `pkg/sw.js`.
+
+## Scope boundary
+
+Separate track from the chat-ffmpeg page-side bridge work (that plan is parked,
+awaiting an execution-approach choice). This feature touches only
+`tools/generator` + one `solobase.toml` line; no runtime, block, or SW-template
+changes.

--- a/tools/generator/src/main.rs
+++ b/tools/generator/src/main.rs
@@ -44,6 +44,8 @@ fn run() -> Result<(), String> {
         let html = template::render_page(m, &content_html);
         fs::write(out.join("index.html"), html)
             .map_err(|e| format!("write index.html: {e}"))?;
+        fs::write(out.join("index.md"), markdown::tool_markdown(m, &content_md))
+            .map_err(|e| format!("write index.md: {e}"))?;
 
         let web_pkg = tool_dir.join("web/pkg");
         copy_file(&web_pkg.join(format!("{}.js", m.wasm)), &out.join(format!("{}.js", m.wasm)))?;

--- a/tools/generator/src/main.rs
+++ b/tools/generator/src/main.rs
@@ -6,6 +6,7 @@
 //! `blocks/<tool>/web/pkg/`.
 
 mod index;
+mod markdown;
 mod meta;
 mod seo;
 mod template;

--- a/tools/generator/src/markdown.rs
+++ b/tools/generator/src/markdown.rs
@@ -1,0 +1,164 @@
+//! Markdown twin of each tool page (`index.md`), single-sourced from the same
+//! `ToolMeta` (meta.toml) + content.md that drive the HTML page, so web-browsing
+//! LLMs can read a tool without parsing HTML.
+
+use crate::meta::{Input, ToolMeta};
+
+/// Public site origin — matches the literal used in `seo.rs` + `template.rs`.
+const SITE: &str = "https://gizza.ai";
+
+/// Render a tool's `index.md`: a generated header (description, run-it, inputs,
+/// output) followed by the tool's prose `content.md`, verbatim.
+pub fn tool_markdown(meta: &ToolMeta, content_md: &str) -> String {
+    let mut s = String::new();
+    s.push_str(&format!("# {}\n\n", meta.h1));
+    s.push_str(&format!("{}\n\n", meta.description));
+
+    s.push_str("## Run it\n\n");
+    s.push_str(&format!("- **CLI:** `{}`\n", cli_example(meta)));
+    s.push_str(&format!("- **Web:** {}/tools/{}/\n\n", SITE, meta.slug));
+
+    s.push_str("## Inputs\n\n");
+    let manual: Vec<&Input> = meta
+        .inputs
+        .iter()
+        .filter(|i| i.source == "field" || i.source == "file")
+        .collect();
+    if manual.is_empty() {
+        s.push_str("- _no manual inputs — runs automatically_\n\n");
+    } else {
+        for i in &manual {
+            let label = if i.label.is_empty() { i.name.as_str() } else { i.label.as_str() };
+            let mut note = i.source.clone();
+            if !i.accept.is_empty() {
+                note.push_str(&format!("; accept: {}", i.accept));
+            }
+            s.push_str(&format!("- `{}` — {} _({})_\n", i.name, label, note));
+        }
+        s.push('\n');
+    }
+
+    s.push_str("## Output\n\n");
+    s.push_str(&format!("- {} ({})\n\n", meta.output_label, meta.format));
+
+    s.push_str("---\n\n");
+    s.push_str(content_md.trim_end());
+    s.push('\n');
+    s
+}
+
+/// The example CLI invocation: field tools use the first field input's
+/// placeholder as the example arg; file tools take a path; auto-only tools
+/// (e.g. clock) take no args.
+fn cli_example(meta: &ToolMeta) -> String {
+    if let Some(field) = meta.inputs.iter().find(|i| i.source == "field") {
+        let arg = if field.placeholder.is_empty() { "..." } else { field.placeholder.as_str() };
+        format!("gizza tool {} \"{}\"", meta.slug, arg)
+    } else if meta.inputs.iter().any(|i| i.source == "file") {
+        format!("gizza tool {} <path>", meta.slug)
+    } else {
+        format!("gizza tool {}", meta.slug)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn field_tool() -> ToolMeta {
+        ToolMeta::from_toml(
+            r#"
+slug          = "calculator"
+title         = "Free Online Calculator — gizza.ai"
+description   = "Evaluate expressions instantly."
+tags          = ["math"]
+h1            = "Free Online Calculator"
+hero_subtitle = "Type a math expression."
+wasm          = "gizza_ai_calculator_web"
+export        = "evaluate"
+live          = false
+output_label  = "Result"
+format        = "number"
+
+[[input]]
+name        = "expr"
+label       = "Expression"
+placeholder = "2 + 2 * 3"
+source      = "field"
+"#,
+        )
+        .unwrap()
+    }
+
+    fn file_tool() -> ToolMeta {
+        ToolMeta::from_toml(
+            r#"
+slug          = "image-grayscale"
+title         = "Grayscale an Image — gizza.ai"
+description   = "Convert an image to grayscale in your browser."
+h1            = "Grayscale an Image"
+hero_subtitle = "Upload an image."
+wasm          = "gizza_ai_image_grayscale_web"
+export        = "build_argv"
+output_label  = "Image"
+format        = "image"
+runtime       = "ffmpeg"
+
+[[input]]
+name   = "file"
+label  = "Image"
+source = "file"
+accept = "image/*"
+"#,
+        )
+        .unwrap()
+    }
+
+    fn live_tool() -> ToolMeta {
+        ToolMeta::from_toml(
+            r#"
+slug          = "clock"
+title         = "Clock — gizza.ai"
+description   = "The current time, live."
+h1            = "Clock"
+hero_subtitle = "Live time."
+wasm          = "gizza_ai_clock_web"
+export        = "now"
+live          = true
+output_label  = "Time"
+format        = "text"
+
+[[input]]
+name   = "now"
+label  = "Now"
+source = "clock"
+"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn field_tool_has_header_runit_inputs_output_prose() {
+        let md = tool_markdown(&field_tool(), "Some **prose** about the calculator.");
+        assert!(md.contains("# Free Online Calculator"));
+        assert!(md.contains("`gizza tool calculator \"2 + 2 * 3\"`"), "CLI example");
+        assert!(md.contains("https://gizza.ai/tools/calculator/"), "web URL");
+        assert!(md.contains("`expr` — Expression _(field)_"), "input listed");
+        assert!(md.contains("Result (number)"), "output listed");
+        assert!(md.contains("Some **prose** about the calculator."), "prose appended");
+    }
+
+    #[test]
+    fn file_tool_uses_path_example_and_accept() {
+        let md = tool_markdown(&file_tool(), "prose");
+        assert!(md.contains("`gizza tool image-grayscale <path>`"), "path CLI example");
+        assert!(md.contains("`file` — Image _(file; accept: image/*)_"), "accept shown");
+    }
+
+    #[test]
+    fn live_tool_takes_no_manual_arguments() {
+        let md = tool_markdown(&live_tool(), "prose");
+        assert!(md.contains("`gizza tool clock`"), "no-arg CLI example");
+        assert!(md.contains("_no manual inputs — runs automatically_"), "no manual inputs note");
+    }
+}

--- a/tools/generator/src/template.rs
+++ b/tools/generator/src/template.rs
@@ -36,6 +36,7 @@ pub fn render_page(meta: &ToolMeta, content_html: &str) -> String {
                 title { (meta.title) }
                 meta name="description" content=(meta.description);
                 link rel="canonical" href=(canonical);
+                link rel="alternate" type="text/markdown" href="index.md";
                 meta property="og:type" content="website";
                 meta property="og:title" content=(meta.title);
                 meta property="og:description" content=(meta.description);
@@ -145,6 +146,10 @@ source      = "field"
         let html = render_page(&sample(), "<h2>About</h2>");
         assert!(html.contains("<title>Free Online Calculator — gizza.ai</title>"));
         assert!(html.contains(r#"<link rel="canonical" href="https://gizza.ai/tools/calculator/">"#));
+        assert!(
+            html.contains(r#"<link rel="alternate" type="text/markdown" href="index.md">"#),
+            "markdown twin discovery link present",
+        );
         assert!(html.contains("application/ld+json"));
         assert!(html.contains(r#"id="in-expr""#));
         assert!(html.contains(r#"id="tool-output""#));


### PR DESCRIPTION
## Summary
- Adds a clean markdown twin (`index.md`) next to every tool page, single-sourced from the same `meta.toml` + `content.md` that drive the HTML, so web-browsing LLMs can read a tool without parsing HTML.
- Generated header: description, a **Run it** block (`gizza tool <slug> …` + URL), the I/O schema; followed by the tool's `content.md` prose. Field/file/auto-only (clock) variants handled.
- `<link rel="alternate" type="text/markdown" href="index.md">` for discovery.
- **Scope deliberately excludes** `/llms.txt`/`sitemap`/`robots` — those are owned by the concurrent `feat/seo-discoverability-and-chrome` effort (`gizza list`-driven). The two are complementary: that effort's `llms.txt` is the index over all tools; this is the per-page detail twin.

## Note on the diff
This branch's base includes the SEO effort's design-doc commit `bc18942` (a shared-working-tree artifact from concurrent sessions). The only **code** overlap with that effort is one added line in `tools/generator/src/main.rs`; `bc18942` dedups when the SEO branch merges. Recommend landing the SEO branch first (it removes the sitemap/robots writes this branch leaves untouched).

## Test Plan
- [x] Generator suite: **15/15** (`cargo test --manifest-path tools/generator/Cargo.toml`)
- [x] Real generation run: `index.md` produced for all 5 page-tools (field/file/live rendering correct); each `index.html` links its twin

🤖 Generated with [Claude Code](https://claude.com/claude-code)