### PR TITLE
feat(runtime): opt gizza skill calls into Unmetered fuel + 64 MiB wasm memory cap

### DIFF
--- a/block-utils/src/lib.rs
+++ b/block-utils/src/lib.rs
@@ -5,6 +5,18 @@
 
 pub mod ffmpeg;
 
+/// Per-call linear-memory cap (in 64 KiB wasm pages) that gizza's trusted,
+/// single-user runtime grants every skill `WasmiBlock`. 1024 pages = 64 MiB.
+///
+/// wafer-run defaults to 256 pages / 16 MiB, which is enough for the light
+/// tools but OOM-traps memory-heavy ones (e.g. the `syntect`+bundled-font
+/// `code-screenshot` render needs ~24 MiB). gizza is local/trusted, so both
+/// its native CLI and browser runtimes raise the cap to this value at every
+/// skill load site; the hosted multi-tenant runtime keeps the 256-page
+/// default. Defined here (shared by `gizza-cli` and the browser `gizza-ai`
+/// crate) so the value lives in exactly one place.
+pub const GIZZA_MAX_WASM_MEMORY_PAGES: u32 = 1024;
+
 #[cfg(target_arch = "wasm32")]
 use std::collections::HashMap;
 

--- a/cli/src/runtime.rs
+++ b/cli/src/runtime.rs
@@ -8,7 +8,7 @@ use wafer_block::{
     streams::{input::InputStream, output::TerminalNotResponse},
 };
 use wafer_block::Block;
-use wafer_run::{Wafer, WasmiBlock};
+use wafer_run::{FuelLimit, Wafer, WasmiBlock};
 
 use crate::SKILL_WASMS;
 
@@ -100,7 +100,13 @@ fn register_skills(
     metas: &mut Vec<ToolMeta>,
 ) -> Result<()> {
     for bytes in SKILL_WASMS {
-        let block = WasmiBlock::load_from_bytes(bytes).context("load skill wasm")?;
+        // gizza is a single-user, trusted CLI: opt skill calls out of the
+        // default 100M fuel cap so heavy tools (e.g. the `phonenumber` crate)
+        // run to completion instead of trapping with `all fuel consumed`.
+        // The Unmetered policy is set on the builder via `fuel_per_call` and
+        // read back here so every load site expresses it the same way.
+        let block = WasmiBlock::load_from_bytes_with_fuel(bytes, wafer.fuel_limit())
+            .context("load skill wasm")?;
         let info = block.info();
         let name = info.name.clone();
         // Capture SkillTool metadata if the block exposes one.
@@ -133,6 +139,8 @@ pub async fn boot_minimal() -> Result<ToolRuntime> {
     let mut wafer = Wafer::builder()
         .disable_inventory()
         .disable_lockfile()
+        // Trusted single-user CLI: skill calls run unmetered (see register_skills).
+        .fuel_per_call(FuelLimit::Unmetered)
         .build()
         .context("build wafer")?;
     let mut names = Vec::new();
@@ -152,6 +160,8 @@ pub async fn boot_full() -> Result<ToolRuntime> {
     let mut wafer = Wafer::builder()
         .disable_inventory()
         .disable_lockfile()
+        // Trusted single-user CLI: skill calls run unmetered (see register_skills).
+        .fuel_per_call(FuelLimit::Unmetered)
         .build()
         .context("build wafer")?;
 

--- a/cli/src/runtime.rs
+++ b/cli/src/runtime.rs
@@ -2,6 +2,7 @@
 use std::sync::Arc;
 
 use anyhow::{Context as _, Result};
+use gizza_ai_block_utils::GIZZA_MAX_WASM_MEMORY_PAGES;
 use wafer_block::{
     core_types::Message,
     meta::{META_REQ_ACTION, META_REQ_RESOURCE},
@@ -101,11 +102,12 @@ fn register_skills(
 ) -> Result<()> {
     for bytes in SKILL_WASMS {
         // gizza is a single-user, trusted CLI: opt skill calls out of the
-        // default 100M fuel cap so heavy tools (e.g. the `phonenumber` crate)
-        // run to completion instead of trapping with `all fuel consumed`.
-        // The Unmetered policy is set on the builder via `fuel_per_call` and
-        // read back here so every load site expresses it the same way.
-        let block = WasmiBlock::load_from_bytes_with_fuel(bytes, wafer.fuel_limit())
+        // default 100M fuel cap AND raise the 256-page / 16 MiB memory cap so
+        // heavy tools run to completion instead of trapping with `all fuel
+        // consumed` (fuel) or `unreachable`/OOM (memory). Both bounds are set
+        // on the builder (`fuel_per_call` + `max_wasm_memory_pages`) and read
+        // back here so every load site expresses the same policy.
+        let block = WasmiBlock::load_from_bytes_with_limits(bytes, wafer.resource_limits())
             .context("load skill wasm")?;
         let info = block.info();
         let name = info.name.clone();
@@ -139,8 +141,10 @@ pub async fn boot_minimal() -> Result<ToolRuntime> {
     let mut wafer = Wafer::builder()
         .disable_inventory()
         .disable_lockfile()
-        // Trusted single-user CLI: skill calls run unmetered (see register_skills).
+        // Trusted single-user CLI: skill calls run unmetered with a raised
+        // memory cap (see register_skills).
         .fuel_per_call(FuelLimit::Unmetered)
+        .max_wasm_memory_pages(GIZZA_MAX_WASM_MEMORY_PAGES)
         .build()
         .context("build wafer")?;
     let mut names = Vec::new();
@@ -160,8 +164,10 @@ pub async fn boot_full() -> Result<ToolRuntime> {
     let mut wafer = Wafer::builder()
         .disable_inventory()
         .disable_lockfile()
-        // Trusted single-user CLI: skill calls run unmetered (see register_skills).
+        // Trusted single-user CLI: skill calls run unmetered with a raised
+        // memory cap (see register_skills).
         .fuel_per_call(FuelLimit::Unmetered)
+        .max_wasm_memory_pages(GIZZA_MAX_WASM_MEMORY_PAGES)
         .build()
         .context("build wafer")?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ use solobase_core::RouteAccess;
 #[cfg(target_arch = "wasm32")]
 use wafer_core::interfaces::config::service::ConfigService;
 #[cfg(target_arch = "wasm32")]
+use wafer_run::FuelLimit;
+#[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
 pub mod blocks;
@@ -200,8 +202,16 @@ pub async fn initialize() -> Result<(), JsValue> {
         .map_err(|e| JsValue::from_str(&format!("register gizza-ai/ffmpeg-runtime: {e}")))?;
 
     for (name, bytes) in skills::SKILLS {
-        let wasmi = wafer_run::wasm::WasmiBlock::load_from_bytes(bytes)
-            .map_err(|e| JsValue::from_str(&format!("loading skill {name}: {e}")))?;
+        // gizza is a browser-local, single-user, trusted app: opt skill calls
+        // out of the default 100M fuel cap so heavy tools (e.g. the
+        // `phonenumber` crate) run to completion instead of trapping with
+        // `all fuel consumed`. The runtime here is built via `SolobaseBuilder`
+        // (which goes through `Wafer::new`, leaving the default metered cap),
+        // so we express the same "gizza skill calls = Unmetered" policy
+        // explicitly at the load site — matching the CLI surface.
+        let wasmi =
+            wafer_run::wasm::WasmiBlock::load_from_bytes_with_fuel(bytes, FuelLimit::Unmetered)
+                .map_err(|e| JsValue::from_str(&format!("loading skill {name}: {e}")))?;
         wafer
             .register_block(*name, Arc::new(wasmi))
             .map_err(|e| JsValue::from_str(&format!("registering skill {name}: {e}")))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,9 @@ use solobase_core::RouteAccess;
 #[cfg(target_arch = "wasm32")]
 use wafer_core::interfaces::config::service::ConfigService;
 #[cfg(target_arch = "wasm32")]
-use wafer_run::FuelLimit;
+use gizza_ai_block_utils::GIZZA_MAX_WASM_MEMORY_PAGES;
+#[cfg(target_arch = "wasm32")]
+use wafer_run::{FuelLimit, ResourceLimits};
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
@@ -203,15 +205,22 @@ pub async fn initialize() -> Result<(), JsValue> {
 
     for (name, bytes) in skills::SKILLS {
         // gizza is a browser-local, single-user, trusted app: opt skill calls
-        // out of the default 100M fuel cap so heavy tools (e.g. the
-        // `phonenumber` crate) run to completion instead of trapping with
-        // `all fuel consumed`. The runtime here is built via `SolobaseBuilder`
-        // (which goes through `Wafer::new`, leaving the default metered cap),
-        // so we express the same "gizza skill calls = Unmetered" policy
+        // out of the default 100M fuel cap AND raise the 256-page / 16 MiB
+        // memory cap so heavy tools (e.g. the `phonenumber` crate, or the
+        // `syntect`+font `code-screenshot` render that needs ~24 MiB) run to
+        // completion instead of trapping with `all fuel consumed` (fuel) or
+        // `unreachable`/OOM (memory). The runtime here is built via
+        // `SolobaseBuilder` (which goes through `Wafer::new`, leaving the
+        // default metered/256-page caps), so we express the same policy
         // explicitly at the load site — matching the CLI surface.
-        let wasmi =
-            wafer_run::wasm::WasmiBlock::load_from_bytes_with_fuel(bytes, FuelLimit::Unmetered)
-                .map_err(|e| JsValue::from_str(&format!("loading skill {name}: {e}")))?;
+        let wasmi = wafer_run::wasm::WasmiBlock::load_from_bytes_with_limits(
+            bytes,
+            ResourceLimits {
+                fuel: FuelLimit::Unmetered,
+                memory_pages: GIZZA_MAX_WASM_MEMORY_PAGES,
+            },
+        )
+        .map_err(|e| JsValue::from_str(&format!("loading skill {name}: {e}")))?;
         wafer
             .register_block(*name, Arc::new(wasmi))
             .map_err(|e| JsValue::from_str(&format!("registering skill {name}: {e}")))?;


### PR DESCRIPTION
## What

Opt gizza's skill calls into **both** an Unmetered wasmi fuel budget **and** a
raised **64 MiB** linear-memory cap, using the new wafer-run resource-limits API
(`FuelLimit` / `ResourceLimits` / `WaferBuilder::fuel_per_call` /
`WaferBuilder::max_wasm_memory_pages` / `Wafer::resource_limits()` /
`WasmiBlock::load_from_bytes_with_limits`).

gizza is a browser-local / CLI app — single-user and trusted — so its skill
tools should not be fuel- or memory-capped. The defaults (**100M fuel** + **256
pages / 16 MiB**) stay the default for hosted multi-tenant runtimes (not gizza's
concern). This unblocks heavy tools that otherwise trap:

- **fuel** — e.g. the `phonenumber` crate (`phone-format`) traps with
  `all fuel consumed` under the default 100M cap.
- **memory** — e.g. the `syntect`+bundled-font `code-screenshot` render needs
  ~24 MiB and OOM-traps (`unreachable`) under the default 256-page / 16 MiB cap.

## Why the load site must pass the limits explicitly

gizza loads each skill through its **own** wasmi engine, so setting
`fuel_per_call` / `max_wasm_memory_pages` on the builder alone does **not** reach
skills — the policy is read back at the load site via `Wafer::resource_limits()`
(or passed directly where there is no builder). Both surfaces express the
identical policy at every load site.

## No magic numbers — one shared const

`block-utils` (shared by both the CLI and browser crates) declares
`pub const GIZZA_MAX_WASM_MEMORY_PAGES: u32 = 1024;` (= 64 MiB). Every load /
builder site references that const, so the value lives in exactly one place.

## The two surfaces

**CLI — `cli/src/runtime.rs`**
- `boot_minimal` and `boot_full` builders add `.fuel_per_call(FuelLimit::Unmetered)`
  **and** `.max_wasm_memory_pages(GIZZA_MAX_WASM_MEMORY_PAGES)`.
- `register_skills` (which holds `&mut Wafer`) loads each skill via
  `WasmiBlock::load_from_bytes_with_limits(bytes, wafer.resource_limits())`,
  reading back the builder policy (both bounds in one call).

**Browser — `src/lib.rs`**
- The runtime is built via `SolobaseBuilder`, which constructs the wafer through
  `Wafer::new` and therefore leaves the **default metered / 256-page caps**
  (there is no `WaferBuilder` site to set them on). To keep the policy identical
  and explicit across both surfaces, the skill load site passes the full
  `ResourceLimits` directly:
  `WasmiBlock::load_from_bytes_with_limits(bytes, ResourceLimits { fuel: FuelLimit::Unmetered, memory_pages: GIZZA_MAX_WASM_MEMORY_PAGES })`.
- Imports `ResourceLimits` (alongside the existing `FuelLimit`) and the shared
  const under the existing `cfg(target_arch = "wasm32")`.

## Hosted runtimes are unaffected

`ResourceLimits::default()` is `{ Metered(100M), 256 pages }` and nothing here
changes the defaults — only gizza's two trusted surfaces opt out. Hosted
multi-tenant runtimes that load blocks through the registry/builder keep both
caps.

## Verification

- **CLI build** — `cargo build --release -p gizza-cli` compiles cleanly against
  the updated wafer-run **main** (local sibling checkout via `[patch]`).
- **Browser build** — `solobase build` compiles the app wasm with the wiring
  (`built gizza-ai (dev) → pkg`).
- **Memory-cap proof** — the previously-OOM-trapping `code-screenshot` Rust-grammar
  render (24 MiB `syntect`+fonts) now produces a valid PNG under the 64 MiB cap.
  See PR #98, which rebases onto this branch and depends on it.
- The earlier Unmeter (fuel) proof — running `phone-format` (`phonenumber`,
  2.7 MB wasm) returns formatted output instead of `all fuel consumed` — still
  holds; the fuel wiring is unchanged from the prior revision.

## Scope

3 files, +43/-16: `block-utils/src/lib.rs` (the shared const), the two builder
sites + load site in `cli/src/runtime.rs`, and the load site + imports in
`src/lib.rs`. No incidental reformatting of unrelated lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
