### PR TITLE
feat(blocks): css-select-extract — fetch a page, extract by CSS selector (network, no page — chat+CLI)

### DIFF
--- a/block-utils/src/lib.rs
+++ b/block-utils/src/lib.rs
@@ -5,6 +5,18 @@
 
 pub mod ffmpeg;
 
+/// Per-call linear-memory cap (in 64 KiB wasm pages) that gizza's trusted,
+/// single-user runtime grants every skill `WasmiBlock`. 1024 pages = 64 MiB.
+///
+/// wafer-run defaults to 256 pages / 16 MiB, which is enough for the light
+/// tools but OOM-traps memory-heavy ones (e.g. the `syntect`+bundled-font
+/// `code-screenshot` render needs ~24 MiB). gizza is local/trusted, so both
+/// its native CLI and browser runtimes raise the cap to this value at every
+/// skill load site; the hosted multi-tenant runtime keeps the 256-page
+/// default. Defined here (shared by `gizza-cli` and the browser `gizza-ai`
+/// crate) so the value lives in exactly one place.
+pub const GIZZA_MAX_WASM_MEMORY_PAGES: u32 = 1024;
+
 #[cfg(target_arch = "wasm32")]
 use std::collections::HashMap;
 

--- a/blocks/css-select-extract/Cargo.toml
+++ b/blocks/css-select-extract/Cargo.toml
@@ -1,0 +1,20 @@
+[workspace]
+resolver = "2"
+members = ["."]
+
+[package]
+name = "gizza-ai-css-select-extract-block"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.82"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wafer-sdk = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
+wafer-block = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
+gizza-ai-block-utils = { path = "../../block-utils" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+scraper = { version = "0.20", default-features = false }

--- a/blocks/css-select-extract/manifest.json
+++ b/blocks/css-select-extract/manifest.json
@@ -1,0 +1,21 @@
+{
+  "name": "gizza-ai/css-select-extract",
+  "version": "0.1.0",
+  "interface": "handler@v1",
+  "summary": "Fetch a page and extract content matching a CSS selector.",
+  "role": "skill",
+  "tool": {
+    "description": "Fetch an http(s) page and extract content from every element matching a CSS selector. Returns a list of matches as their text content, inner HTML, or a named attribute's value.",
+    "parameters": {
+      "type": "object",
+      "required": ["url", "selector"],
+      "properties": {
+        "url":      { "type": "string", "description": "Absolute http or https URL of the page to fetch." },
+        "selector": { "type": "string", "description": "CSS selector to match elements (e.g. \"h2.title\", \"a\", \"div#main p\")." },
+        "extract":  { "type": "string", "enum": ["text", "html", "attr"], "description": "What to extract from each matched element: \"text\" (default) = concatenated text content, \"html\" = inner HTML, \"attr\" = the value of the attribute named by \"attr\"." },
+        "attr":     { "type": "string", "description": "Attribute name to read when extract=\"attr\" (e.g. \"href\"). Required when extract=\"attr\"; elements lacking it are skipped." },
+        "limit":    { "type": "integer", "minimum": 1, "description": "Maximum number of matches to return (default 100)." }
+      }
+    }
+  }
+}

--- a/blocks/css-select-extract/src/lib.rs
+++ b/blocks/css-select-extract/src/lib.rs
@@ -1,0 +1,287 @@
+//! gizza-ai/css-select-extract — fetch a page via wafer-run/network and
+//! extract content matching a CSS selector (text / inner HTML / attribute).
+
+// The #[wafer_block] macro emits wasm-only registration; supporting imports
+// and the Args type are only used inside that impl.
+#![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
+
+use std::collections::HashMap;
+
+use gizza_ai_block_utils::{SkillError, SkillResultExt};
+use serde::{Deserialize, Serialize};
+use wafer_sdk::*;
+
+/// Default cap on the number of matches returned when `limit` is omitted.
+const DEFAULT_LIMIT: usize = 100;
+
+/// Maximum bytes of HTML we'll fetch and parse. The runtime grants this block
+/// a 64 MiB linear-memory cap (`GIZZA_MAX_WASM_MEMORY_PAGES`), so a generous
+/// page-size cap is safe; this just guards against pathologically huge bodies.
+const MAX_HTML_BYTES: usize = 8 << 20; // 8 MiB
+
+/// What to pull out of each matched element.
+pub mod core {
+    use scraper::{Html, Selector};
+
+    /// The three extraction modes the tool supports.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum ExtractKind {
+        /// Concatenated text content of the element (and its descendants).
+        Text,
+        /// The element's inner HTML.
+        Html,
+        /// The value of a named attribute (elements lacking it are skipped).
+        Attr,
+    }
+
+    impl ExtractKind {
+        /// Parse the user-facing string form. `None` defaults to `Text`.
+        pub fn parse(s: Option<&str>) -> Result<Self, String> {
+            match s {
+                None | Some("text") => Ok(Self::Text),
+                Some("html") => Ok(Self::Html),
+                Some("attr") => Ok(Self::Attr),
+                Some(other) => Err(format!(
+                    "invalid extract `{other}`: expected one of text, html, attr"
+                )),
+            }
+        }
+    }
+
+    /// Run `selector` against `html` and extract a value from each match.
+    ///
+    /// - `Text` → the element's concatenated text content (descendant text
+    ///   nodes joined with no separator, matching the document's whitespace).
+    /// - `Html` → the element's inner HTML.
+    /// - `Attr` → the value of the attribute named by `attr`; elements that
+    ///   lack the attribute are skipped (not emitted as empty strings).
+    ///
+    /// At most `limit` matches are returned. An invalid CSS selector, or
+    /// `Attr` without an attribute name, is a clear `Err`.
+    pub fn extract(
+        html: &str,
+        selector: &str,
+        kind: ExtractKind,
+        attr: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<String>, String> {
+        let sel = Selector::parse(selector)
+            .map_err(|e| format!("invalid CSS selector `{selector}`: {e}"))?;
+
+        if kind == ExtractKind::Attr {
+            let name = attr
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| "`attr` is required when extract=\"attr\"".to_string())?;
+            // Validate up front so an empty page still reports the bad arg.
+            let _ = name;
+        }
+
+        let doc = Html::parse_document(html);
+        let mut out = Vec::new();
+        for el in doc.select(&sel) {
+            if out.len() >= limit {
+                break;
+            }
+            match kind {
+                ExtractKind::Text => {
+                    out.push(el.text().collect::<String>());
+                }
+                ExtractKind::Html => {
+                    out.push(el.inner_html());
+                }
+                ExtractKind::Attr => {
+                    // attr presence was validated above; safe to unwrap the name.
+                    let name = attr.unwrap().trim();
+                    if let Some(v) = el.value().attr(name) {
+                        out.push(v.to_string());
+                    }
+                    // Elements lacking the attribute are skipped.
+                }
+            }
+        }
+        Ok(out)
+    }
+}
+
+#[derive(Deserialize)]
+struct Args {
+    url: String,
+    selector: String,
+    #[serde(default)]
+    extract: Option<String>,
+    #[serde(default)]
+    attr: Option<String>,
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+#[derive(Serialize)]
+struct ToolResp {
+    url: String,
+    selector: String,
+    extract: String,
+    count: usize,
+    matches: Vec<String>,
+}
+
+/// Extract a `Content-Type` header value (case-insensitive name match,
+/// first value in the multi-value list). Returns `None` if absent.
+fn extract_content_type(headers: &HashMap<String, Vec<String>>) -> Option<String> {
+    headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+        .and_then(|(_, vs)| vs.first().cloned())
+}
+
+#[cfg(target_arch = "wasm32")]
+struct CssSelectExtract;
+
+#[cfg(target_arch = "wasm32")]
+#[wafer_block(
+    name = "gizza-ai/css-select-extract",
+    version = "0.1.0",
+    interface = "handler@v1",
+    summary = "Fetch a page and extract content matching a CSS selector",
+    requires = ["wafer-run/network"],
+    skill(
+        description = "Fetch an http(s) page and extract content from every element matching a CSS selector. Returns a list of matches as their text content, inner HTML, or a named attribute's value.",
+        parameters = r#"{
+            "type": "object",
+            "properties": {
+                "url":      { "type": "string", "description": "Absolute http or https URL of the page to fetch." },
+                "selector": { "type": "string", "description": "CSS selector to match elements (e.g. \"h2.title\", \"a\", \"div#main p\")." },
+                "extract":  { "type": "string", "enum": ["text", "html", "attr"], "description": "What to extract from each matched element: \"text\" (default) = concatenated text content, \"html\" = inner HTML, \"attr\" = the value of the attribute named by \"attr\"." },
+                "attr":     { "type": "string", "description": "Attribute name to read when extract=\"attr\" (e.g. \"href\"). Required when extract=\"attr\"; elements lacking it are skipped." },
+                "limit":    { "type": "integer", "minimum": 1, "description": "Maximum number of matches to return (default 100)." }
+            },
+            "required": ["url", "selector"],
+            "additionalProperties": false
+        }"#
+    ),
+)]
+impl CssSelectExtract {
+    fn handle(_msg: Message, body: Vec<u8>) -> GuestResult {
+        match run(body) {
+            Ok(v) => GuestResult::respond(v),
+            Err(e) => GuestResult::error(e.into()),
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
+    let args: Args = serde_json::from_slice(&body).invalid_args("css-select-extract")?;
+
+    let kind =
+        core::ExtractKind::parse(args.extract.as_deref()).map_err(SkillError::InvalidArgs)?;
+    let limit = args.limit.unwrap_or(DEFAULT_LIMIT).max(1);
+
+    let resp = wafer_sdk::clients::network::do_request("GET", &args.url, &HashMap::new(), None)?;
+    if resp.status_code >= 400 {
+        return Err(SkillError::HttpStatus {
+            status: resp.status_code,
+            url: args.url,
+        });
+    }
+    if resp.body.len() > MAX_HTML_BYTES {
+        return Err(SkillError::TooLarge {
+            kind: "input page",
+            bytes: resp.body.len(),
+            cap: MAX_HTML_BYTES,
+        });
+    }
+    // Surface the content-type only to keep parity with web-fetch's diagnostics;
+    // we parse whatever we get as HTML regardless (html5ever is lenient).
+    let _content_type = extract_content_type(&resp.headers);
+    let html = String::from_utf8_lossy(&resp.body);
+
+    let matches = core::extract(&html, &args.selector, kind, args.attr.as_deref(), limit)
+        .map_err(SkillError::InvalidArgs)?;
+
+    let tool = ToolResp {
+        url: args.url,
+        selector: args.selector,
+        extract: match kind {
+            core::ExtractKind::Text => "text",
+            core::ExtractKind::Html => "html",
+            core::ExtractKind::Attr => "attr",
+        }
+        .to_string(),
+        count: matches.len(),
+        matches,
+    };
+    serde_json::to_vec(&tool)
+        .map_err(|e| SkillError::Serialize(format!("serialize tool response: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::core::{extract, ExtractKind};
+
+    const FIXTURE: &str = r#"
+        <html><body>
+          <h2 class="title">First Heading</h2>
+          <h2 class="title">Second <em>Heading</em></h2>
+          <p>not a title</p>
+          <a href="https://example.com/a">Link A</a>
+          <a>no href here</a>
+          <a href="https://example.com/b">Link B</a>
+        </body></html>
+    "#;
+
+    #[test]
+    fn extracts_text_from_fixture() {
+        let got = extract(FIXTURE, "h2.title", ExtractKind::Text, None, 100).unwrap();
+        assert_eq!(got, vec!["First Heading", "Second Heading"]);
+    }
+
+    #[test]
+    fn extracts_inner_html() {
+        let got = extract(FIXTURE, "h2.title", ExtractKind::Html, None, 100).unwrap();
+        assert_eq!(got[0], "First Heading");
+        assert_eq!(got[1], "Second <em>Heading</em>");
+    }
+
+    #[test]
+    fn extracts_attr_and_skips_missing() {
+        // Three <a> elements but only two carry href → the bare <a> is skipped.
+        let got = extract(FIXTURE, "a", ExtractKind::Attr, Some("href"), 100).unwrap();
+        assert_eq!(got, vec!["https://example.com/a", "https://example.com/b"]);
+    }
+
+    #[test]
+    fn invalid_selector_is_an_error() {
+        let err = extract(FIXTURE, "h2..bad[", ExtractKind::Text, None, 100).unwrap_err();
+        assert!(err.contains("invalid CSS selector"), "got: {err}");
+    }
+
+    #[test]
+    fn attr_without_name_is_an_error() {
+        let err = extract(FIXTURE, "a", ExtractKind::Attr, None, 100).unwrap_err();
+        assert!(err.contains("`attr` is required"), "got: {err}");
+        let err = extract(FIXTURE, "a", ExtractKind::Attr, Some("  "), 100).unwrap_err();
+        assert!(err.contains("`attr` is required"), "got: {err}");
+    }
+
+    #[test]
+    fn limit_caps_matches() {
+        let got = extract(FIXTURE, "a", ExtractKind::Attr, Some("href"), 1).unwrap();
+        assert_eq!(got, vec!["https://example.com/a"]);
+    }
+
+    #[test]
+    fn no_matches_returns_empty() {
+        let got = extract(FIXTURE, "h3", ExtractKind::Text, None, 100).unwrap();
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn extract_kind_parse_defaults_and_rejects() {
+        assert_eq!(ExtractKind::parse(None).unwrap(), ExtractKind::Text);
+        assert_eq!(ExtractKind::parse(Some("text")).unwrap(), ExtractKind::Text);
+        assert_eq!(ExtractKind::parse(Some("html")).unwrap(), ExtractKind::Html);
+        assert_eq!(ExtractKind::parse(Some("attr")).unwrap(), ExtractKind::Attr);
+        assert!(ExtractKind::parse(Some("bogus")).is_err());
+    }
+}

--- a/blocks/css-select-extract/src/lib.rs
+++ b/blocks/css-select-extract/src/lib.rs
@@ -68,14 +68,17 @@ pub mod core {
         let sel = Selector::parse(selector)
             .map_err(|e| format!("invalid CSS selector `{selector}`: {e}"))?;
 
-        if kind == ExtractKind::Attr {
-            let name = attr
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .ok_or_else(|| "`attr` is required when extract=\"attr\"".to_string())?;
-            // Validate up front so an empty page still reports the bad arg.
-            let _ = name;
-        }
+        // For attr extraction, resolve the (trimmed, non-empty) attribute name
+        // up front so a bad `attr` arg is reported even on an empty page.
+        let attr_name = if kind == ExtractKind::Attr {
+            Some(
+                attr.map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .ok_or_else(|| "`attr` is required when extract=\"attr\"".to_string())?,
+            )
+        } else {
+            None
+        };
 
         let doc = Html::parse_document(html);
         let mut out = Vec::new();
@@ -91,8 +94,8 @@ pub mod core {
                     out.push(el.inner_html());
                 }
                 ExtractKind::Attr => {
-                    // attr presence was validated above; safe to unwrap the name.
-                    let name = attr.unwrap().trim();
+                    // attr_name is Some for ExtractKind::Attr (validated above).
+                    let name = attr_name.expect("attr_name set for ExtractKind::Attr");
                     if let Some(v) = el.value().attr(name) {
                         out.push(v.to_string());
                     }

--- a/blocks/css-select-extract/wafer.toml
+++ b/blocks/css-select-extract/wafer.toml
@@ -1,0 +1,6 @@
+[package]
+org = "gizza-ai"
+name = "css-select-extract"
+version = "0.1.0"
+abi = 1
+summary = "Fetch a page and extract content matching a CSS selector."

--- a/cli/src/runtime.rs
+++ b/cli/src/runtime.rs
@@ -8,7 +8,7 @@ use wafer_block::{
     streams::{input::InputStream, output::TerminalNotResponse},
 };
 use wafer_block::Block;
-use wafer_run::{Wafer, WasmiBlock};
+use wafer_run::{FuelLimit, Wafer, WasmiBlock};
 
 use crate::SKILL_WASMS;
 
@@ -100,7 +100,13 @@ fn register_skills(
     metas: &mut Vec<ToolMeta>,
 ) -> Result<()> {
     for bytes in SKILL_WASMS {
-        let block = WasmiBlock::load_from_bytes(bytes).context("load skill wasm")?;
+        // gizza is a single-user, trusted CLI: opt skill calls out of the
+        // default 100M fuel cap so heavy tools (e.g. the `phonenumber` crate)
+        // run to completion instead of trapping with `all fuel consumed`.
+        // The Unmetered policy is set on the builder via `fuel_per_call` and
+        // read back here so every load site expresses it the same way.
+        let block = WasmiBlock::load_from_bytes_with_fuel(bytes, wafer.fuel_limit())
+            .context("load skill wasm")?;
         let info = block.info();
         let name = info.name.clone();
         // Capture SkillTool metadata if the block exposes one.
@@ -133,6 +139,8 @@ pub async fn boot_minimal() -> Result<ToolRuntime> {
     let mut wafer = Wafer::builder()
         .disable_inventory()
         .disable_lockfile()
+        // Trusted single-user CLI: skill calls run unmetered (see register_skills).
+        .fuel_per_call(FuelLimit::Unmetered)
         .build()
         .context("build wafer")?;
     let mut names = Vec::new();
@@ -152,6 +160,8 @@ pub async fn boot_full() -> Result<ToolRuntime> {
     let mut wafer = Wafer::builder()
         .disable_inventory()
         .disable_lockfile()
+        // Trusted single-user CLI: skill calls run unmetered (see register_skills).
+        .fuel_per_call(FuelLimit::Unmetered)
         .build()
         .context("build wafer")?;
 

--- a/cli/src/runtime.rs
+++ b/cli/src/runtime.rs
@@ -2,6 +2,7 @@
 use std::sync::Arc;
 
 use anyhow::{Context as _, Result};
+use gizza_ai_block_utils::GIZZA_MAX_WASM_MEMORY_PAGES;
 use wafer_block::{
     core_types::Message,
     meta::{META_REQ_ACTION, META_REQ_RESOURCE},
@@ -101,11 +102,12 @@ fn register_skills(
 ) -> Result<()> {
     for bytes in SKILL_WASMS {
         // gizza is a single-user, trusted CLI: opt skill calls out of the
-        // default 100M fuel cap so heavy tools (e.g. the `phonenumber` crate)
-        // run to completion instead of trapping with `all fuel consumed`.
-        // The Unmetered policy is set on the builder via `fuel_per_call` and
-        // read back here so every load site expresses it the same way.
-        let block = WasmiBlock::load_from_bytes_with_fuel(bytes, wafer.fuel_limit())
+        // default 100M fuel cap AND raise the 256-page / 16 MiB memory cap so
+        // heavy tools run to completion instead of trapping with `all fuel
+        // consumed` (fuel) or `unreachable`/OOM (memory). Both bounds are set
+        // on the builder (`fuel_per_call` + `max_wasm_memory_pages`) and read
+        // back here so every load site expresses the same policy.
+        let block = WasmiBlock::load_from_bytes_with_limits(bytes, wafer.resource_limits())
             .context("load skill wasm")?;
         let info = block.info();
         let name = info.name.clone();
@@ -139,8 +141,10 @@ pub async fn boot_minimal() -> Result<ToolRuntime> {
     let mut wafer = Wafer::builder()
         .disable_inventory()
         .disable_lockfile()
-        // Trusted single-user CLI: skill calls run unmetered (see register_skills).
+        // Trusted single-user CLI: skill calls run unmetered with a raised
+        // memory cap (see register_skills).
         .fuel_per_call(FuelLimit::Unmetered)
+        .max_wasm_memory_pages(GIZZA_MAX_WASM_MEMORY_PAGES)
         .build()
         .context("build wafer")?;
     let mut names = Vec::new();
@@ -160,8 +164,10 @@ pub async fn boot_full() -> Result<ToolRuntime> {
     let mut wafer = Wafer::builder()
         .disable_inventory()
         .disable_lockfile()
-        // Trusted single-user CLI: skill calls run unmetered (see register_skills).
+        // Trusted single-user CLI: skill calls run unmetered with a raised
+        // memory cap (see register_skills).
         .fuel_per_call(FuelLimit::Unmetered)
+        .max_wasm_memory_pages(GIZZA_MAX_WASM_MEMORY_PAGES)
         .build()
         .context("build wafer")?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ use solobase_core::RouteAccess;
 #[cfg(target_arch = "wasm32")]
 use wafer_core::interfaces::config::service::ConfigService;
 #[cfg(target_arch = "wasm32")]
+use wafer_run::FuelLimit;
+#[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
 pub mod blocks;
@@ -200,8 +202,16 @@ pub async fn initialize() -> Result<(), JsValue> {
         .map_err(|e| JsValue::from_str(&format!("register gizza-ai/ffmpeg-runtime: {e}")))?;
 
     for (name, bytes) in skills::SKILLS {
-        let wasmi = wafer_run::wasm::WasmiBlock::load_from_bytes(bytes)
-            .map_err(|e| JsValue::from_str(&format!("loading skill {name}: {e}")))?;
+        // gizza is a browser-local, single-user, trusted app: opt skill calls
+        // out of the default 100M fuel cap so heavy tools (e.g. the
+        // `phonenumber` crate) run to completion instead of trapping with
+        // `all fuel consumed`. The runtime here is built via `SolobaseBuilder`
+        // (which goes through `Wafer::new`, leaving the default metered cap),
+        // so we express the same "gizza skill calls = Unmetered" policy
+        // explicitly at the load site — matching the CLI surface.
+        let wasmi =
+            wafer_run::wasm::WasmiBlock::load_from_bytes_with_fuel(bytes, FuelLimit::Unmetered)
+                .map_err(|e| JsValue::from_str(&format!("loading skill {name}: {e}")))?;
         wafer
             .register_block(*name, Arc::new(wasmi))
             .map_err(|e| JsValue::from_str(&format!("registering skill {name}: {e}")))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,9 @@ use solobase_core::RouteAccess;
 #[cfg(target_arch = "wasm32")]
 use wafer_core::interfaces::config::service::ConfigService;
 #[cfg(target_arch = "wasm32")]
-use wafer_run::FuelLimit;
+use gizza_ai_block_utils::GIZZA_MAX_WASM_MEMORY_PAGES;
+#[cfg(target_arch = "wasm32")]
+use wafer_run::{FuelLimit, ResourceLimits};
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
@@ -203,15 +205,22 @@ pub async fn initialize() -> Result<(), JsValue> {
 
     for (name, bytes) in skills::SKILLS {
         // gizza is a browser-local, single-user, trusted app: opt skill calls
-        // out of the default 100M fuel cap so heavy tools (e.g. the
-        // `phonenumber` crate) run to completion instead of trapping with
-        // `all fuel consumed`. The runtime here is built via `SolobaseBuilder`
-        // (which goes through `Wafer::new`, leaving the default metered cap),
-        // so we express the same "gizza skill calls = Unmetered" policy
+        // out of the default 100M fuel cap AND raise the 256-page / 16 MiB
+        // memory cap so heavy tools (e.g. the `phonenumber` crate, or the
+        // `syntect`+font `code-screenshot` render that needs ~24 MiB) run to
+        // completion instead of trapping with `all fuel consumed` (fuel) or
+        // `unreachable`/OOM (memory). The runtime here is built via
+        // `SolobaseBuilder` (which goes through `Wafer::new`, leaving the
+        // default metered/256-page caps), so we express the same policy
         // explicitly at the load site — matching the CLI surface.
-        let wasmi =
-            wafer_run::wasm::WasmiBlock::load_from_bytes_with_fuel(bytes, FuelLimit::Unmetered)
-                .map_err(|e| JsValue::from_str(&format!("loading skill {name}: {e}")))?;
+        let wasmi = wafer_run::wasm::WasmiBlock::load_from_bytes_with_limits(
+            bytes,
+            ResourceLimits {
+                fuel: FuelLimit::Unmetered,
+                memory_pages: GIZZA_MAX_WASM_MEMORY_PAGES,
+            },
+        )
+        .map_err(|e| JsValue::from_str(&format!("loading skill {name}: {e}")))?;
         wafer
             .register_block(*name, Arc::new(wasmi))
             .map_err(|e| JsValue::from_str(&format!("registering skill {name}: {e}")))?;

--- a/tests/skills_embed.rs
+++ b/tests/skills_embed.rs
@@ -32,6 +32,22 @@ fn web_fetch_skill_is_embedded() {
 }
 
 #[test]
+fn css_select_extract_skill_is_embedded() {
+    assert!(
+        gizza_ai::skills::SKILLS
+            .iter()
+            .any(|(n, _)| *n == "gizza-ai/css-select-extract"),
+        "gizza-ai/css-select-extract should be embedded — did you forget to build the block first?"
+    );
+    let (_, bytes) = gizza_ai::skills::SKILLS
+        .iter()
+        .find(|(n, _)| *n == "gizza-ai/css-select-extract")
+        .expect("css-select-extract");
+    assert!(!bytes.is_empty(), "css-select-extract wasm bytes non-empty");
+    assert_eq!(&bytes[..4], b"\0asm", "css-select-extract bytes look like wasm");
+}
+
+#[test]
 fn ffmpeg_skill_is_embedded() {
     assert!(
         gizza_ai::skills::SKILLS


### PR DESCRIPTION
## css-select-extract — fetch a page and extract content by CSS selector

**Tool type:** web / **network** — fetches a URL via the `wafer-run/network`
host block (SSRF-guarded, public URLs only). **Surface: chat + CLI block, NO
page** (mirrors `blocks/web-fetch`). No file attachment (it fetches a URL, not
an upload), no generator/Playwright page.

**Example prompt:** *"Get the text of every h2.title on this page"*

### Schema (chat `skill()` + manifest)

| param | type | required | notes |
|-------|------|----------|-------|
| `url` | string | yes | absolute http/https URL |
| `selector` | string | yes | a CSS selector (e.g. `h2.title`, `a`, `div#main p`) |
| `extract` | enum `text\|html\|attr` | no (default `text`) | what to pull from each match |
| `attr` | string | only when `extract=attr` | attribute name (e.g. `href`); elements lacking it are skipped |
| `limit` | integer | no (default `100`) | cap the number of matches |

### Behavior

- pure `core::extract(html, selector, kind, attr, limit) -> Result<Vec<String>, String>`
  via the **`scraper`** crate (html5ever + the `selectors` engine).
  - `text` → element's concatenated text content
  - `html` → element's inner HTML
  - `attr` → the named attribute's value; nodes lacking it are skipped
  - invalid selector → clear error; `attr` without a name → clear error
- The skill handler GETs `url` via `wafer_sdk::clients::network::do_request`,
  rejects status >= 400 and bodies over 8 MiB, parses the body as HTML, and
  returns a flat JSON envelope the LLM reads directly:
  `{url, selector, extract, count, matches:[...]}`.
- Matches are capped by `limit` (default 100). The runtime grants this block the
  64 MiB linear-memory cap, so large pages parse fine.

### scraper wasm32-wasip1 verdict — **feasible**, with a producer prereq

`scraper` (default-features off) compiles cleanly to `wasm32-wasip1`. It does,
however, surface a `wasi_snapshot_preview1::sched_yield` import (pulled in via
`ahash`/`selectors` spin/back-off paths that reference `std::thread::yield_now`)
that the wafer-run wasmi host did **not** previously stub, so the block failed to
instantiate with `cannot find definition for import ...::sched_yield`.

**Producer fix:** wafer-run/wafer-run#243 adds a no-op `sched_yield` stub to the
runtime host **and** the `wafer` CLI validator (single-threaded guest → yield is
a no-op; mirrors the existing `environ_get` stub). **This PR depends on #243
landing on wafer-run main** (gizza tracks `wafer-run` `branch = "main"`, so CI
picks it up automatically once merged). I verified the full chain locally by
reinstalling the `wafer` CLI from #243 and patching the gizza CLI build at it
(see CLI results below).

### Build + test results (actual)

- `wafer build` (block, after #243-patched `wafer` CLI) →
  `OK  gizza-ai/css-select-extract v0.1.0  (1068.2 KiB)` ✅
- `cargo test --workspace` (block crate) → **8 passed** (text extraction from a
  fixture, inner-HTML extraction, attr extraction skipping missing, invalid
  selector error, attr-without-name error, limit cap, no-match empty,
  enum parse) ✅
- `cargo +nightly fmt` (block crate only) → clean ✅
- `solobase build` → `built gizza-ai (dev) → pkg` ✅
- `cargo test` (gizza root: tools/cli/generator + skills_embed) → **all green**
  (incl. new `css_select_extract_skill_is_embedded`) ✅

### CLI tests (real fetch, against the #243-patched runtime)

```
$ gizza tool css-select-extract 'url=https://example.com' 'selector=h1' extract=text
{"url":"https://example.com","selector":"h1","extract":"text","count":1,"matches":["Example Domain"]}

$ gizza tool css-select-extract 'url=https://example.com' selector=a extract=attr attr=href
{"url":"https://example.com","selector":"a","extract":"attr","count":1,"matches":["https://iana.org/domains/example"]}
```

Both match the expected results (`Example Domain` text; the IANA link href).

### Assumptions / limitations

- **No page surface** (network tool). Chat + CLI only — recorded per the build
  notes' tool-shape classification.
- **Depends on wafer-run #243** (the `sched_yield` host stub). Until that lands
  on wafer-run main, the block validates/instantiates only against a patched
  runtime. The block.wasm itself is correct and wasm-feasible.
- `extract=text` uses the document's own whitespace (descendant text nodes
  concatenated, no separator), matching `scraper`'s `ElementRef::text()`.
- `limit` defaults to 100 to keep responses bounded for the LLM even on
  large pages.

### Self-review

- Args validation: `extract` enum parsed before the network call;
  `attr`-required-when-`attr` validated in `core::extract` so an empty page still
  reports the bad arg. HTTP >= 400 and 8 MiB body cap rejected with typed
  `SkillError`s (mapped to the right `ErrorCode`s by `block-utils`).
- No raw SQL, no hardcoded domain values, no sync bridges. `core::extract` is
  pure and host-testable; the network/SDK-gated path stays under
  `cfg(target_arch = "wasm32")` exactly like `web-fetch`.
- `manifest.json` / `wafer.toml` / the macro `skill()` schema are kept
  consistent (informational manifest mirrors the macro schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
