### PR TITLE
fix(seo): carry the apex SEO/social <head> in the static crawler shell

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -3,7 +3,23 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>gizza-ai</title>
+  <!-- SEO / social metadata for the cold, crawler-facing load. This static shell
+       is what a no-JS crawler or social-card scraper (Twitter/Slack/LinkedIn)
+       sees; the in-app render_chat() (Service-Worker/SSR) carries the same head
+       for JS clients. Keep these values in sync with the SEO_* constants in
+       src/blocks/ui.rs — the static_shell_carries_seo_head test enforces it. -->
+  <title>gizza.ai — free, private AI chat in your browser</title>
+  <meta name="description" content="gizza.ai is a free, private AI chat assistant. All inference runs in your browser via WebGPU — your conversations never leave your device.">
+  <link rel="canonical" href="https://gizza.ai/">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="gizza.ai — free, private AI chat in your browser">
+  <meta property="og:description" content="gizza.ai is a free, private AI chat assistant. All inference runs in your browser via WebGPU — your conversations never leave your device.">
+  <meta property="og:url" content="https://gizza.ai/">
+  <meta property="og:image" content="https://gizza.ai/gis.png">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="gizza.ai — free, private AI chat in your browser">
+  <meta name="twitter:description" content="gizza.ai is a free, private AI chat assistant. All inference runs in your browser via WebGPU — your conversations never leave your device.">
+  <script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","name":"gizza.ai","url":"https://gizza.ai"},{"@type":"WebSite","name":"gizza.ai","url":"https://gizza.ai","description":"Free, private AI chat and tools — all inference runs in your browser via WebGPU, your conversations never leave your device."}]}</script>
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/src/blocks/ui.rs
+++ b/src/blocks/ui.rs
@@ -17,6 +17,19 @@ use wafer_block::{
 
 use super::DEFAULT_MODEL_ID;
 
+/// Canonical SEO / social metadata for the apex page.
+///
+/// Single source consumed by BOTH the Service-Worker/SSR render
+/// ([`render_chat`]) and the static, crawler-facing shell `site/index.html`
+/// (which `solobase.toml` overlays as the deployed `index.html`). A no-JS
+/// crawler or social-card scraper only ever sees that static shell, so the SEO
+/// `<head>` must be present there too — the `static_shell_carries_seo_head`
+/// test fails if the shell drifts from these values.
+const SEO_TITLE: &str = "gizza.ai — free, private AI chat in your browser";
+const SEO_DESCRIPTION: &str = "gizza.ai is a free, private AI chat assistant. All inference runs in your browser via WebGPU — your conversations never leave your device.";
+const SEO_CANONICAL: &str = "https://gizza.ai/";
+const SEO_OG_IMAGE: &str = "https://gizza.ai/gis.png";
+
 pub struct UiBlock;
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -109,17 +122,17 @@ fn render_chat() -> maud::Markup {
             head {
                 meta charset="utf-8";
                 meta name="viewport" content="width=device-width, initial-scale=1";
-                title { "gizza.ai — free, private AI chat in your browser" }
-                meta name="description" content="gizza.ai is a free, private AI chat assistant. All inference runs in your browser via WebGPU — your conversations never leave your device.";
-                link rel="canonical" href="https://gizza.ai/";
+                title { (SEO_TITLE) }
+                meta name="description" content=(SEO_DESCRIPTION);
+                link rel="canonical" href=(SEO_CANONICAL);
                 meta property="og:type" content="website";
-                meta property="og:title" content="gizza.ai — free, private AI chat in your browser";
-                meta property="og:description" content="gizza.ai is a free, private AI chat assistant. All inference runs in your browser via WebGPU — your conversations never leave your device.";
-                meta property="og:url" content="https://gizza.ai/";
-                meta property="og:image" content="https://gizza.ai/gis.png";
+                meta property="og:title" content=(SEO_TITLE);
+                meta property="og:description" content=(SEO_DESCRIPTION);
+                meta property="og:url" content=(SEO_CANONICAL);
+                meta property="og:image" content=(SEO_OG_IMAGE);
                 meta name="twitter:card" content="summary";
-                meta name="twitter:title" content="gizza.ai — free, private AI chat in your browser";
-                meta name="twitter:description" content="gizza.ai is a free, private AI chat assistant. All inference runs in your browser via WebGPU — your conversations never leave your device.";
+                meta name="twitter:title" content=(SEO_TITLE);
+                meta name="twitter:description" content=(SEO_DESCRIPTION);
                 script type="application/ld+json" { (PreEscaped(json_ld)) }
                 link rel="stylesheet" href="https://site-kit.suppers.ai/dist/design-system.css";
                 script type="module" src="https://site-kit.suppers.ai/dist/components/sa-chat.js" {}
@@ -473,6 +486,38 @@ mod tests {
         assert!(
             s.contains(r#""@type":"Organization""#),
             "JSON-LD Organization type present"
+        );
+    }
+
+    /// The cold, crawler-facing apex is the static `site/index.html` overlay
+    /// (`solobase.toml` copies it to the deployed `index.html`) — NOT
+    /// [`render_chat`], which is the Service-Worker/SSR path a no-JS crawler or
+    /// social-card scraper (Twitter/Slack/LinkedIn) never executes. So the SEO
+    /// `<head>` must be present statically here too, kept in sync with
+    /// `render_chat` via the shared `SEO_*` constants (this test is the guard).
+    #[test]
+    fn static_shell_carries_seo_head() {
+        let shell = include_str!("../../site/index.html");
+        assert!(
+            shell.contains(SEO_TITLE),
+            "static shell <title>/og:title uses the SEO title"
+        );
+        assert!(
+            shell.contains(SEO_DESCRIPTION),
+            "static shell has the SEO meta description"
+        );
+        assert!(
+            shell.contains(&format!(r#"rel="canonical" href="{SEO_CANONICAL}""#)),
+            "static shell has the canonical link"
+        );
+        assert!(shell.contains("og:title"), "static shell has OG title");
+        assert!(
+            shell.contains("twitter:card"),
+            "static shell has the Twitter card"
+        );
+        assert!(
+            shell.contains("application/ld+json"),
+            "static shell has JSON-LD"
         );
     }
 }


### PR DESCRIPTION
## fix(seo): carry the apex SEO/social `<head>` in the static crawler shell

### The gap (found during the #101 live-site verification)

The deployed apex `/` on gizza.ai is served from the **static `site/index.html`** overlay (`solobase.toml:13` copies it verbatim to `index.html`), **not** from `render_chat()`. #101 added the apex SEO `<head>` + JSON-LD only to `render_chat()` — the Service-Worker/SSR path that a JS client reaches.

A **no-JS crawler or social-card scraper** (Twitter/Slack/Discord/LinkedIn link previews) only ever sees the raw static shell, which was SEO-bare:

```
<title>gizza-ai</title>   <!-- and nothing else: no description, canonical, OG, Twitter, JSON-LD -->
```

So apex link previews showed no card and non-JS crawlers indexed a bare page. (Googlebot, which renders JS, was fine; the static SEO files — sitemap/robots/llms.txt — and the per-tool pages were already statically SEO-rich.)

### The fix (root-cause, no drift)

- Add the same SEO/social head to `site/index.html`: SEO `<title>`, `meta description`, `canonical`, OG (`type`/`title`/`description`/`url`/`image`), Twitter card, and JSON-LD `Organization`+`WebSite` — matching `render_chat()`.
- Extract the values into **single-source constants** (`SEO_TITLE`, `SEO_DESCRIPTION`, `SEO_CANONICAL`, `SEO_OG_IMAGE`) in `src/blocks/ui.rs`, consumed by `render_chat()` (also de-dupes the description that was repeated 3× there).
- **Drift guard:** new test `static_shell_carries_seo_head` reads `site/index.html` via `include_str!` and asserts it contains those constants + `twitter:card` + `application/ld+json`. If `render_chat()`'s SEO constants change without updating the static shell, the test fails.

The client still rewrites `document.title` to "gizza.ai" after boot for the browser tab; crawlers get the descriptive SEO title from the raw HTML.

### Tests (TDD)

- **RED:** added `static_shell_carries_seo_head` → failed (static shell was bare).
- **GREEN:** added the head to `site/index.html` → passes.
- **REFACTOR:** extracted the `SEO_*` constants; existing `head_has_seo_tags` (covers `render_chat()`) stayed green, proving the SSR output is unchanged.

```
cargo test --lib        # 41 passed, 0 failed (incl. head_has_seo_tags + static_shell_carries_seo_head)
```

`og:image` target `https://gizza.ai/gis.png` verified live (200 image/png).

### Notes

- **Not run:** the full root `cargo test` integration suite (`tests/dispatch_skills.rs`) needs the per-block `target/block.wasm` artifacts built first — a pre-existing local-environment requirement unrelated to this change (CI builds them). This change touches only `ui.rs` + `site/index.html` and cannot affect skill dispatch.
- **fmt:** deliberately did not run repo-wide `cargo +nightly fmt` — the test module has pre-existing nightly-fmt drift in untouched tests, and reformatting it would pollute this PR (gizza CI has no fmt gate). The added code is nightly-fmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
