### PR TITLE
feat(phone-format): retrofit onto shared tool abstraction (Recipe P)

### DIFF
--- a/blocks/phone-format/Cargo.toml
+++ b/blocks/phone-format/Cargo.toml
@@ -15,5 +15,6 @@ crate-type = ["cdylib", "rlib"]
 wafer-sdk = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
 wafer-block = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
 gizza-ai-phone-format-core = { path = "core" }
+gizza-ai-block-utils = { path = "../../block-utils" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/blocks/phone-format/src/lib.rs
+++ b/blocks/phone-format/src/lib.rs
@@ -1,11 +1,12 @@
 //! gizza-ai/phone-format — chat skill block (thin wrapper around core).
 //!
-//! Parses, validates, and formats an international phone number. Takes
-//! `{ "number": "+1 415 555 2671", "region": "US"? }` and returns
-//! `{ "result": "Valid: yes\nE.164: …\n…" }` or `{ "error": "..." }`.
-//! No host calls — runs entirely inside the WASM sandbox (the `phonenumber`
-//! crate bundles its own metadata).
+//! Parses, validates, and formats an international phone number. The chat schema
+//! is derived from `descriptor()` (single source — shared shape across chat +
+//! CLI); the handler delegates to `block_utils::run_skill` and returns
+//! `{ "result": "Valid: yes\nE.164: …\n…" }`. No host calls — runs entirely
+//! inside the WASM sandbox (the `phonenumber` crate bundles its own metadata).
 #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
+use gizza_ai_block_utils::{run_skill, Input, Param, SkillError, ToolDescriptor};
 use serde::Deserialize;
 use wafer_sdk::*;
 
@@ -14,6 +15,25 @@ struct Args {
     number: String,
     #[serde(default)]
     region: String,
+}
+
+/// Single-source param descriptor → chat schema (and CLI). See
+/// docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md.
+fn descriptor() -> ToolDescriptor {
+    ToolDescriptor::new(Input::None)
+        .param(
+            Param::string("number")
+                .required()
+                .describe("The phone number to analyze. May include a +country prefix, e.g. +1 415 555 2671."),
+        )
+        .param(
+            Param::string("region")
+                .describe("Optional ISO-3166 alpha-2 region code (e.g. US, GB, DE) used to interpret a number given without a + prefix."),
+        )
+}
+
+fn schema_json() -> String {
+    descriptor().to_schema_json()
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -27,35 +47,46 @@ struct PhoneFormat;
     summary = "Phone number formatter & validator skill",
     skill(
         description = "Parse, validate, and format an international phone number. Reports validity, E.164, national & international formats, the country/region, and the number type when derivable.",
-        parameters = r#"{
-            "type": "object",
-            "properties": {
-                "number": { "type": "string", "description": "The phone number to analyze. May include a +country prefix, e.g. +1 415 555 2671." },
-                "region": { "type": "string", "description": "Optional ISO-3166 alpha-2 region code (e.g. US, GB, DE) used to interpret a number given without a + prefix." }
-            },
-            "required": ["number"],
-            "additionalProperties": false
-        }"#
+        parameters = schema_json()
     )
 )]
 impl PhoneFormat {
     fn handle(_msg: Message, body: Vec<u8>) -> GuestResult {
-        let args: Args = match serde_json::from_slice(&body) {
-            Ok(a) => a,
-            Err(e) => return respond_error(format!("invalid args: {e}")),
-        };
-        match gizza_ai_phone_format_core::format_number(&args.number, &args.region) {
-            Ok(v) => GuestResult::respond(
-                serde_json::to_vec(&serde_json::json!({ "result": v })).unwrap_or_default(),
-            ),
-            Err(e) => respond_error(e),
+        // run_skill wraps the returned value in { "result": … } — phone-format's
+        // existing success shape — and routes errors through GuestResult::error.
+        match run_skill(&body, "phone-format", |a: Args| {
+            gizza_ai_phone_format_core::format_number(&a.number, &a.region)
+                .map_err(SkillError::InvalidArgs)
+        }) {
+            Ok(v) => GuestResult::respond(v),
+            Err(e) => GuestResult::error(e.into()),
         }
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-fn respond_error(msg: String) -> GuestResult {
-    GuestResult::respond(
-        serde_json::to_vec(&serde_json::json!({ "error": msg })).unwrap_or_default(),
-    )
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Migration safety: the descriptor-derived chat schema must match the
+    /// pre-retrofit authored schema, so the LLM sees no drift. (to_schema_json
+    /// now emits `additionalProperties: false` uniformly, which phone-format's
+    /// authored schema already had — so this is an exact match.)
+    #[test]
+    fn schema_json_matches_authored_chat_schema() {
+        let authored: serde_json::Value = serde_json::from_str(
+            r#"{
+                "type": "object",
+                "properties": {
+                    "number": { "type": "string", "description": "The phone number to analyze. May include a +country prefix, e.g. +1 415 555 2671." },
+                    "region": { "type": "string", "description": "Optional ISO-3166 alpha-2 region code (e.g. US, GB, DE) used to interpret a number given without a + prefix." }
+                },
+                "required": ["number"],
+                "additionalProperties": false
+            }"#,
+        )
+        .unwrap();
+        let derived: serde_json::Value = serde_json::from_str(&schema_json()).unwrap();
+        assert_eq!(derived, authored, "no LLM-facing chat-schema drift");
+    }
 }


### PR DESCRIPTION
Retrofit `gizza-ai/phone-format` (pure-text tool, "Recipe P") onto the shared tool abstraction, mirroring the url-encode exemplar (`e1c1c87`).

## What changed

- **`descriptor()` → `schema_json()` in `src/lib.rs`** (module-level, not cfg-gated) is now the single source for the chat schema. `Input::None`; params `number` (required string) and `region` (optional string), reproducing the previous authored names/types/descriptions/required/`additionalProperties:false` exactly.
- `#[wafer_block(skill(parameters = …))]` now reads `schema_json()` instead of an inline JSON literal; the `#[wafer_block]` impl stays `#[cfg(target_arch="wasm32")]`.
- **`handle()` delegates to `block_utils::run_skill`** — replaces the hand-written parse/match and the `respond_error` helper (errors now flow through `GuestResult::error(e.into())`). Success shape is unchanged: `{ "result": "Valid: yes\nE.164: …\n…" }`.
- Added `gizza-ai-block-utils = { path = "../../block-utils" }` to `Cargo.toml`.
- core stays pure (no descriptor / no block-utils dep there).

## Drift-guard

Added a native `#[test] fn schema_json_matches_authored_chat_schema()` asserting the descriptor-derived schema equals the pre-retrofit authored `parameters` JSON. The authored schema already declared `additionalProperties:false`, so this is an exact match.

## Verify (actual output)

- `cargo test --workspace`: drift-guard `schema_json_matches_authored_chat_schema ... ok` (1 passed); core 7 passed; web 0; all green.
- `wafer build` (in block dir): `OK  gizza-ai/phone-format v0.1.0  (2786.7 KiB)` — large payload is the bundled `phonenumber` libphonenumber metadata, as documented in core.
- CLI smoke `gizza tool phone-format 'number=+14155552671'` →
  `"Valid: yes\nE.164: +14155552671\nNational: (415) 555-2671\nInternational: +1 415-555-2671\nCountry/region: US\nType: fixed line or mobile"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
