### PR TITLE
feat(web-fetch): retrofit onto shared tool abstraction (Recipe N)

### DIFF
--- a/block-utils/src/descriptor.rs
+++ b/block-utils/src/descriptor.rs
@@ -181,7 +181,16 @@ impl ToolDescriptor {
                 }
             }
             if let Some(m) = p.minimum {
-                prop.insert("minimum".into(), json!(m));
+                // Render whole-number bounds as JSON integers (`1`, not `1.0`)
+                // so an integer param's `minimum` matches what hand-authored
+                // schemas wrote and what `ParamKind::Integer` implies. `Param`
+                // stores `minimum` as f64; without this, every integer min
+                // would serialize as a float and drift from the authored schema.
+                if m.fract() == 0.0 && m.is_finite() {
+                    prop.insert("minimum".into(), json!(m as i64));
+                } else {
+                    prop.insert("minimum".into(), json!(m));
+                }
             }
             if let Some(d) = &p.default {
                 prop.insert("default".into(), d.clone());
@@ -268,7 +277,10 @@ mod tests {
             "The expression."
         );
         assert_eq!(v["required"], serde_json::json!(["expression"]));
-        assert_eq!(v["additionalProperties"], false, "schemas reject unknown params");
+        assert_eq!(
+            v["additionalProperties"], false,
+            "schemas reject unknown params"
+        );
         assert!(v.get("oneOf").is_none(), "no url/ref oneOf for Input::None");
     }
 
@@ -302,7 +314,8 @@ mod tests {
         );
         // typed params.
         assert_eq!(v["properties"]["width"]["type"], "integer");
-        assert_eq!(v["properties"]["width"]["minimum"], 1.0);
+        // Whole-number bounds render as JSON integers, not floats.
+        assert_eq!(v["properties"]["width"]["minimum"], 1);
         assert_eq!(
             v["properties"]["fit"]["enum"],
             serde_json::json!(["contain", "cover", "stretch"])

--- a/blocks/web-fetch/src/lib.rs
+++ b/blocks/web-fetch/src/lib.rs
@@ -1,4 +1,10 @@
 //! gizza-ai/web-fetch — fetches a URL via wafer-run/network.
+//!
+//! The chat schema is derived from `descriptor()` (single source — shared shape
+//! across chat + CLI). The handler stays thin (parse `Args`, run the fetch, emit
+//! the flat `ToolResp`) rather than going through `run_skill`, because web-fetch's
+//! success shape is the flat `ToolResp` JSON, not the `{ "result": … }` wrapper
+//! `run_skill` produces.
 
 // The #[wafer_block] macro emits wasm-only registration; supporting imports
 // and the Args type are only used inside that impl.
@@ -6,7 +12,7 @@
 
 use std::collections::HashMap;
 
-use gizza_ai_block_utils::{SkillError, SkillResultExt};
+use gizza_ai_block_utils::{Input, Param, SkillError, SkillResultExt, ToolDescriptor};
 use serde::{Deserialize, Serialize};
 use wafer_sdk::*;
 
@@ -26,6 +32,28 @@ struct ToolResp {
     content_type: Option<String>,
     body: String,
     truncated: bool,
+}
+
+/// Single-source param descriptor → chat schema (and CLI). See
+/// docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md.
+/// web-fetch is `Input::None` — `url` is a normal required string param (it has
+/// no `ref`), so there is no `url`⊕`ref` `oneOf`.
+fn descriptor() -> ToolDescriptor {
+    ToolDescriptor::new(Input::None)
+        .param(
+            Param::string("url")
+                .required()
+                .describe("HTTP/HTTPS URL to fetch."),
+        )
+        .param(
+            Param::integer("max_bytes").min(1.0).describe(
+                "Maximum number of bytes to return (default: 1048576). Response is truncated if larger.",
+            ),
+        )
+}
+
+fn schema_json() -> String {
+    descriptor().to_schema_json()
 }
 
 /// Trim a body to `max_bytes`. Returns `(prefix, was_truncated)`.
@@ -58,19 +86,13 @@ struct WebFetch;
     requires = ["wafer-run/network"],
     skill(
         description = "Fetch a URL and return its body as text. Optionally limit the response size.",
-        parameters = r#"{
-            "type": "object",
-            "properties": {
-                "url":       { "type": "string", "description": "HTTP/HTTPS URL to fetch." },
-                "max_bytes": { "type": "integer", "minimum": 1, "description": "Maximum number of bytes to return (default: 1048576). Response is truncated if larger." }
-            },
-            "required": ["url"],
-            "additionalProperties": false
-        }"#
+        parameters = schema_json()
     ),
 )]
 impl WebFetch {
     fn handle(_msg: Message, body: Vec<u8>) -> GuestResult {
+        // web-fetch returns the flat ToolResp JSON directly (no `{ "result": … }`
+        // wrapper), so it keeps a thin handle rather than using run_skill.
         match run(body) {
             Ok(v) => GuestResult::respond(v),
             Err(e) => GuestResult::error(e.into()),
@@ -96,12 +118,36 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
         body: body_str,
         truncated,
     };
-    serde_json::to_vec(&tool).map_err(|e| SkillError::Serialize(format!("serialize tool response: {e}")))
+    serde_json::to_vec(&tool)
+        .map_err(|e| SkillError::Serialize(format!("serialize tool response: {e}")))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Migration safety: the descriptor-derived chat schema must match the
+    /// pre-retrofit authored schema, so the LLM sees no drift. (to_schema_json
+    /// now emits `additionalProperties: false`, which web-fetch's authored
+    /// schema already had; the descriptor renders `max_bytes`'s minimum as the
+    /// JSON number `1`, same as the authored schema.)
+    #[test]
+    fn schema_json_matches_authored_chat_schema() {
+        let authored: serde_json::Value = serde_json::from_str(
+            r#"{
+                "type": "object",
+                "properties": {
+                    "url":       { "type": "string", "description": "HTTP/HTTPS URL to fetch." },
+                    "max_bytes": { "type": "integer", "minimum": 1, "description": "Maximum number of bytes to return (default: 1048576). Response is truncated if larger." }
+                },
+                "required": ["url"],
+                "additionalProperties": false
+            }"#,
+        )
+        .unwrap();
+        let derived: serde_json::Value = serde_json::from_str(&schema_json()).unwrap();
+        assert_eq!(derived, authored, "no LLM-facing chat-schema drift");
+    }
 
     #[test]
     fn maybe_truncate_clips_when_over_limit() {
@@ -152,10 +198,7 @@ mod tests {
         let mut headers = HashMap::new();
         headers.insert(
             "content-type".to_string(),
-            vec![
-                "application/json".to_string(),
-                "text/plain".to_string(),
-            ],
+            vec!["application/json".to_string(), "text/plain".to_string()],
         );
         assert_eq!(
             extract_content_type(&headers).as_deref(),


### PR DESCRIPTION
## What

Retrofits `gizza-ai/web-fetch` onto the shared tool abstraction (Recipe N),
mirroring the url-encode exemplar (`e1c1c87`).

- `descriptor()` + `schema_json()` live in `blocks/web-fetch/src/lib.rs` (deps
  `block-utils`), NOT core — keeps core pure. Both are module-level (not
  cfg-gated); the `#[wafer_block]` impl stays `#[cfg(target_arch = "wasm32")]`
  and now uses `parameters = schema_json()` as the single source for the chat
  schema.
- web-fetch is `Input::None`: `url` is a normal required `Param::string`, NOT the
  `url`⊕`ref` `oneOf` (it has no `ref`). `max_bytes` is an optional
  `Param::integer().min(1.0)`. Descriptions match the current authored schema
  verbatim.

### Handler: NON-run_skill path (intentional)

web-fetch's success shape is the **flat `ToolResp` JSON** (`{status, url,
content_type, body, truncated}`), NOT the `{ "result": … }` wrapper `run_skill`
produces. So the handler keeps a thin `handle` → `run(body)` that parses `Args`,
runs the fetch, and returns the flat bytes via `GuestResult::respond` on Ok /
`GuestResult::error(e.into())` on Err. The fetch logic itself is unchanged.

### Drift-guard

`schema_json_matches_authored_chat_schema()` pastes web-fetch's current authored
`parameters` JSON and asserts it equals the descriptor-derived schema. The
authored schema already had `additionalProperties: false`, so no addition was
needed there.

### Foundation refinement (root-cause fix in block-utils)

web-fetch is the first numeric-param retrofit, and it surfaced a real
LLM-facing drift in `ToolDescriptor::to_schema_json`: `Param` stores `minimum`
as `f64`, so `json!(m)` rendered `max_bytes`'s `minimum` as `1.0`, while the
hand-authored schema (and every integer param) means the JSON integer `1`. Fixed
at root cause: `to_schema_json` now renders whole-number, finite bounds as JSON
integers (`1`, not `1.0`). This is the same kind of uniformity refinement the
url-encode exemplar made to the shared descriptor (`additionalProperties`).
Updated the existing `schema_for_media_tool_…` block-utils test to assert the
integer rendering. All 45 block-utils tests pass.

## Verify (actual output)

- `cargo test … blocks/web-fetch … --workspace` → **7 passed; 0 failed**
  (incl. the drift-guard).
- `cargo test … block-utils` → **45 passed; 0 failed**.
- `wafer build` (in `blocks/web-fetch`) → `OK  gizza-ai/web-fetch v0.1.0
  (417.8 KiB)`, validated.
- CLI smoke:
  `gizza tool web-fetch 'url=https://httpbin.org/robots.txt'` →
  `{"status":200,"url":"https://httpbin.org/robots.txt","content_type":"text/plain","body":"User-agent: *\nDisallow: /deny\n","truncated":false}`
  — flat `ToolResp` shape preserved exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
