### PR TITLE
feat(word-count): retrofit onto shared tool abstraction (Recipe P)

### DIFF
--- a/blocks/word-count/Cargo.toml
+++ b/blocks/word-count/Cargo.toml
@@ -15,5 +15,6 @@ crate-type = ["cdylib", "rlib"]
 wafer-sdk = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
 wafer-block = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
 gizza-ai-word-count-core = { path = "core" }
+gizza-ai-block-utils = { path = "../../block-utils" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/blocks/word-count/src/lib.rs
+++ b/blocks/word-count/src/lib.rs
@@ -1,15 +1,32 @@
 //! gizza-ai/word-count — counts words, characters, and lines in a block of text.
 //!
-//! Thin chat-skill wrapper around `gizza-ai-word-count-core`. Takes
-//! `{ "text": "..." }`, returns `{ "result": "N words, N characters, N lines" }`
-//! or `{ "error": "..." }`. No host calls — runs entirely inside the WASM sandbox.
+//! Thin chat-skill wrapper around `gizza-ai-word-count-core`. The chat schema is
+//! derived from `descriptor()` (single source — shared shape across chat + CLI);
+//! the handler delegates to `block_utils::run_skill`, which wraps the result in
+//! `{ "result": "N words, N characters, N lines" }`. No host calls — runs
+//! entirely inside the WASM sandbox.
 #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
+use gizza_ai_block_utils::{run_skill, Input, Param, SkillError, ToolDescriptor};
 use serde::Deserialize;
 use wafer_sdk::*;
 
 #[derive(Deserialize)]
 struct Args {
     text: String,
+}
+
+/// Single-source param descriptor → chat schema (and CLI). See
+/// docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md.
+fn descriptor() -> ToolDescriptor {
+    ToolDescriptor::new(Input::None).param(
+        Param::string("text")
+            .required()
+            .describe("The text to analyze."),
+    )
+}
+
+fn schema_json() -> String {
+    descriptor().to_schema_json()
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -23,34 +40,44 @@ struct WordCount;
     summary = "Word Count skill",
     skill(
         description = "Count the words, characters, and lines in a block of text.",
-        parameters = r#"{
-            "type": "object",
-            "properties": {
-                "text": { "type": "string", "description": "The text to analyze." }
-            },
-            "required": ["text"],
-            "additionalProperties": false
-        }"#
-    ),
+        parameters = schema_json()
+    )
 )]
 impl WordCount {
     fn handle(_msg: Message, body: Vec<u8>) -> GuestResult {
-        let args: Args = match serde_json::from_slice(&body) {
-            Ok(a) => a,
-            Err(e) => return respond_error(format!("invalid args: {e}")),
-        };
-        match gizza_ai_word_count_core::count(&args.text) {
-            Ok(v) => GuestResult::respond(
-                serde_json::to_vec(&serde_json::json!({ "result": v })).unwrap_or_default(),
-            ),
-            Err(e) => respond_error(e),
+        // run_skill wraps the returned value in { "result": … } — word-count's
+        // existing success shape — and routes errors through GuestResult::error.
+        match run_skill(&body, "word-count", |a: Args| {
+            gizza_ai_word_count_core::count(&a.text).map_err(SkillError::InvalidArgs)
+        }) {
+            Ok(v) => GuestResult::respond(v),
+            Err(e) => GuestResult::error(e.into()),
         }
     }
 }
 
-#[cfg(target_arch = "wasm32")]
-fn respond_error(msg: String) -> GuestResult {
-    GuestResult::respond(
-        serde_json::to_vec(&serde_json::json!({ "error": msg })).unwrap_or_default(),
-    )
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Migration safety: the descriptor-derived chat schema must match the
+    /// pre-retrofit authored schema, so the LLM sees no drift. (to_schema_json
+    /// now emits `additionalProperties: false` uniformly, which word-count's
+    /// authored schema already had — so this is an exact match.)
+    #[test]
+    fn schema_json_matches_authored_chat_schema() {
+        let authored: serde_json::Value = serde_json::from_str(
+            r#"{
+                "type": "object",
+                "properties": {
+                    "text": { "type": "string", "description": "The text to analyze." }
+                },
+                "required": ["text"],
+                "additionalProperties": false
+            }"#,
+        )
+        .unwrap();
+        let derived: serde_json::Value = serde_json::from_str(&schema_json()).unwrap();
+        assert_eq!(derived, authored, "no LLM-facing chat-schema drift");
+    }
 }


### PR DESCRIPTION
## What

Retrofit the **word-count** pure-text tool onto the shared tool abstraction (Recipe P), mirroring the canonical `url-encode` exemplar.

## Changes (only `blocks/word-count/**`)

- `src/lib.rs`:
  - Added module-level `descriptor()` (`Input::None` + a single required `text` string param: `"The text to analyze."`) and `schema_json()` (derived via `ToolDescriptor::to_schema_json()`), neither cfg-gated.
  - `#[wafer_block(skill(parameters = schema_json()))]` now derives the chat schema from the single-source descriptor instead of an inline JSON literal.
  - `handle()` delegates to `block_utils::run_skill(&body, "word-count", |a: Args| count(&a.text).map_err(SkillError::InvalidArgs))`, preserving the existing `{ "result": "N words, N characters, N lines" }` success shape and routing errors through `GuestResult::error`. Removed the old flat `respond_error` / `{ "error": … }` path.
  - Added native `#[test] schema_json_matches_authored_chat_schema` drift-guard asserting the descriptor-derived schema equals word-count's pre-retrofit authored `parameters` JSON (with `additionalProperties: false`, which the authored schema already had).
- `Cargo.toml`: added `gizza-ai-block-utils = { path = "../../block-utils" }`.

No shared/other files touched (block-utils unchanged).

## Verify (actual output)

- `cargo test --workspace`: 4 tests pass (1 block incl. drift-guard, 3 core).
- `wafer build`: `OK  gizza-ai/word-count v0.1.0  (281.2 KiB)`.
- CLI `gizza tool word-count 'text=hello world foo'` → `"3 words, 15 characters, 1 lines"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
