### PR TITLE
feat(image-convert): retrofit onto shared tool abstraction (Recipe M)

### DIFF
--- a/blocks/image-convert/Cargo.toml
+++ b/blocks/image-convert/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["."]
+members = [".", "core", "web"]
 
 [package]
 name = "gizza-ai-image-convert-block"
@@ -15,6 +15,6 @@ crate-type = ["cdylib", "rlib"]
 wafer-sdk = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
 wafer-block = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
 gizza-ai-block-utils = { path = "../../block-utils" }
+gizza-ai-image-convert-core = { path = "core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-base64 = "0.22"

--- a/blocks/image-convert/core/Cargo.toml
+++ b/blocks/image-convert/core/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "gizza-ai-image-convert-core"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.82"
+
+[dependencies]

--- a/blocks/image-convert/core/src/lib.rs
+++ b/blocks/image-convert/core/src/lib.rs
@@ -1,0 +1,150 @@
+//! gizza-ai/image-convert core — pure ffmpeg argv construction shared by the
+//! chat skill block and the standalone web page. No wafer/wasm-bindgen deps.
+//!
+//! image-convert transcodes an image to a DIFFERENT target format (jpeg, png,
+//! webp). Unlike resize/compress, the output extension is the user-chosen target
+//! format, not the input's. JPEG/WebP take a lossy `-q:v` derived from a
+//! web-conventional `quality` 1-100; PNG is lossless and omits `-q:v`.
+
+/// Target image format image-convert can transcode to.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Format {
+    Jpeg,
+    Png,
+    Webp,
+}
+
+impl Format {
+    /// Lower-cased file extension this format writes (used for `out.<ext>`).
+    pub fn ext(self) -> &'static str {
+        match self {
+            Format::Jpeg => "jpg",
+            Format::Png => "png",
+            Format::Webp => "webp",
+        }
+    }
+}
+
+/// Parse the user-facing format string (the values the chat schema + page accept).
+/// JPEG is spelled `"jpeg"` (not `"jpg"`) to match the schema enum.
+pub fn parse_format(s: &str) -> Result<Format, String> {
+    match s {
+        "jpeg" => Ok(Format::Jpeg),
+        "png" => Ok(Format::Png),
+        "webp" => Ok(Format::Webp),
+        other => Err(format!(
+            "format {other:?} not supported (jpeg|png|webp)"
+        )),
+    }
+}
+
+/// Map web-conventional quality 1-100 to ffmpeg's -q:v range 31 (worst) – 2 (best).
+/// Mirrored by `gizza-ai/image-compress`'s `quality_to_qv` so the two tools agree.
+pub fn quality_to_qv(q: u8) -> u8 {
+    let q = q.clamp(1, 100) as f32;
+    let qv = 31.0 - (q - 1.0) * (29.0 / 99.0);
+    qv.round().clamp(2.0, 31.0) as u8
+}
+
+/// Build the ffmpeg argv (no leading "ffmpeg") to transcode `in_name` to
+/// `out_name` in `format` at `quality` (1-100). PNG is lossless and omits the
+/// quality flag; jpeg/webp set `-q:v`.
+pub fn build_argv(in_name: &str, out_name: &str, format: Format, quality: u8) -> Vec<String> {
+    let mut argv = vec!["-i".to_string(), in_name.to_string()];
+    if format != Format::Png {
+        argv.push("-q:v".into());
+        argv.push(quality_to_qv(quality).to_string());
+    }
+    argv.push(out_name.to_string());
+    argv
+}
+
+/// Validate `quality`, parse `format`, and build `(argv, out_name)` for an input
+/// file. `out_name` uses the TARGET format's extension. Single source shared by
+/// the chat block (`src/lib.rs`) and the web page (`web/src/lib.rs`).
+pub fn plan_convert(
+    format: &str,
+    quality: u8,
+    in_name: &str,
+) -> Result<(Vec<String>, String), String> {
+    if !(1..=100).contains(&quality) {
+        return Err(format!("quality must be 1-100, got {quality}"));
+    }
+    let fmt = parse_format(format)?;
+    let out_name = format!("out.{}", fmt.ext());
+    Ok((build_argv(in_name, &out_name, fmt, quality), out_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flag_value(argv: &[String], flag: &str) -> Option<String> {
+        argv.iter().position(|a| a == flag).map(|i| argv[i + 1].clone())
+    }
+
+    #[test]
+    fn parse_format_known() {
+        assert_eq!(parse_format("jpeg").unwrap(), Format::Jpeg);
+        assert_eq!(parse_format("png").unwrap(), Format::Png);
+        assert_eq!(parse_format("webp").unwrap(), Format::Webp);
+    }
+
+    #[test]
+    fn parse_format_rejects_unknown() {
+        assert!(parse_format("gif").is_err());
+        assert!(parse_format("jpg").is_err());
+    }
+
+    #[test]
+    fn quality_85_maps_to_qv_about_6() {
+        let qv = quality_to_qv(85);
+        assert!((5..=7).contains(&qv), "expected 5-7, got {qv}");
+    }
+
+    #[test]
+    fn quality_100_maps_to_qv_2_best() {
+        assert_eq!(quality_to_qv(100), 2);
+    }
+
+    #[test]
+    fn quality_1_maps_to_qv_31_worst() {
+        assert_eq!(quality_to_qv(1), 31);
+    }
+
+    #[test]
+    fn argv_jpeg_includes_qv() {
+        let argv = build_argv("in.png", "out.jpg", Format::Jpeg, 85);
+        let qv: u8 = flag_value(&argv, "-q:v").expect("jpeg argv must set -q:v").parse().unwrap();
+        assert!((5..=7).contains(&qv));
+    }
+
+    #[test]
+    fn argv_png_omits_qv() {
+        let argv = build_argv("in.jpg", "out.png", Format::Png, 85);
+        assert!(!argv.iter().any(|a| a == "-q:v"), "png argv should not include -q:v: {argv:?}");
+    }
+
+    #[test]
+    fn argv_webp_includes_qv() {
+        let argv = build_argv("in.png", "out.webp", Format::Webp, 50);
+        assert!(argv.iter().any(|a| a == "-q:v"));
+    }
+
+    #[test]
+    fn plan_convert_uses_target_extension() {
+        let (_argv, out) = plan_convert("png", 85, "cat.jpg").unwrap();
+        assert_eq!(out, "out.png");
+        let (_argv, out) = plan_convert("jpeg", 85, "cat.png").unwrap();
+        assert_eq!(out, "out.jpg");
+        let (_argv, out) = plan_convert("webp", 85, "cat.png").unwrap();
+        assert_eq!(out, "out.webp");
+    }
+
+    #[test]
+    fn plan_convert_rejects_out_of_range_quality_and_bad_format() {
+        assert!(plan_convert("png", 0, "a.png").is_err());
+        assert!(plan_convert("png", 101, "a.png").is_err());
+        assert!(plan_convert("gif", 85, "a.png").is_err());
+    }
+}

--- a/blocks/image-convert/page/content.md
+++ b/blocks/image-convert/page/content.md
@@ -1,0 +1,17 @@
+## Convert an image in your browser
+
+Pick an image, choose a target format (JPEG, PNG, or WebP), and get a converted
+copy instantly. The conversion runs entirely in your browser with ffmpeg
+compiled to WebAssembly — your image is never uploaded to a server.
+
+### Formats
+
+- **JPEG** — small, lossy; great for photos. The quality knob (1-100) controls
+  compression.
+- **PNG** — lossless; great for graphics and transparency. Quality is ignored.
+- **WebP** — modern, smaller than JPEG/PNG at similar quality.
+
+### Tips
+
+- Leave quality blank to use the default (85). It only affects JPEG and WebP.
+- Works offline once the page has loaded.

--- a/blocks/image-convert/page/meta.toml
+++ b/blocks/image-convert/page/meta.toml
@@ -1,0 +1,29 @@
+slug          = "image-convert"
+title         = "Convert an Image Online — gizza.ai"
+description   = "Convert any image to JPEG, PNG, or WebP right in your browser — pick a target format and quality. No upload to a server, runs locally, free."
+tags          = ["image", "convert", "format", "jpeg", "png", "webp", "transcode"]
+h1            = "Convert an Image"
+hero_subtitle = "Pick an image, choose a target format — it's converted in your browser, nothing is uploaded."
+wasm          = "gizza_ai_image_convert_web"
+export        = "build_argv"
+runtime       = "ffmpeg"
+output_label  = "Converted image"
+format        = "image"
+
+[[input]]
+name   = "image"
+source = "file"
+accept = "image/*"
+label  = "Image"
+
+[[input]]
+name        = "format"
+source      = "field"
+label       = "Target format (jpeg|png|webp)"
+placeholder = "png"
+
+[[input]]
+name        = "quality"
+source      = "field"
+label       = "Quality (1-100)"
+placeholder = "85"

--- a/blocks/image-convert/src/lib.rs
+++ b/blocks/image-convert/src/lib.rs
@@ -1,23 +1,32 @@
-//! gizza-ai/image-convert — fetch an image URL or attachment ref, transcode to a different format.
+//! gizza-ai/image-convert — fetch an image URL or attachment ref, transcode to a
+//! different format via ffmpeg, return envelope.
+//!
+//! The chat schema is derived from `descriptor()` (single source — shared shape
+//! across chat + CLI + page); the handler delegates source-resolution, ffmpeg
+//! dispatch, and envelope-building to `block_utils`. Tool-specific validation
+//! (format enum, quality 1-100) and the pure `core` argv builder stay shared with
+//! the page. See
+//! docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md.
 
-// The #[wafer_block] macro emits the impl gated to wasm32; supporting imports,
-// constants, and the Args type are only used there. See image-resize for the
-// full rationale.
+// The #[wafer_block] macro emits the impl gated to wasm32 (the macro generates
+// a native registration call that requires ::new()). All the supporting imports,
+// constants, and the Args type are only used inside the wasm32-gated impl, so
+// they appear "unused" when running native unit tests. `descriptor()` /
+// `schema_json()` and the block-local helpers remain native-compilable so the
+// drift-guard + unit tests below can exercise them.
 #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
 
-use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use gizza_ai_block_utils::{
-    dispatch_ffmpeg_runtime, format_to_mime_and_ext, mime_to_ext, replace_extension,
-    validate_quality_1_100, AssetKind, Envelope, FfmpegReq, FfmpegResp, ForUi, SkillError,
-    SkillResultExt, Source, SourceFields,
+    build_media_envelope, mime_to_ext, replace_extension, validate_quality_1_100, AssetKind, Input,
+    Param, SkillError, SkillResultExt, SourceFields, ToolDescriptor,
 };
+#[cfg(target_arch = "wasm32")]
+use gizza_ai_block_utils::{dispatch_ffmpeg, format_to_mime_and_ext, resolve_source};
+use gizza_ai_image_convert_core::build_argv;
 use serde::Deserialize;
 use wafer_sdk::*;
 
-#[cfg(target_arch = "wasm32")]
-use gizza_ai_block_utils::{fetch_from_url, load_from_attachment};
-
-const MAX_INPUT_BYTES: usize = 4 * 1024 * 1024;
+const MAX_INPUT_BYTES: usize = 4 * 1024 * 1024; // 4 MiB
 const MAX_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
 const DEFAULT_QUALITY: u8 = 85;
 
@@ -30,27 +39,33 @@ struct Args {
     quality: Option<u8>,
 }
 
-/// Map web-conventional quality 1-100 to ffmpeg's -q:v range 31 (worst) – 2 (best).
-fn quality_to_qv(q: u8) -> u8 {
-    let q = q.clamp(1, 100) as f32;
-    let qv = 31.0 - (q - 1.0) * (29.0 / 99.0);
-    qv.round().clamp(2.0, 31.0) as u8
+/// Single-source param descriptor → chat schema (and CLI + page). The drift-guard
+/// test below proves the derived schema matches the pre-retrofit authored one.
+fn descriptor() -> ToolDescriptor {
+    ToolDescriptor::new(Input::Image)
+        .param(
+            Param::enumv("format", ["jpeg", "png", "webp"])
+                .required()
+                .describe("Target image format."),
+        )
+        .param(
+            Param::integer("quality")
+                .min(1.0)
+                .max(100.0)
+                .describe("Output quality 1-100 (default 85, ignored for png)."),
+        )
 }
 
-
-fn build_argv(in_name: &str, out_name: &str, format: &str, quality: u8) -> Vec<String> {
-    let mut argv = vec!["-i".to_string(), in_name.to_string()];
-    if format != "png" {
-        argv.push("-q:v".into());
-        argv.push(quality_to_qv(quality).to_string());
-    }
-    argv.push(out_name.to_string());
-    argv
+fn schema_json() -> String {
+    descriptor().to_schema_json()
 }
 
 #[cfg(target_arch = "wasm32")]
 struct ImageConvert;
 
+// The #[wafer_block] macro emits a native registration call requiring ::new()
+// on the impl; skill-style impls don't have one. Gate the struct + impl to
+// wasm32 so unit tests can still compile natively.
 #[cfg(target_arch = "wasm32")]
 #[wafer_block(
     name = "gizza-ai/image-convert",
@@ -60,20 +75,7 @@ struct ImageConvert;
     requires = ["wafer-run/network", "gizza-ai/ffmpeg-runtime"],
     skill(
         description = "Convert an image to a different format (jpeg, png, webp). Provide either url (HTTP/HTTPS) or ref (id from a prior image tool call).",
-        parameters = r#"{
-            "type": "object",
-            "properties": {
-                "url":     { "type": "string", "description": "Image URL (HTTP/HTTPS)." },
-                "ref":     { "type": "string", "description": "Reference id from a prior image tool call (e.g. \"call_42\"). Use either url or ref." },
-                "format":  { "type": "string", "enum": ["jpeg", "png", "webp"], "description": "Target image format." },
-                "quality": { "type": "integer", "minimum": 1, "maximum": 100, "description": "Output quality 1-100 (default 85, ignored for png)." }
-            },
-            "required": ["format"],
-            "oneOf": [
-                { "required": ["url"] },
-                { "required": ["ref"] }
-            ]
-        }"#
+        parameters = schema_json()
     ),
 )]
 impl ImageConvert {
@@ -87,111 +89,84 @@ impl ImageConvert {
 
 #[cfg(target_arch = "wasm32")]
 fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
+    // 1. Validate args (tool-specific — format enum + quality 1-100).
     let args: Args = serde_json::from_slice(&body).invalid_args("image-convert")?;
-    let (out_mime, out_ext) = format_to_mime_and_ext(AssetKind::Image, &args.format).ok_or_else(|| {
-        SkillError::InvalidArgs(format!(
-            "invalid image-convert args: format {:?} not supported (jpeg|png|webp)",
-            args.format
-        ))
-    })?;
+    let (out_mime, out_ext) =
+        format_to_mime_and_ext(AssetKind::Image, &args.format).ok_or_else(|| {
+            SkillError::InvalidArgs(format!(
+                "invalid image-convert args: format {:?} not supported (jpeg|png|webp)",
+                args.format
+            ))
+        })?;
     validate_quality_1_100(args.quality, "image-convert")?;
     let quality = args.quality.unwrap_or(DEFAULT_QUALITY);
+    let fmt = gizza_ai_image_convert_core::parse_format(&args.format)
+        .map_err(|e| SkillError::InvalidArgs(format!("invalid image-convert args: {e}")))?;
 
-    let (input_bytes, in_mime, in_filename) = match args.source.into_inner() {
-        Source::Url(u) => fetch_from_url(&u, AssetKind::Image, MAX_INPUT_BYTES)?,
-        Source::Ref(id) => load_from_attachment(&id, AssetKind::Image, MAX_INPUT_BYTES)?,
-    };
+    // 2. Resolve source — URL fetch or attachment lookup.
+    let (input_bytes, in_mime, in_filename) =
+        resolve_source(args.source.into_inner(), AssetKind::Image, MAX_INPUT_BYTES)?;
 
-    let in_ext = mime_to_ext(&in_mime).ok_or_else(|| {
-        SkillError::InvalidArgs(format!("unsupported input mime: {in_mime}"))
-    })?;
+    // 3. Build ffmpeg argv (shared pure core). Output uses the TARGET format ext.
+    let in_ext = mime_to_ext(&in_mime)
+        .ok_or_else(|| SkillError::InvalidArgs(format!("unsupported input mime: {in_mime}")))?;
     let ffmpeg_in = format!("in.{in_ext}");
     let ffmpeg_out = format!("out.{out_ext}");
-    let argv = build_argv(&ffmpeg_in, &ffmpeg_out, &args.format, quality);
+    let argv = build_argv(&ffmpeg_in, &ffmpeg_out, fmt, quality);
 
-    let req = FfmpegReq {
-        args: argv,
-        inputs: vec![(ffmpeg_in, input_bytes)],
-        output: ffmpeg_out,
-    };
-    let req_body = serde_json::to_vec(&req)
-        .map_err(|e| SkillError::Serialize(format!("serialize ffmpeg request: {e}")))?;
-    let ff_resp_bytes = dispatch_ffmpeg_runtime(&req_body)?;
-    let ff: FfmpegResp = serde_json::from_slice(&ff_resp_bytes)
-        .map_err(|e| SkillError::Serialize(format!("malformed ffmpeg response: {e}")))?;
+    // 4. Dispatch to ffmpeg-runtime.
+    let output = dispatch_ffmpeg(argv, ffmpeg_in, input_bytes, ffmpeg_out)?;
 
-    if ff.exit_code != 0 {
-        let snippet: String = ff.log.chars().take(200).collect();
-        return Err(SkillError::FfmpegExitNonZero {
-            exit: ff.exit_code,
-            snippet,
-        });
-    }
-    if ff.output.len() > MAX_OUTPUT_BYTES {
-        return Err(SkillError::TooLarge {
-            kind: "output image",
-            bytes: ff.output.len(),
-            cap: MAX_OUTPUT_BYTES,
-        });
-    }
-
-    let output_size = ff.output.len();
-    let encoded = B64.encode(&ff.output);
-    let data_url = format!("data:{out_mime};base64,{encoded}");
+    // 5. Envelope.
+    let output_size = output.len();
     let filename = replace_extension(&in_filename, out_ext);
-    let env = Envelope {
-        for_llm: format!(
-            "converted {} from {} to {} ({})",
-            in_filename, in_mime, out_mime, output_size
-        ),
-        for_ui: ForUi {
-            data_url,
-            mime: out_mime.to_string(),
-            filename,
-        },
-    };
-    serde_json::to_vec(&env).map_err(|e| SkillError::Serialize(format!("serialize envelope: {e}")))
+    let for_llm = format!("converted {in_filename} from {in_mime} to {out_mime} ({output_size})");
+    build_media_envelope(
+        output.as_slice(),
+        out_mime,
+        filename,
+        for_llm,
+        MAX_OUTPUT_BYTES,
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Migration safety: the descriptor-derived chat schema must match the
+    /// pre-retrofit authored schema, so the LLM sees no drift. `to_schema_json`
+    /// emits `additionalProperties: false` uniformly (image-convert's authored
+    /// schema lacked it — added below as intentional uniform hardening). The
+    /// `url`/`ref` property descriptions are centralized in `to_schema_json`, so
+    /// the expected JSON uses that shared wording.
     #[test]
-    fn quality_85_maps_to_qv_about_6() {
-        let qv = quality_to_qv(85);
-        assert!((5..=7).contains(&qv), "expected 5-7, got {qv}");
+    fn schema_json_matches_authored_chat_schema() {
+        let authored: serde_json::Value = serde_json::from_str(
+            r#"{
+                "type": "object",
+                "properties": {
+                    "url":     { "type": "string", "description": "Image URL (HTTP/HTTPS). Use either url or ref." },
+                    "ref":     { "type": "string", "description": "Reference id from a prior tool call. Use either url or ref." },
+                    "format":  { "type": "string", "enum": ["jpeg", "png", "webp"], "description": "Target image format." },
+                    "quality": { "type": "integer", "minimum": 1, "maximum": 100, "description": "Output quality 1-100 (default 85, ignored for png)." }
+                },
+                "additionalProperties": false,
+                "required": ["format"],
+                "oneOf": [
+                    { "required": ["url"] },
+                    { "required": ["ref"] }
+                ]
+            }"#,
+        )
+        .unwrap();
+        let derived: serde_json::Value = serde_json::from_str(&schema_json()).unwrap();
+        assert_eq!(derived, authored, "no LLM-facing chat-schema drift");
     }
 
     #[test]
-    fn quality_100_maps_to_qv_2_best() {
-        assert_eq!(quality_to_qv(100), 2);
+    fn output_filename_swaps_extension() {
+        assert_eq!(replace_extension("cat.jpg", "png"), "cat.png");
+        assert_eq!(replace_extension("photo.png", "webp"), "photo.webp");
     }
-
-    #[test]
-    fn quality_1_maps_to_qv_31_worst() {
-        assert_eq!(quality_to_qv(1), 31);
-    }
-
-    #[test]
-    fn argv_jpeg_includes_qv() {
-        let argv = build_argv("in.png", "out.jpg", "jpeg", 85);
-        assert!(argv.iter().any(|a| a == "-q:v"));
-        let idx = argv.iter().position(|a| a == "-q:v").unwrap();
-        let qv: u8 = argv[idx + 1].parse().unwrap();
-        assert!((5..=7).contains(&qv));
-    }
-
-    #[test]
-    fn argv_png_omits_qv() {
-        let argv = build_argv("in.jpg", "out.png", "png", 85);
-        assert!(!argv.iter().any(|a| a == "-q:v"), "png argv should not include -q:v: {argv:?}");
-    }
-
-    #[test]
-    fn argv_webp_includes_qv() {
-        let argv = build_argv("in.png", "out.webp", "webp", 50);
-        assert!(argv.iter().any(|a| a == "-q:v"));
-    }
-
 }

--- a/blocks/image-convert/web/Cargo.toml
+++ b/blocks/image-convert/web/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "gizza-ai-image-convert-web"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.82"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+serde-wasm-bindgen = "0.6"
+gizza-ai-image-convert-core = { path = "../core" }
+gizza-ai-block-utils = { path = "../../../block-utils" }

--- a/blocks/image-convert/web/src/lib.rs
+++ b/blocks/image-convert/web/src/lib.rs
@@ -1,0 +1,30 @@
+//! Browser-facing wasm-bindgen wrapper for /tools/image-convert/ (ffmpeg page).
+//! Builds the ffmpeg argv (pure, shared with the chat block via core).
+//!
+//! Page field order (meta.toml) MUST match this param order: `format`, then
+//! `quality`, then the file (`in_name`). `tool.js` calls
+//! `build_argv(...fieldArgs, inName)`.
+
+use wasm_bindgen::prelude::*;
+
+use gizza_ai_block_utils::ArgvPlan;
+use gizza_ai_image_convert_core::plan_convert;
+
+/// Default quality used when the page's quality field is left blank (which
+/// arrives here as 0.0 — see `tool.js` numeric coercion of empty fields).
+const DEFAULT_QUALITY: u8 = 85;
+
+/// `format` is one of `jpeg|png|webp`; `quality` is 1-100 (0/empty defaults to
+/// 85, ignored for png). Returns `{ argv: string[], out_name }` or throws a JS
+/// error string.
+#[wasm_bindgen]
+pub fn build_argv(format: &str, quality: f64, in_name: &str) -> Result<JsValue, JsValue> {
+    let q = if quality > 0.0 {
+        quality.round().clamp(1.0, 100.0) as u8
+    } else {
+        DEFAULT_QUALITY
+    };
+    let (argv, out_name) = plan_convert(format, q, in_name).map_err(|e| JsValue::from_str(&e))?;
+    serde_wasm_bindgen::to_value(&ArgvPlan { argv, out_name })
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+}


### PR DESCRIPTION
## Retrofit `image-convert` onto the shared tool abstraction (Recipe M)

Mirrors the canonical media exemplar (`image-resize` / `image-grayscale`):
single-source `descriptor()` drives the chat schema, and the handler delegates
source-resolution, ffmpeg dispatch, and envelope-building to `block-utils`. The
tool-specific argv/quality logic moves into a shared pure `core` crate so the
chat block and the new standalone page use one source.

### Changes (all under `blocks/image-convert/`)

- **`src/lib.rs`** — module-level `descriptor()` + `schema_json()`
  (`Input::Image` + `format` enum + `quality` integer min/max); `parameters =
  schema_json()`. `run()` now flows `resolve_source(AssetKind::Image)` → core
  `build_argv` → `dispatch_ffmpeg` → `build_media_envelope`. `Args` flattens
  `SourceFields` (url⊕ref validated at deserialize). Dropped the inline
  base64/ffmpeg-wire/envelope plumbing (now shared in `block-utils`).
- **`core/`** (new) — pure `quality_to_qv`, `build_argv`, `parse_format`, and a
  `plan_convert(format, quality, in_name)` for the page. Output extension is the
  TARGET format (unlike resize/grayscale/compress, which keep the input ext).
  `quality_to_qv` is byte-identical to the prior inline impl (image-compress's
  core documents that it mirrors this one).
- **`web/`** (new) — wasm-bindgen page wrapper returning
  `gizza_ai_block_utils::ArgvPlan`. Field order (`format`, `quality`, file)
  matches `meta.toml` and `tool.js`'s `build_argv(...fieldArgs, inName)`.
- **`page/`** (new) — `meta.toml` + `content.md` for `/tools/image-convert/`.
- **`Cargo.toml`** — workspace members `[".", "core", "web"]`, add core dep,
  drop now-unused `base64`.

### Drift-guard

Native `#[test] schema_json_matches_authored_chat_schema` asserts the
descriptor-derived schema equals the pre-retrofit authored `parameters` JSON,
with the uniform `additionalProperties: false` added and the centralized
`url`/`ref` wording (from `to_schema_json`). Integer `minimum`/`maximum` render
as `1`/`100`, and the `url`⊕`ref` `oneOf` is generated. PASSES.

### Verification (all run, all green)

- `cargo test --workspace`: 12 passed (block 2 incl. drift-guard, core 10).
- `wafer build`: OK `gizza-ai/image-convert v0.1.0` (530.0 KiB).
- `wasm-pack build web --target web --release`: Done, pkg ready.
- CLI: `gizza tool image-convert format=png url=…/rust.png` →
  `converted rust.png from image/png to image/png (14523)`.

block-utils / shared files were NOT modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
