### PR TITLE
feat(image-crop): retrofit onto shared tool abstraction (Recipe M)

### DIFF
--- a/blocks/image-crop/Cargo.toml
+++ b/blocks/image-crop/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["."]
+members = [".", "core", "web"]
 
 [package]
 name = "gizza-ai-image-crop-block"
@@ -15,6 +15,6 @@ crate-type = ["cdylib", "rlib"]
 wafer-sdk = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
 wafer-block = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
 gizza-ai-block-utils = { path = "../../block-utils" }
+gizza-ai-image-crop-core = { path = "core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-base64 = "0.22"

--- a/blocks/image-crop/core/Cargo.toml
+++ b/blocks/image-crop/core/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "gizza-ai-image-crop-core"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.82"
+
+[dependencies]

--- a/blocks/image-crop/core/src/lib.rs
+++ b/blocks/image-crop/core/src/lib.rs
@@ -1,0 +1,74 @@
+//! gizza-ai/image-crop core — pure ffmpeg argv construction shared by the chat
+//! skill block and the standalone web page. No wafer/wasm-bindgen deps.
+
+/// Build the ffmpeg argv for a crop (no leading "ffmpeg").
+///
+/// ffmpeg's `crop` video filter takes `crop=w:h:x:y` — width and height first,
+/// then the top-left x/y offset.
+pub fn build_argv(in_name: &str, out_name: &str, x: u32, y: u32, w: u32, h: u32) -> Vec<String> {
+    vec![
+        "-i".into(),
+        in_name.into(),
+        "-vf".into(),
+        format!("crop={w}:{h}:{x}:{y}"),
+        out_name.into(),
+    ]
+}
+
+/// Validate the crop rectangle and return `(argv, out_name)` for an input file.
+/// `out_name` keeps the input extension. Used by the web page (file in → file out).
+pub fn plan_crop(
+    in_name: &str,
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+) -> Result<(Vec<String>, String), String> {
+    if w == 0 || h == 0 {
+        return Err("width and height must be > 0".into());
+    }
+    let ext = in_name
+        .rsplit('.')
+        .next()
+        .filter(|e| !e.is_empty())
+        .unwrap_or("png");
+    let out_name = format!("out.{ext}");
+    Ok((build_argv(in_name, &out_name, x, y, w, h), out_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn argv_crop_positional_order() {
+        // ffmpeg crop filter is w:h:x:y.
+        let argv = build_argv("in.png", "out.png", 10, 20, 200, 300);
+        assert_eq!(
+            argv,
+            vec![
+                "-i".to_string(),
+                "in.png".to_string(),
+                "-vf".to_string(),
+                "crop=200:300:10:20".to_string(),
+                "out.png".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_crop_keeps_extension_and_validates() {
+        let (argv, out) = plan_crop("in.jpg", 0, 0, 320, 240).unwrap();
+        assert_eq!(out, "out.jpg");
+        assert!(argv.iter().any(|a| a == "crop=320:240:0:0"));
+        assert!(plan_crop("in.png", 0, 0, 0, 10).is_err());
+        assert!(plan_crop("in.png", 0, 0, 10, 0).is_err());
+    }
+
+    #[test]
+    fn plan_crop_defaults_extension_when_trailing_dot() {
+        // A trailing dot leaves an empty last segment → fall back to "png".
+        let (_, out) = plan_crop("file.", 0, 0, 10, 10).unwrap();
+        assert_eq!(out, "out.png");
+    }
+}

--- a/blocks/image-crop/page/content.md
+++ b/blocks/image-crop/page/content.md
@@ -1,0 +1,20 @@
+## Crop an image in your browser
+
+Pick an image, set the top-left corner (X and Y) and the width and height of the
+rectangle you want to keep, and get the cropped copy instantly. The cropping
+runs entirely in your browser with ffmpeg compiled to WebAssembly — your image is
+never uploaded to a server.
+
+### How the rectangle works
+
+- **X offset** — how far from the left edge the crop starts, in pixels.
+- **Y offset** — how far from the top edge the crop starts, in pixels.
+- **Width** — how wide the kept rectangle is, in pixels.
+- **Height** — how tall the kept rectangle is, in pixels.
+
+The origin `(0, 0)` is the top-left corner of the image.
+
+### Tips
+
+- Keep the rectangle inside the image's dimensions, or ffmpeg will reject it.
+- Works offline once the page has loaded.

--- a/blocks/image-crop/page/meta.toml
+++ b/blocks/image-crop/page/meta.toml
@@ -1,0 +1,41 @@
+slug          = "image-crop"
+title         = "Crop an Image Online — gizza.ai"
+description   = "Crop any image right in your browser — set the x/y offset and the width/height of the rectangle to keep. No upload to a server, runs locally, free."
+tags          = ["image", "crop", "trim", "cut", "rectangle"]
+h1            = "Crop an Image"
+hero_subtitle = "Pick an image, set the crop rectangle — it's cropped in your browser, nothing is uploaded."
+wasm          = "gizza_ai_image_crop_web"
+export        = "build_argv"
+runtime       = "ffmpeg"
+output_label  = "Cropped image"
+format        = "image"
+
+[[input]]
+name   = "image"
+source = "file"
+accept = "image/*"
+label  = "Image"
+
+[[input]]
+name        = "x"
+source      = "field"
+label       = "X offset (px)"
+placeholder = "0"
+
+[[input]]
+name        = "y"
+source      = "field"
+label       = "Y offset (px)"
+placeholder = "0"
+
+[[input]]
+name        = "width"
+source      = "field"
+label       = "Width (px)"
+placeholder = "640"
+
+[[input]]
+name        = "height"
+source      = "field"
+label       = "Height (px)"
+placeholder = "480"

--- a/blocks/image-crop/src/lib.rs
+++ b/blocks/image-crop/src/lib.rs
@@ -1,48 +1,83 @@
-//! gizza-ai/image-crop — fetch an image URL or attachment ref, crop a rectangle via ffmpeg.
+//! gizza-ai/image-crop — fetch an image URL or attachment ref, crop a rectangle
+//! via ffmpeg, return envelope.
+//!
+//! The chat schema is derived from `descriptor()` (single source — shared shape
+//! across chat + CLI + page); the handler delegates source-resolution, ffmpeg
+//! dispatch, and envelope-building to `block_utils`. Tool-specific validation
+//! (width/height must be > 0) and the pure `core` argv builder stay here. See
+//! docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md.
 
-// The #[wafer_block] macro emits the impl gated to wasm32; supporting imports,
-// constants, and the Args type are only used there. See image-resize for the
-// full rationale.
+// The #[wafer_block] macro emits the impl gated to wasm32 (the macro generates
+// a native registration call that requires ::new()). All the supporting imports,
+// constants, and the Args type are only used inside the wasm32-gated impl, so
+// they appear "unused" when running native unit tests. `descriptor()` /
+// `schema_json()` remain native-compilable so the drift-guard + unit tests below
+// can exercise them. See image-resize for the full rationale.
 #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
 
-use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use gizza_ai_block_utils::{
-    dispatch_ffmpeg_runtime, filename_with_suffix, mime_to_ext, AssetKind, Envelope, FfmpegReq,
-    FfmpegResp, ForUi, SkillError, SkillResultExt, Source, SourceFields,
+    build_media_envelope, filename_with_suffix, mime_to_ext, AssetKind, Input, Param, SkillError,
+    SkillResultExt, ToolDescriptor,
 };
+#[cfg(target_arch = "wasm32")]
+use gizza_ai_block_utils::{dispatch_ffmpeg, resolve_source};
+use gizza_ai_image_crop_core::build_argv;
 use serde::Deserialize;
 use wafer_sdk::*;
 
-#[cfg(target_arch = "wasm32")]
-use gizza_ai_block_utils::{fetch_from_url, load_from_attachment};
-
-const MAX_INPUT_BYTES: usize = 4 * 1024 * 1024;
+const MAX_INPUT_BYTES: usize = 4 * 1024 * 1024; // 4 MiB
 const MAX_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
 
 #[derive(Deserialize, Debug)]
 struct Args {
     #[serde(flatten)]
-    source: SourceFields,
+    source: gizza_ai_block_utils::SourceFields,
     x: u32,
     y: u32,
     width: u32,
     height: u32,
 }
 
-fn build_argv(in_name: &str, out_name: &str, x: u32, y: u32, w: u32, h: u32) -> Vec<String> {
-    vec![
-        "-i".into(),
-        in_name.into(),
-        "-vf".into(),
-        format!("crop={w}:{h}:{x}:{y}"),
-        out_name.into(),
-    ]
+/// Single-source param descriptor → chat schema (and CLI + page). The drift-guard
+/// test below proves the derived schema matches the pre-retrofit authored one.
+fn descriptor() -> ToolDescriptor {
+    ToolDescriptor::new(Input::Image)
+        .param(
+            Param::integer("x")
+                .required()
+                .min(0.0)
+                .describe("Left offset of the crop rectangle in pixels."),
+        )
+        .param(
+            Param::integer("y")
+                .required()
+                .min(0.0)
+                .describe("Top offset of the crop rectangle in pixels."),
+        )
+        .param(
+            Param::integer("width")
+                .required()
+                .min(1.0)
+                .describe("Width of the crop rectangle in pixels."),
+        )
+        .param(
+            Param::integer("height")
+                .required()
+                .min(1.0)
+                .describe("Height of the crop rectangle in pixels."),
+        )
 }
 
+fn schema_json() -> String {
+    descriptor().to_schema_json()
+}
 
 #[cfg(target_arch = "wasm32")]
 struct ImageCrop;
 
+// The #[wafer_block] macro emits a native registration call requiring ::new()
+// on the impl; skill-style impls don't have one. Gate the struct + impl to
+// wasm32 so unit tests can still compile natively.
 #[cfg(target_arch = "wasm32")]
 #[wafer_block(
     name = "gizza-ai/image-crop",
@@ -51,23 +86,8 @@ struct ImageCrop;
     summary = "Crop a rectangular region from an image fetched by URL or from a prior tool call ref",
     requires = ["wafer-run/network", "gizza-ai/ffmpeg-runtime"],
     skill(
-        description = "Crop a rectangular region from an image. Provide either url (HTTP/HTTPS) or ref (id from a prior image tool call).",
-        parameters = r#"{
-            "type": "object",
-            "properties": {
-                "url":    { "type": "string", "description": "Image URL (HTTP/HTTPS)." },
-                "ref":    { "type": "string", "description": "Reference id from a prior image tool call (e.g. \"call_42\"). Use either url or ref." },
-                "x":      { "type": "integer", "minimum": 0, "description": "Left offset of the crop rectangle in pixels." },
-                "y":      { "type": "integer", "minimum": 0, "description": "Top offset of the crop rectangle in pixels." },
-                "width":  { "type": "integer", "minimum": 1, "description": "Width of the crop rectangle in pixels." },
-                "height": { "type": "integer", "minimum": 1, "description": "Height of the crop rectangle in pixels." }
-            },
-            "required": ["x", "y", "width", "height"],
-            "oneOf": [
-                { "required": ["url"] },
-                { "required": ["ref"] }
-            ]
-        }"#
+        description = "Crop a rectangular region from an image. Coordinates are in pixels with (0,0) at the top-left corner. Provide either url (HTTP/HTTPS) or ref (id from a prior image tool call).",
+        parameters = schema_json()
     ),
 )]
 impl ImageCrop {
@@ -81,6 +101,7 @@ impl ImageCrop {
 
 #[cfg(target_arch = "wasm32")]
 fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
+    // 1. Validate args (tool-specific — width/height must be > 0).
     let args: Args = serde_json::from_slice(&body).invalid_args("image-crop")?;
     if args.width == 0 || args.height == 0 {
         return Err(SkillError::InvalidArgs(
@@ -88,80 +109,78 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
         ));
     }
 
-    let (input_bytes, mime, in_filename) = match args.source.into_inner() {
-        Source::Url(u) => fetch_from_url(&u, AssetKind::Image, MAX_INPUT_BYTES)?,
-        Source::Ref(id) => load_from_attachment(&id, AssetKind::Image, MAX_INPUT_BYTES)?,
-    };
+    // 2. Resolve source — URL fetch or attachment lookup.
+    let (input_bytes, mime, in_filename) =
+        resolve_source(args.source.into_inner(), AssetKind::Image, MAX_INPUT_BYTES)?;
 
-    let ext = mime_to_ext(&mime).ok_or_else(|| {
-        SkillError::InvalidArgs(format!("unsupported input mime: {mime}"))
-    })?;
+    // 3. Build ffmpeg argv (shared pure core).
+    let ext = mime_to_ext(&mime)
+        .ok_or_else(|| SkillError::InvalidArgs(format!("unsupported input mime: {mime}")))?;
     let ffmpeg_in = format!("in.{ext}");
     let ffmpeg_out = format!("out.{ext}");
-    let argv = build_argv(&ffmpeg_in, &ffmpeg_out, args.x, args.y, args.width, args.height);
+    let argv = build_argv(
+        &ffmpeg_in,
+        &ffmpeg_out,
+        args.x,
+        args.y,
+        args.width,
+        args.height,
+    );
 
-    let req = FfmpegReq {
-        args: argv,
-        inputs: vec![(ffmpeg_in, input_bytes)],
-        output: ffmpeg_out,
-    };
-    let req_body = serde_json::to_vec(&req)
-        .map_err(|e| SkillError::Serialize(format!("serialize ffmpeg request: {e}")))?;
-    let ff_resp_bytes = dispatch_ffmpeg_runtime(&req_body)?;
-    let ff: FfmpegResp = serde_json::from_slice(&ff_resp_bytes)
-        .map_err(|e| SkillError::Serialize(format!("malformed ffmpeg response: {e}")))?;
+    // 4. Dispatch to ffmpeg-runtime.
+    let output = dispatch_ffmpeg(argv, ffmpeg_in, input_bytes, ffmpeg_out)?;
 
-    if ff.exit_code != 0 {
-        let snippet: String = ff.log.chars().take(200).collect();
-        return Err(SkillError::FfmpegExitNonZero {
-            exit: ff.exit_code,
-            snippet,
-        });
-    }
-    if ff.output.len() > MAX_OUTPUT_BYTES {
-        return Err(SkillError::TooLarge {
-            kind: "output image",
-            bytes: ff.output.len(),
-            cap: MAX_OUTPUT_BYTES,
-        });
-    }
-
-    let output_size = ff.output.len();
-    let encoded = B64.encode(&ff.output);
-    let data_url = format!("data:{mime};base64,{encoded}");
+    // 5. Envelope.
+    let output_size = output.len();
     let filename = filename_with_suffix(&in_filename, "-cropped", ext);
-    let env = Envelope {
-        for_llm: format!(
-            "cropped {} at ({},{}) {}x{} ({} {})",
-            in_filename, args.x, args.y, args.width, args.height, output_size, mime
-        ),
-        for_ui: ForUi {
-            data_url,
-            mime,
-            filename,
-        },
-    };
-    serde_json::to_vec(&env).map_err(|e| SkillError::Serialize(format!("serialize envelope: {e}")))
+    let for_llm = format!(
+        "cropped {} at ({},{}) {}x{} ({} {})",
+        in_filename, args.x, args.y, args.width, args.height, output_size, mime
+    );
+    build_media_envelope(&output, &mime, filename, for_llm, MAX_OUTPUT_BYTES)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Migration safety: the descriptor-derived chat schema must match the
+    /// pre-retrofit authored schema, so the LLM sees no drift. `to_schema_json`
+    /// emits `additionalProperties: false` uniformly (image-crop's authored
+    /// schema lacked it — added below as intentional uniform hardening) and the
+    /// shared `url`/`ref` property descriptions are centralized in
+    /// `to_schema_json`, so the expected JSON uses that shared wording.
     #[test]
-    fn argv_crop_positional_order() {
-        let argv = build_argv("in.png", "out.png", 10, 20, 200, 300);
-        assert_eq!(argv, vec![
-            "-i".to_string(),
-            "in.png".to_string(),
-            "-vf".to_string(),
-            "crop=200:300:10:20".to_string(),
-            "out.png".to_string(),
-        ]);
+    fn schema_json_matches_authored_chat_schema() {
+        let authored: serde_json::Value = serde_json::from_str(
+            r#"{
+                "type": "object",
+                "properties": {
+                    "url":    { "type": "string", "description": "Image URL (HTTP/HTTPS). Use either url or ref." },
+                    "ref":    { "type": "string", "description": "Reference id from a prior tool call. Use either url or ref." },
+                    "x":      { "type": "integer", "minimum": 0, "description": "Left offset of the crop rectangle in pixels." },
+                    "y":      { "type": "integer", "minimum": 0, "description": "Top offset of the crop rectangle in pixels." },
+                    "width":  { "type": "integer", "minimum": 1, "description": "Width of the crop rectangle in pixels." },
+                    "height": { "type": "integer", "minimum": 1, "description": "Height of the crop rectangle in pixels." }
+                },
+                "additionalProperties": false,
+                "required": ["x", "y", "width", "height"],
+                "oneOf": [
+                    { "required": ["url"] },
+                    { "required": ["ref"] }
+                ]
+            }"#,
+        )
+        .unwrap();
+        let derived: serde_json::Value = serde_json::from_str(&schema_json()).unwrap();
+        assert_eq!(derived, authored, "no LLM-facing chat-schema drift");
     }
 
     #[test]
     fn output_filename_appends_cropped_suffix() {
-        assert_eq!(filename_with_suffix("cat.png", "-cropped", "png"), "cat-cropped.png");
+        assert_eq!(
+            filename_with_suffix("cat.png", "-cropped", "png"),
+            "cat-cropped.png"
+        );
     }
 }

--- a/blocks/image-crop/web/Cargo.toml
+++ b/blocks/image-crop/web/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "gizza-ai-image-crop-web"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.82"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+serde-wasm-bindgen = "0.6"
+gizza-ai-image-crop-core = { path = "../core" }
+gizza-ai-block-utils = { path = "../../../block-utils" }

--- a/blocks/image-crop/web/src/lib.rs
+++ b/blocks/image-crop/web/src/lib.rs
@@ -1,0 +1,34 @@
+//! Browser-facing wasm-bindgen wrapper for the standalone /tools/image-crop/ page.
+//! Builds the ffmpeg argv (pure, shared with the chat block via core); the JS
+//! page driver runs it through the browser ffmpeg bridge.
+
+use wasm_bindgen::prelude::*;
+
+use gizza_ai_block_utils::ArgvPlan;
+use gizza_ai_image_crop_core::plan_crop;
+
+/// Returns `{ argv: string[], out_name }` or throws a JS error string. The page
+/// driver calls `build_argv(...fieldArgs, in_name)`, with field args in the order
+/// the page's `[[input]]` fields are declared: x, y, width, height.
+#[wasm_bindgen]
+pub fn build_argv(
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+    in_name: &str,
+) -> Result<JsValue, JsValue> {
+    if x < 0.0 || y < 0.0 || width < 0.0 || height < 0.0 {
+        return Err(JsValue::from_str("x, y, width, height must be >= 0"));
+    }
+    let (argv, out_name) = plan_crop(
+        in_name,
+        x as u32,
+        y as u32,
+        width as u32,
+        height as u32,
+    )
+    .map_err(|e| JsValue::from_str(&e))?;
+    serde_wasm_bindgen::to_value(&ArgvPlan { argv, out_name })
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+}


### PR DESCRIPTION
## Retrofit `image-crop` onto the shared tool abstraction (Recipe M)

Mirrors the canonical `image-resize` media/ffmpeg-page exemplar. The chat schema
is now derived from a single-source `descriptor()` instead of a hand-authored
JSON blob, and the handler delegates source-resolution, ffmpeg dispatch, and
envelope-building to `block-utils`.

### Changes (all under `blocks/image-crop/**`)

- **`src/lib.rs`** — `descriptor()` + `schema_json()` (module-level, `Input::Image`
  + required integer `x`/`y` (min 0) and `width`/`height` (min 1), descriptions
  reproduced from the prior authored schema). `parameters = schema_json()` in the
  `#[wafer_block]` attr. `run()` is now `resolve_source(AssetKind::Image)` →
  core `build_argv` → `dispatch_ffmpeg` → `build_media_envelope`. Tool-specific
  validation (width/height > 0) preserved. Errors via `GuestResult::error(e.into())`.
- **`core/`** — new pure crate: `build_argv` (ffmpeg `crop=w:h:x:y`) + `plan_crop`
  (validates + keeps extension, used by the page). No wafer/wasm deps.
- **`web/`** — new wasm-bindgen wrapper exporting `build_argv(x, y, width, height,
  in_name)` → `gizza_ai_block_utils::ArgvPlan`, calling the shared core.
- **`page/`** — new standalone `/tools/image-crop/` page (`meta.toml` + `content.md`),
  ffmpeg runtime, file input + x/y/width/height fields.
- **`Cargo.toml`** — workspace members `core` + `web`; added the core dep; dropped
  the now-unused direct `base64` dep (envelope built via block-utils).

### Drift-guard

Native `#[test] schema_json_matches_authored_chat_schema` pastes the prior
authored `parameters` JSON and asserts equality with `schema_json()`. As with
`image-resize`, the expected JSON uses the centralized `url`/`ref` wording from
`to_schema_json` and adds `additionalProperties: false` (uniform hardening the
authored schema lacked). All other fields — `required: [x, y, width, height]`,
the `url`⊕`ref` `oneOf`, integer types/minimums/descriptions — match exactly.

### Verification (all run, all green)

- `cargo test --workspace` — block 2/2, core 3/3, web 0/0 pass (incl. drift-guard).
- `wafer build` — `OK gizza-ai/image-crop v0.1.0 (528.1 KiB)`.
- `wasm-pack build web --target web --release` — pkg built.
- CLI: `gizza tool image-crop width=32 height=32 x=0 y=0 url=…/rust.png` →
  `cropped rust.png at (0,0) 32x32 (180 image/png)`, wrote `rust-cropped.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
