### PR TITLE
feat(video-compress): retrofit onto shared tool abstraction (Recipe M)

### DIFF
--- a/blocks/video-compress/src/lib.rs
+++ b/blocks/video-compress/src/lib.rs
@@ -1,20 +1,26 @@
 //! gizza-ai/video-compress — fetch a video URL or attachment ref, shrink its
 //! file size with a single-pass CRF re-encode (H.264/AAC), keep the container.
+//!
+//! The chat schema is derived from `descriptor()` (single source — shared shape
+//! across chat + CLI + page); the handler delegates source-resolution, ffmpeg
+//! dispatch, and envelope-building to `block_utils`. Tool-specific validation
+//! (a finite `crf`) and the pure `core` argv builder stay here. See
+//! docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md.
 
 // The #[wafer_block] macro emits the impl gated to wasm32 (it generates a native
 // registration call that requires ::new()). All the supporting imports,
 // constants, and the Args type are only used inside the wasm32-gated impl, so
-// they appear "unused" when running native unit tests. See image-resize for the
-// full rationale.
+// they appear "unused" when running native unit tests. `descriptor()` /
+// `schema_json()` remain native-compilable so the drift-guard test below can
+// exercise them. See image-resize for the full rationale.
 #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
 
-use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use gizza_ai_block_utils::{
-    dispatch_ffmpeg_runtime, filename_with_suffix, mime_to_ext, AssetKind, Envelope, FfmpegReq,
-    FfmpegResp, ForUi, SkillError, SkillResultExt, Source, SourceFields,
+    build_media_envelope, filename_with_suffix, mime_to_ext, AssetKind, Input, Param, SkillError,
+    SkillResultExt, ToolDescriptor,
 };
 #[cfg(target_arch = "wasm32")]
-use gizza_ai_block_utils::{fetch_from_url, load_from_attachment};
+use gizza_ai_block_utils::{dispatch_ffmpeg, resolve_source};
 use gizza_ai_video_compress_core::{build_argv, clamp_crf};
 use serde::Deserialize;
 use wafer_sdk::*;
@@ -25,10 +31,25 @@ const MAX_OUTPUT_BYTES: usize = 10 * 1024 * 1024;
 #[derive(Deserialize, Debug)]
 struct Args {
     #[serde(flatten)]
-    source: SourceFields,
+    source: gizza_ai_block_utils::SourceFields,
     /// CRF quality knob; omitted → core default (lower = higher quality/larger).
     #[serde(default)]
     crf: Option<f64>,
+}
+
+/// Single-source param descriptor → chat schema (and CLI + page). The drift-guard
+/// test below proves the derived schema matches the pre-retrofit authored one.
+fn descriptor() -> ToolDescriptor {
+    ToolDescriptor::new(Input::Video).param(
+        Param::number("crf")
+            .min(18.0)
+            .max(34.0)
+            .describe("Quality/size knob (default 28). Lower = higher quality/larger; higher = smaller. Clamped to 18-34."),
+    )
+}
+
+fn schema_json() -> String {
+    descriptor().to_schema_json()
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -36,7 +57,7 @@ struct VideoCompress;
 
 // The #[wafer_block] macro emits a native registration call requiring ::new()
 // on the impl; skill-style impls don't have one. Gate the struct + impl to
-// wasm32 so the core unit tests still compile natively.
+// wasm32 so the drift-guard + core unit tests still compile natively.
 #[cfg(target_arch = "wasm32")]
 #[wafer_block(
     name = "gizza-ai/video-compress",
@@ -46,18 +67,7 @@ struct VideoCompress;
     requires = ["wafer-run/network", "gizza-ai/ffmpeg-runtime"],
     skill(
         description = "Shrink a video's file size by re-encoding it at a chosen quality (CRF), keeping the container format. Provide either url (HTTP/HTTPS) or ref (id from a prior tool call). Single-pass H.264/AAC re-encode — higher crf = smaller file / lower quality. This is a quality knob, not a target-size guarantee (true target-byte-size needs a 2-pass encode).",
-        parameters = r#"{
-            "type": "object",
-            "properties": {
-                "url": { "type": "string", "description": "Video URL (HTTP/HTTPS)." },
-                "ref": { "type": "string", "description": "Reference id from a prior video tool call (e.g. \"call_42\"). Use either url or ref." },
-                "crf": { "type": "number", "minimum": 18, "maximum": 34, "description": "Quality/size knob (default 28). Lower = higher quality/larger; higher = smaller. Clamped to 18-34." }
-            },
-            "oneOf": [
-                { "required": ["url"] },
-                { "required": ["ref"] }
-            ]
-        }"#
+        parameters = schema_json()
     ),
 )]
 impl VideoCompress {
@@ -87,59 +97,24 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
     let crf = clamp_crf(crf_req);
 
     // 2. Resolve source — URL fetch or attachment lookup.
-    let (input_bytes, in_mime, in_filename) = match args.source.into_inner() {
-        Source::Url(u) => fetch_from_url(&u, AssetKind::Video, MAX_INPUT_BYTES)?,
-        Source::Ref(id) => load_from_attachment(&id, AssetKind::Video, MAX_INPUT_BYTES)?,
-    };
+    let (input_bytes, in_mime, in_filename) =
+        resolve_source(args.source.into_inner(), AssetKind::Video, MAX_INPUT_BYTES)?;
 
     // 3. Build ffmpeg argv (core keeps the input container extension).
     let in_ext = mime_to_ext(&in_mime).unwrap_or("mp4");
     let ffmpeg_in = format!("in.{in_ext}");
     let (argv, ffmpeg_out) = build_argv(crf_req, &ffmpeg_in);
 
-    // 4. Call ffmpeg-runtime.
-    let req = FfmpegReq {
-        args: argv,
-        inputs: vec![(ffmpeg_in, input_bytes)],
-        output: ffmpeg_out.clone(),
-    };
-    let req_body = serde_json::to_vec(&req)
-        .map_err(|e| SkillError::Serialize(format!("serialize ffmpeg request: {e}")))?;
-    let ff_resp_bytes = dispatch_ffmpeg_runtime(&req_body)?;
-    let ff: FfmpegResp = serde_json::from_slice(&ff_resp_bytes)
-        .map_err(|e| SkillError::Serialize(format!("malformed ffmpeg response: {e}")))?;
-
-    if ff.exit_code != 0 {
-        let snippet: String = ff.log.chars().take(200).collect();
-        return Err(SkillError::FfmpegExitNonZero {
-            exit: ff.exit_code,
-            snippet,
-        });
-    }
-    if ff.output.len() > MAX_OUTPUT_BYTES {
-        return Err(SkillError::TooLarge {
-            kind: "output video",
-            bytes: ff.output.len(),
-            cap: MAX_OUTPUT_BYTES,
-        });
-    }
+    // 4. Dispatch to ffmpeg-runtime.
+    let output = dispatch_ffmpeg(argv, ffmpeg_in, input_bytes, ffmpeg_out.clone())?;
 
     // 5. Envelope. Output mime follows the produced extension (== input ext).
     let out_ext = ffmpeg_out.rsplit_once('.').map(|(_, e)| e).unwrap_or("mp4");
     let out_mime = ext_to_video_mime(out_ext);
-    let output_size = ff.output.len();
-    let encoded = B64.encode(&ff.output);
-    let data_url = format!("data:{out_mime};base64,{encoded}");
+    let output_size = output.len();
     let filename = filename_with_suffix(&in_filename, "-compressed", out_ext);
-    let env = Envelope {
-        for_llm: format!("compressed {in_filename} at crf {crf} ({output_size} bytes {out_mime})"),
-        for_ui: ForUi {
-            data_url,
-            mime: out_mime.to_string(),
-            filename,
-        },
-    };
-    serde_json::to_vec(&env).map_err(|e| SkillError::Serialize(format!("serialize envelope: {e}")))
+    let for_llm = format!("compressed {in_filename} at crf {crf} ({output_size} bytes {out_mime})");
+    build_media_envelope(&output, out_mime, filename, for_llm, MAX_OUTPUT_BYTES)
 }
 
 /// Map an output container extension to its video MIME (mirrors `mime_to_ext`).
@@ -150,5 +125,47 @@ fn ext_to_video_mime(ext: &str) -> &'static str {
         "mov" => "video/quicktime",
         "mkv" => "video/x-matroska",
         _ => "video/mp4",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Migration safety: the descriptor-derived chat schema must match the
+    /// pre-retrofit authored schema, so the LLM sees no drift. `to_schema_json`
+    /// now emits `additionalProperties: false` uniformly (video-compress's
+    /// authored schema lacked it — added below as intentional uniform hardening)
+    /// and centralizes the `url`/`ref` property descriptions, so the expected
+    /// JSON uses that shared wording. The `crf` number bounds (18/34, whole
+    /// numbers) render as JSON integers.
+    #[test]
+    fn schema_json_matches_authored_chat_schema() {
+        let authored: serde_json::Value = serde_json::from_str(
+            r#"{
+                "type": "object",
+                "properties": {
+                    "url": { "type": "string", "description": "Video URL (HTTP/HTTPS). Use either url or ref." },
+                    "ref": { "type": "string", "description": "Reference id from a prior tool call. Use either url or ref." },
+                    "crf": { "type": "number", "minimum": 18, "maximum": 34, "description": "Quality/size knob (default 28). Lower = higher quality/larger; higher = smaller. Clamped to 18-34." }
+                },
+                "additionalProperties": false,
+                "oneOf": [
+                    { "required": ["url"] },
+                    { "required": ["ref"] }
+                ]
+            }"#,
+        )
+        .unwrap();
+        let derived: serde_json::Value = serde_json::from_str(&schema_json()).unwrap();
+        assert_eq!(derived, authored, "no LLM-facing chat-schema drift");
+    }
+
+    #[test]
+    fn output_filename_uses_compressed_suffix() {
+        assert_eq!(
+            filename_with_suffix("clip.mp4", "-compressed", "mp4"),
+            "clip-compressed.mp4"
+        );
     }
 }

--- a/blocks/video-compress/web/Cargo.toml
+++ b/blocks/video-compress/web/Cargo.toml
@@ -9,6 +9,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wasm-bindgen = "0.2"
-serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 gizza-ai-video-compress-core = { path = "../core" }
+gizza-ai-block-utils = { path = "../../../block-utils" }

--- a/blocks/video-compress/web/src/lib.rs
+++ b/blocks/video-compress/web/src/lib.rs
@@ -2,14 +2,9 @@
 //! page. Builds the ffmpeg argv (pure, shared with the chat block via core); the
 //! JS page driver runs it through the browser ffmpeg bridge.
 
-use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
-#[derive(Serialize)]
-struct Plan {
-    argv: Vec<String>,
-    out_name: String,
-}
+use gizza_ai_block_utils::ArgvPlan;
 
 /// `crf` of 0 (or non-finite) means "unset" and falls back to the default; the
 /// value is clamped to the accepted quality range by core. Returns
@@ -18,6 +13,6 @@ struct Plan {
 #[wasm_bindgen]
 pub fn build_argv(crf: f64, in_name: &str) -> Result<JsValue, JsValue> {
     let (argv, out_name) = gizza_ai_video_compress_core::build_argv(crf, in_name);
-    serde_wasm_bindgen::to_value(&Plan { argv, out_name })
+    serde_wasm_bindgen::to_value(&ArgvPlan { argv, out_name })
         .map_err(|e| JsValue::from_str(&e.to_string()))
 }


### PR DESCRIPTION
## What

Retrofits the `gizza-ai/video-compress` media/ffmpeg-PAGE tool (Recipe M — it already had core/web/page) onto the shared tool abstraction, mirroring the canonical `image-resize` exemplar.

### `blocks/video-compress/src/lib.rs`
- Added module-level `descriptor()` (`Input::Video` + a `number` `crf` param with `min(18)`/`max(34)`) and `schema_json()`; the `#[wafer_block(skill(...))]` attribute now uses `parameters = schema_json()` instead of a hand-authored JSON string literal — single source of truth across chat + CLI + page.
- `run()` now delegates source resolution and ffmpeg dispatch to `block_utils`: `resolve_source(AssetKind::Video)` → core `build_argv` → `dispatch_ffmpeg` → `build_media_envelope`. The hand-rolled `fetch_from_url`/`load_from_attachment` branch, the manual `FfmpegReq`/`FfmpegResp`/`dispatch_ffmpeg_runtime` plumbing, the inline base64 `data:` URL build, and the manual `Envelope`/`ForUi` construction are all gone.
- Tool-specific validation (reject a non-finite `crf`) and the pure `core` argv builder are unchanged.
- Errors flow through `GuestResult::error(e.into())` via `SkillError`.

### Drift-guard (mandatory)
- Added native `#[test] schema_json_matches_authored_chat_schema` that pastes the CURRENT authored `parameters` JSON and asserts equality with `schema_json()`. Per the shared-abstraction contract, the expected JSON adds `"additionalProperties": false` (authored lacked it — uniform hardening) and uses the centralized `url`/`ref` descriptions emitted by `to_schema_json`. The `crf` number bounds (18/34, whole numbers) render as JSON integers.

### `blocks/video-compress/web/src/lib.rs` + `web/Cargo.toml`
- Replaced the local `struct Plan` with `gizza_ai_block_utils::ArgvPlan`.
- Added the `gizza-ai-block-utils` path dep to the web crate and dropped the now-unused direct `serde` dep (matches `image-resize/web`).

## Verification

- `cargo test --workspace`: **2 + 9 passed** (drift-guard `schema_json_matches_authored_chat_schema` green; 9 core argv tests green).
- `wafer build`: **OK gizza-ai/video-compress v0.1.0 (528.6 KiB)**.
- `wasm-pack build web --target web --release`: **Done** (pkg ready).
- CLI smoke (`gizza tool video-compress crf=30 'url=…/mov_bbb.mp4'`): **`compressed mov_bbb.mp4 at crf 30 (260196 bytes video/mp4)`** — downloaded + re-encoded a real video end-to-end, no fuel trap.

No `block-utils`/shared-file changes were needed — the abstraction already exposed everything (`resolve_source`, `dispatch_ffmpeg`, `build_media_envelope`, `ArgvPlan`, `AssetKind::Video`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
