### PR TITLE
feat(video-frame-extract): retrofit onto shared tool abstraction + page (Recipe M)

### DIFF
--- a/blocks/video-frame-extract/Cargo.toml
+++ b/blocks/video-frame-extract/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["."]
+members = [".", "core", "web"]
 
 [package]
 name = "gizza-ai-video-frame-extract-block"
@@ -15,6 +15,6 @@ crate-type = ["cdylib", "rlib"]
 wafer-sdk = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
 wafer-block = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
 gizza-ai-block-utils = { path = "../../block-utils" }
+gizza-ai-video-frame-extract-core = { path = "core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-base64 = "0.22"

--- a/blocks/video-frame-extract/core/Cargo.toml
+++ b/blocks/video-frame-extract/core/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "gizza-ai-video-frame-extract-core"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.82"
+
+[dependencies]

--- a/blocks/video-frame-extract/core/src/lib.rs
+++ b/blocks/video-frame-extract/core/src/lib.rs
@@ -1,0 +1,96 @@
+//! gizza-ai/video-frame-extract core — pure ffmpeg argv construction shared by
+//! the chat skill block and the standalone web page. No wafer/wasm-bindgen deps.
+//!
+//! Seek to a timestamp and grab a single video frame, encoded as PNG. The input
+//! is a video (any container ffmpeg can demux) but the output is always an
+//! image (`out.png`), so the page renders the result as an `<img>` even though
+//! the file input accepts `video/*`.
+
+/// The fixed output filename — always PNG regardless of the input container.
+pub const OUTPUT_NAME: &str = "out.png";
+
+/// Validate a timestamp (seconds). Must be finite and `>= 0`.
+pub fn validate_timestamp(timestamp: f64) -> Result<(), String> {
+    if !timestamp.is_finite() || timestamp < 0.0 {
+        return Err(format!(
+            "timestamp must be >= 0 and finite, got {timestamp}"
+        ));
+    }
+    Ok(())
+}
+
+/// Build the ffmpeg argv (no leading `ffmpeg`) to seek to `timestamp` seconds
+/// and write a single frame to `out_name` as PNG. `-ss` precedes `-i` for a
+/// fast input-seek; `-frames:v 1 -update 1` writes exactly one image.
+pub fn build_argv(in_name: &str, out_name: &str, timestamp: f64) -> Vec<String> {
+    vec![
+        "-ss".into(),
+        format!("{timestamp}"),
+        "-i".into(),
+        in_name.into(),
+        "-frames:v".into(),
+        "1".into(),
+        "-update".into(),
+        "1".into(),
+        "-y".into(),
+        out_name.into(),
+    ]
+}
+
+/// Validate the timestamp and return `(argv, out_name)` for an input file.
+/// The output is always `out.png` (the extracted frame is a PNG image). Used by
+/// the web page (video file in → image file out).
+pub fn plan_extract(in_name: &str, timestamp: f64) -> Result<(Vec<String>, String), String> {
+    validate_timestamp(timestamp)?;
+    let out_name = OUTPUT_NAME.to_string();
+    Ok((build_argv(in_name, &out_name, timestamp), out_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn argv_seeks_before_input_and_grabs_one_frame() {
+        let argv = build_argv("in.mp4", "out.png", 5.0);
+        assert_eq!(argv[0], "-ss");
+        assert_eq!(argv[1], "5");
+        assert_eq!(argv[2], "-i");
+        assert_eq!(argv[3], "in.mp4");
+        assert!(argv.windows(2).any(|w| w[0] == "-frames:v" && w[1] == "1"));
+        assert!(argv.windows(2).any(|w| w[0] == "-update" && w[1] == "1"));
+        assert_eq!(argv.last().map(String::as_str), Some("out.png"));
+    }
+
+    #[test]
+    fn argv_renders_fractional_timestamp() {
+        let argv = build_argv("in.webm", "out.png", 1.5);
+        assert_eq!(argv[1], "1.5");
+    }
+
+    #[test]
+    fn validate_timestamp_accepts_zero_and_positive() {
+        assert!(validate_timestamp(0.0).is_ok());
+        assert!(validate_timestamp(12.5).is_ok());
+    }
+
+    #[test]
+    fn validate_timestamp_rejects_negative_and_non_finite() {
+        assert!(validate_timestamp(-1.0).is_err());
+        assert!(validate_timestamp(f64::NAN).is_err());
+        assert!(validate_timestamp(f64::INFINITY).is_err());
+    }
+
+    #[test]
+    fn plan_extract_outputs_png_and_validates() {
+        let (argv, out) = plan_extract("clip.mov", 3.0).unwrap();
+        assert_eq!(out, "out.png");
+        assert_eq!(argv[0], "-ss");
+        assert_eq!(argv[1], "3");
+        assert!(argv.iter().any(|a| a == "clip.mov"));
+        // Output is always PNG regardless of input container.
+        assert_eq!(argv.last().map(String::as_str), Some("out.png"));
+        assert!(plan_extract("clip.mp4", -2.0).is_err());
+        assert!(plan_extract("clip.mp4", f64::NAN).is_err());
+    }
+}

--- a/blocks/video-frame-extract/page/content.md
+++ b/blocks/video-frame-extract/page/content.md
@@ -1,0 +1,18 @@
+## Extract a frame from a video in your browser
+
+Pick a video, type a timestamp in seconds, and grab the frame at that moment as
+a PNG image. The extraction runs entirely in your browser with ffmpeg compiled
+to WebAssembly — your video is never uploaded to a server.
+
+### How it works
+
+- ffmpeg seeks to the timestamp you give and writes exactly one frame.
+- The frame is saved as a **PNG** (lossless), so it's ready to download or feed
+  into an image tool like resize, crop, or convert.
+
+### Tips
+
+- Use `0` to grab the very first frame.
+- Fractional seconds work too — e.g. `1.5` for one and a half seconds in.
+- A timestamp past the end of the video yields the last available frame.
+- Works offline once the page has loaded.

--- a/blocks/video-frame-extract/page/meta.toml
+++ b/blocks/video-frame-extract/page/meta.toml
@@ -1,0 +1,23 @@
+slug          = "video-frame-extract"
+title         = "Extract a Frame from a Video — gizza.ai"
+description   = "Grab a single frame from any video as a PNG image, right in your browser — pick a timestamp in seconds. Runs locally with ffmpeg, nothing is uploaded, free."
+tags          = ["video", "frame", "extract", "screenshot", "thumbnail", "still", "png"]
+h1            = "Extract a Video Frame"
+hero_subtitle = "Pick a video and a timestamp — a single frame is grabbed as a PNG in your browser, nothing is uploaded."
+wasm          = "gizza_ai_video_frame_extract_web"
+export        = "build_argv"
+runtime       = "ffmpeg"
+output_label  = "Extracted frame (PNG)"
+format        = "image"
+
+[[input]]
+name   = "file"
+source = "file"
+accept = "video/*"
+label  = "Video"
+
+[[input]]
+name        = "timestamp"
+source      = "field"
+label       = "Timestamp (seconds)"
+placeholder = "1"

--- a/blocks/video-frame-extract/src/lib.rs
+++ b/blocks/video-frame-extract/src/lib.rs
@@ -1,50 +1,65 @@
-//! gizza-ai/video-frame-extract — fetch a video URL or attachment ref, extract a single frame as PNG.
+//! gizza-ai/video-frame-extract — fetch a video URL or attachment ref, extract a
+//! single frame at a given timestamp, return it as a PNG envelope.
+//!
+//! The chat schema is derived from `descriptor()` (single source — shared shape
+//! across chat + CLI + page); the handler delegates source-resolution, ffmpeg
+//! dispatch, and envelope-building to `block_utils`. The pure `core` argv
+//! builder is shared with the standalone web page. The input is a video but the
+//! output is always a PNG image, so the page is `format="image"`. See
+//! docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md.
 
-// The #[wafer_block] macro emits the impl gated to wasm32; supporting imports,
-// constants, and the Args type are only used there. See image-resize for the
-// full rationale.
+// The #[wafer_block] macro emits the impl gated to wasm32 (the macro generates
+// a native registration call that requires ::new()). All the supporting imports,
+// constants, and the Args type are only used inside the wasm32-gated impl, so
+// they appear "unused" when running native unit tests. `descriptor()` /
+// `schema_json()` remain native-compilable so the drift-guard below can exercise
+// them. See image-resize for the full rationale.
 #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
 
-use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use gizza_ai_block_utils::{
-    dispatch_ffmpeg_runtime, filename_with_suffix, mime_to_ext, AssetKind, Envelope, FfmpegReq,
-    FfmpegResp, ForUi, SkillError, SkillResultExt, Source, SourceFields,
+    build_media_envelope, filename_with_suffix, mime_to_ext, AssetKind, Input, Param, SkillError,
+    SkillResultExt, ToolDescriptor,
 };
+#[cfg(target_arch = "wasm32")]
+use gizza_ai_block_utils::{dispatch_ffmpeg, resolve_source};
+use gizza_ai_video_frame_extract_core::{build_argv, validate_timestamp, OUTPUT_NAME};
 use serde::Deserialize;
 use wafer_sdk::*;
 
-#[cfg(target_arch = "wasm32")]
-use gizza_ai_block_utils::{fetch_from_url, load_from_attachment};
-
-const MAX_INPUT_BYTES: usize = 10 * 1024 * 1024;
+const MAX_INPUT_BYTES: usize = 10 * 1024 * 1024; // 10 MiB
 const MAX_OUTPUT_BYTES: usize = 10 * 1024 * 1024;
+
+/// The output is always a PNG image, regardless of the input video container.
+const OUTPUT_MIME: &str = "image/png";
 
 #[derive(Deserialize, Debug)]
 struct Args {
     #[serde(flatten)]
-    source: SourceFields,
+    source: gizza_ai_block_utils::SourceFields,
     timestamp: f64,
 }
 
+/// Single-source param descriptor → chat schema (and CLI + page). The drift-guard
+/// test below proves the derived schema matches the pre-retrofit authored one.
+fn descriptor() -> ToolDescriptor {
+    ToolDescriptor::new(Input::Video).param(
+        Param::number("timestamp")
+            .required()
+            .min(0.0)
+            .describe("Timestamp in seconds."),
+    )
+}
 
-fn build_argv(in_name: &str, out_name: &str, timestamp: f64) -> Vec<String> {
-    vec![
-        "-ss".into(),
-        format!("{timestamp}"),
-        "-i".into(),
-        in_name.into(),
-        "-frames:v".into(),
-        "1".into(),
-        "-update".into(),
-        "1".into(),
-        "-y".into(),
-        out_name.into(),
-    ]
+fn schema_json() -> String {
+    descriptor().to_schema_json()
 }
 
 #[cfg(target_arch = "wasm32")]
 struct VideoFrameExtract;
 
+// The #[wafer_block] macro emits a native registration call requiring ::new()
+// on the impl; skill-style impls don't have one. Gate the struct + impl to
+// wasm32 so unit tests can still compile natively.
 #[cfg(target_arch = "wasm32")]
 #[wafer_block(
     name = "gizza-ai/video-frame-extract",
@@ -54,19 +69,7 @@ struct VideoFrameExtract;
     requires = ["wafer-run/network", "gizza-ai/ffmpeg-runtime"],
     skill(
         description = "Extract a single frame from a video at the given timestamp (seconds), output as PNG. The PNG is naturally chainable into image-resize, image-crop, or image-convert via ref. Provide either url (HTTP/HTTPS) or ref (id from a prior tool call).",
-        parameters = r#"{
-            "type": "object",
-            "properties": {
-                "url":       { "type": "string" },
-                "ref":       { "type": "string" },
-                "timestamp": { "type": "number", "minimum": 0, "description": "Timestamp in seconds." }
-            },
-            "required": ["timestamp"],
-            "oneOf": [
-                { "required": ["url"] },
-                { "required": ["ref"] }
-            ]
-        }"#
+        parameters = schema_json()
     ),
 )]
 impl VideoFrameExtract {
@@ -80,82 +83,72 @@ impl VideoFrameExtract {
 
 #[cfg(target_arch = "wasm32")]
 fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
+    // 1. Validate args (tool-specific — timestamp must be >= 0 and finite).
     let args: Args = serde_json::from_slice(&body).invalid_args("video-frame-extract")?;
-    if args.timestamp < 0.0 || !args.timestamp.is_finite() {
-        return Err(SkillError::InvalidArgs(format!(
-            "invalid video-frame-extract args: timestamp must be >= 0 and finite, got {}",
-            args.timestamp
-        )));
-    }
+    validate_timestamp(args.timestamp)
+        .map_err(|e| SkillError::InvalidArgs(format!("invalid video-frame-extract args: {e}")))?;
 
-    let (input_bytes, in_mime, in_filename) = match args.source.into_inner() {
-        Source::Url(u) => fetch_from_url(&u, AssetKind::Video, MAX_INPUT_BYTES)?,
-        Source::Ref(id) => load_from_attachment(&id, AssetKind::Video, MAX_INPUT_BYTES)?,
-    };
+    // 2. Resolve source — URL fetch or attachment lookup (input is a video).
+    let (input_bytes, in_mime, in_filename) =
+        resolve_source(args.source.into_inner(), AssetKind::Video, MAX_INPUT_BYTES)?;
 
-    let in_ext = mime_to_ext(&in_mime).unwrap_or("bin");
+    // 3. Build ffmpeg argv (shared pure core). Output is always PNG.
+    let in_ext = mime_to_ext(&in_mime).unwrap_or("mp4");
     let ffmpeg_in = format!("in.{in_ext}");
-    let ffmpeg_out = "out.png".to_string();
+    let ffmpeg_out = OUTPUT_NAME.to_string();
     let argv = build_argv(&ffmpeg_in, &ffmpeg_out, args.timestamp);
 
-    let req = FfmpegReq {
-        args: argv,
-        inputs: vec![(ffmpeg_in, input_bytes)],
-        output: ffmpeg_out,
-    };
-    let req_body = serde_json::to_vec(&req)
-        .map_err(|e| SkillError::Serialize(format!("serialize ffmpeg request: {e}")))?;
-    let ff_resp_bytes = dispatch_ffmpeg_runtime(&req_body)?;
-    let ff: FfmpegResp = serde_json::from_slice(&ff_resp_bytes)
-        .map_err(|e| SkillError::Serialize(format!("malformed ffmpeg response: {e}")))?;
+    // 4. Dispatch to ffmpeg-runtime.
+    let output = dispatch_ffmpeg(argv, ffmpeg_in, input_bytes, ffmpeg_out)?;
 
-    if ff.exit_code != 0 {
-        let snippet: String = ff.log.chars().take(200).collect();
-        return Err(SkillError::FfmpegExitNonZero {
-            exit: ff.exit_code,
-            snippet,
-        });
-    }
-    if ff.output.len() > MAX_OUTPUT_BYTES {
-        return Err(SkillError::TooLarge {
-            kind: "output frame",
-            bytes: ff.output.len(),
-            cap: MAX_OUTPUT_BYTES,
-        });
-    }
-
-    let output_size = ff.output.len();
-    let encoded = B64.encode(&ff.output);
-    let data_url = format!("data:image/png;base64,{encoded}");
+    // 5. Envelope — the extracted frame is an image/png.
+    let output_size = output.len();
     let filename = filename_with_suffix(&in_filename, &format!("-frame-{}", args.timestamp), "png");
-
-    let env = Envelope {
-        for_llm: format!(
-            "extracted frame at {}s from {} (PNG, {} bytes)",
-            args.timestamp, in_filename, output_size
-        ),
-        for_ui: ForUi {
-            data_url,
-            mime: "image/png".to_string(),
-            filename,
-        },
-    };
-    serde_json::to_vec(&env).map_err(|e| SkillError::Serialize(format!("serialize envelope: {e}")))
+    let for_llm = format!(
+        "extracted frame at {}s from {} (PNG, {} bytes)",
+        args.timestamp, in_filename, output_size
+    );
+    build_media_envelope(&output, OUTPUT_MIME, filename, for_llm, MAX_OUTPUT_BYTES)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Migration safety: the descriptor-derived chat schema must match the
+    /// pre-retrofit authored schema, so the LLM sees no drift. `to_schema_json`
+    /// emits `additionalProperties: false` uniformly (the authored schema lacked
+    /// it — added below as intentional uniform hardening) and centralizes the
+    /// `url`/`ref` property descriptions (the authored schema left them blank —
+    /// the expected JSON uses the shared `Input::Video` wording).
     #[test]
-    fn argv_default() {
-        let argv = build_argv("in.mp4", "out.png", 5.0);
-        assert_eq!(argv[0], "-ss");
-        assert_eq!(argv[1], "5");
-        assert_eq!(argv[2], "-i");
-        assert_eq!(argv[3], "in.mp4");
-        assert!(argv.iter().any(|a| a == "-frames:v"));
-        assert!(argv.iter().any(|a| a == "1"));
-        assert_eq!(argv.last().map(String::as_str), Some("out.png"));
+    fn schema_json_matches_authored_chat_schema() {
+        let authored: serde_json::Value = serde_json::from_str(
+            r#"{
+                "type": "object",
+                "properties": {
+                    "url":       { "type": "string", "description": "Video URL (HTTP/HTTPS). Use either url or ref." },
+                    "ref":       { "type": "string", "description": "Reference id from a prior tool call. Use either url or ref." },
+                    "timestamp": { "type": "number", "minimum": 0, "description": "Timestamp in seconds." }
+                },
+                "additionalProperties": false,
+                "required": ["timestamp"],
+                "oneOf": [
+                    { "required": ["url"] },
+                    { "required": ["ref"] }
+                ]
+            }"#,
+        )
+        .unwrap();
+        let derived: serde_json::Value = serde_json::from_str(&schema_json()).unwrap();
+        assert_eq!(derived, authored, "no LLM-facing chat-schema drift");
+    }
+
+    #[test]
+    fn output_filename_uses_frame_timestamp_suffix_and_png() {
+        assert_eq!(
+            filename_with_suffix("clip.mp4", "-frame-5", "png"),
+            "clip-frame-5.png"
+        );
     }
 }

--- a/blocks/video-frame-extract/web/Cargo.toml
+++ b/blocks/video-frame-extract/web/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "gizza-ai-video-frame-extract-web"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.82"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+serde-wasm-bindgen = "0.6"
+gizza-ai-video-frame-extract-core = { path = "../core" }
+gizza-ai-block-utils = { path = "../../../block-utils" }

--- a/blocks/video-frame-extract/web/src/lib.rs
+++ b/blocks/video-frame-extract/web/src/lib.rs
@@ -1,0 +1,23 @@
+//! Browser-facing wasm-bindgen wrapper for the standalone /tools/video-frame-extract/
+//! page. Builds the ffmpeg argv (pure, shared with the chat block via core); the
+//! JS page driver runs it through the browser ffmpeg bridge.
+//!
+//! Input is a video file; output is always a PNG image (the page's `format` is
+//! `image`, so the extracted frame renders as an `<img>`).
+
+use wasm_bindgen::prelude::*;
+
+use gizza_ai_block_utils::ArgvPlan;
+use gizza_ai_video_frame_extract_core::plan_extract;
+
+/// `timestamp` is in seconds (0 grabs the first frame). The page passes the
+/// `timestamp` field then the uploaded file's `in_name` (field order =
+/// `build_argv` param order). Returns `{ argv: string[], out_name }` (always
+/// `out.png`) or throws a JS error string.
+#[wasm_bindgen]
+pub fn build_argv(timestamp: f64, in_name: &str) -> Result<JsValue, JsValue> {
+    let (argv, out_name) =
+        plan_extract(in_name, timestamp).map_err(|e| JsValue::from_str(&e))?;
+    serde_wasm_bindgen::to_value(&ArgvPlan { argv, out_name })
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+}


### PR DESCRIPTION
## What

Retrofit `gizza-ai/video-frame-extract` onto the shared tool abstraction (Recipe M: media/ffmpeg, video in → single image frame out) and give it a standalone `/tools/video-frame-extract/` page.

The input is a **video** (`Input::Video`, `AssetKind::Video`, file input `accept="video/*"`) but the output is always a **PNG image**, so the page is `format="image"` (the result renders as an `<img>`) with `runtime="ffmpeg"`, and the chat envelope mime is `image/png`.

## Changes

- **`src/lib.rs` (chat)** — now derives the chat schema from a module-level `descriptor()` / `schema_json()` (single source), delegates to the shared `resolve_source(AssetKind::Video)` → core `build_argv` → `dispatch_ffmpeg` → `build_media_envelope(image/png)` helpers, and reports errors via `GuestResult::error(e.into())`. Dropped the hand-rolled fetch/dispatch/base64-encode code and the now-unused `base64` dep.
- **`core/`** (new) — pure `build_argv`, `validate_timestamp`, and `plan_extract` (video file in → `out.png`), shared verbatim by the chat block and the web page. No wafer/wasm-bindgen deps.
- **`web/`** (new) — `wasm-bindgen` wrapper exporting `build_argv(timestamp, in_name)` → shared `ArgvPlan { argv, out_name }`. Timestamp `0` legitimately grabs the first frame (no "0 = unset" sentinel).
- **`page/meta.toml` + `page/content.md`** (new) — `format="image"`, `runtime="ffmpeg"`, file input `accept="video/*"` + a `timestamp` scalar field; SEO copy.
- **`Cargo.toml`** — `[workspace] members = [".", "core", "web"]` + the core dep.

No `block-utils` / shared files were touched.

## Drift-guard

Native `#[test] schema_json_matches_authored_chat_schema` pastes the pre-retrofit authored `parameters` JSON and asserts equality with the descriptor-derived `schema_json()`. Per the established convention, the expected JSON adds `additionalProperties: false` (uniform hardening) and uses the centralized `Input::Video` `url`/`ref` descriptions; the `timestamp` number param keeps `minimum: 0` + `required` and the `url`⊕`ref` `oneOf` is preserved. **PASS.**

## Verification

- `cargo test --workspace` → **7 passed** (drift-guard + 1 block + 5 core).
- `wafer build` → **OK gizza-ai/video-frame-extract v0.1.0 (526.4 KiB)**.
- `wasm-pack build web --target web --release` → **Done**, pkg ready.
- CLI `gizza tool video-frame-extract timestamp=1 url=…/mov_bbb.mp4` → **`extracted frame at 1s from mov_bbb.mp4 (PNG, 132400 bytes)`**, wrote a valid 320×176 PNG. (The CLI first correctly rejected the wrong param name with `missing required arg \`timestamp\``, confirming the new schema is wired through the CLI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
