### PR TITLE
feat(ffmpeg): retrofit onto shared tool abstraction (Recipe N)

### DIFF
--- a/blocks/ffmpeg/src/lib.rs
+++ b/blocks/ffmpeg/src/lib.rs
@@ -1,5 +1,11 @@
 //! gizza-ai/ffmpeg — fetch a URL, run `ffmpeg -i input` on the bytes,
 //! return the log.
+//!
+//! The chat schema is derived from `descriptor()` (single source — shared shape
+//! across chat + CLI). The handler stays thin (parse `Args`, fetch the bytes,
+//! run ffmpeg-runtime, emit the flat `ToolResp`) rather than going through
+//! `run_skill`, because ffmpeg's success shape is the flat `ToolResp` JSON
+//! (`{ url, info }`), not the `{ "result": … }` wrapper `run_skill` produces.
 
 // The #[wafer_block] macro emits wasm-only registration; supporting imports
 // and the Args type are only used inside that impl. See image-resize for
@@ -9,7 +15,8 @@
 use std::collections::HashMap;
 
 use gizza_ai_block_utils::{
-    dispatch_ffmpeg_runtime, FfmpegReq, FfmpegResp, SkillError, SkillResultExt,
+    dispatch_ffmpeg_runtime, FfmpegReq, FfmpegResp, Input, Param, SkillError, SkillResultExt,
+    ToolDescriptor,
 };
 use serde::{Deserialize, Serialize};
 use wafer_sdk::*;
@@ -25,6 +32,23 @@ struct Args {
 struct ToolResp {
     url: String,
     info: String,
+}
+
+/// Single-source param descriptor → chat schema (and CLI). See
+/// docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md.
+/// ffmpeg is `Input::None` — `url` is a normal required string param (the
+/// chat/CLI surface takes only a `url`, with no `ref`), so there is no
+/// `url`⊕`ref` `oneOf`.
+fn descriptor() -> ToolDescriptor {
+    ToolDescriptor::new(Input::None).param(
+        Param::string("url")
+            .required()
+            .describe("HTTP/HTTPS URL of the media file to inspect."),
+    )
+}
+
+fn schema_json() -> String {
+    descriptor().to_schema_json()
 }
 
 /// argv for an ffprobe-style inspection — read `input` from ffmpeg's
@@ -45,18 +69,13 @@ struct FfmpegSkill;
     requires = ["wafer-run/network", "gizza-ai/ffmpeg-runtime"],
     skill(
         description = "Run ffprobe on a media URL and return format/stream metadata.",
-        parameters = r#"{
-            "type": "object",
-            "properties": {
-                "url": { "type": "string", "description": "HTTP/HTTPS URL of the media file to inspect." }
-            },
-            "required": ["url"],
-            "additionalProperties": false
-        }"#
+        parameters = schema_json()
     ),
 )]
 impl FfmpegSkill {
     fn handle(_msg: Message, body: Vec<u8>) -> GuestResult {
+        // ffmpeg returns the flat ToolResp JSON directly (no `{ "result": … }`
+        // wrapper), so it keeps a thin handle rather than using run_skill.
         match run(body) {
             Ok(v) => GuestResult::respond(v),
             Err(e) => GuestResult::error(e.into()),
@@ -109,6 +128,27 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
 mod tests {
     use super::*;
 
+    /// Migration safety: the descriptor-derived chat schema must match the
+    /// pre-retrofit authored schema, so the LLM sees no drift. (to_schema_json
+    /// emits `additionalProperties: false`, which ffmpeg's authored schema
+    /// already had — so this is an exact match.)
+    #[test]
+    fn schema_json_matches_authored_chat_schema() {
+        let authored: serde_json::Value = serde_json::from_str(
+            r#"{
+                "type": "object",
+                "properties": {
+                    "url": { "type": "string", "description": "HTTP/HTTPS URL of the media file to inspect." }
+                },
+                "required": ["url"],
+                "additionalProperties": false
+            }"#,
+        )
+        .unwrap();
+        let derived: serde_json::Value = serde_json::from_str(&schema_json()).unwrap();
+        assert_eq!(derived, authored, "no LLM-facing chat-schema drift");
+    }
+
     #[test]
     fn argv_uses_input_filename_with_dash_i() {
         let argv = build_inspect_argv();
@@ -121,7 +161,8 @@ mod tests {
             url: "https://x.test/a.mp4".to_string(),
             info: "Stream #0: Video".to_string(),
         };
-        let json: serde_json::Value = serde_json::from_slice(&serde_json::to_vec(&tool).unwrap()).unwrap();
+        let json: serde_json::Value =
+            serde_json::from_slice(&serde_json::to_vec(&tool).unwrap()).unwrap();
         assert_eq!(json["url"], "https://x.test/a.mp4");
         assert_eq!(json["info"], "Stream #0: Video");
     }


### PR DESCRIPTION
## Summary

Retrofits the `gizza-ai/ffmpeg` tool (no-page chat + CLI: run ffprobe on a media
URL → format/stream metadata text) onto the shared tool abstraction, the same
single-source-descriptor pattern used by `web-fetch` and `url-encode`.

The chat schema is now **derived** from a module-level `descriptor()` /
`schema_json()` in `blocks/ffmpeg/src/lib.rs` rather than hand-authored in the
`#[wafer_block(skill(parameters = …))]` literal:

- `descriptor()` = `Input::None` + `Param::string("url").required()` — the
  chat/CLI surface takes only a `url` string (no `ref`), so there is no
  `url`⊕`ref` `oneOf`.
- `parameters = schema_json()` replaces the inline schema literal.
- Param description reproduced **exactly** (`"HTTP/HTTPS URL of the media file
  to inspect."`); skill `description` unchanged.

The ffprobe-invocation logic (`build_inspect_argv` → `FfmpegReq` →
`dispatch_ffmpeg_runtime` → flat `ToolResp { url, info }`) is **unchanged** —
only the chat-wrapper schema was swapped. ffmpeg keeps a thin `handle()`
(`Ok => respond`, `Err => error(e.into())`) rather than `run_skill`, because its
success shape is the flat `ToolResp` JSON, not the `{ "result": … }` wrapper.

No changes to `block-utils` or any shared file — all needed pieces
(`Input`, `Param`, `ToolDescriptor`, `FfmpegReq`/`FfmpegResp`,
`dispatch_ffmpeg_runtime`) already exist.

## Drift guard

Added native `#[test] schema_json_matches_authored_chat_schema` that pastes the
pre-retrofit authored `parameters` JSON and asserts equality with
`schema_json()`. The authored schema already had `additionalProperties: false`,
so it is an exact match. Passes.

## Verification

- `cargo test --workspace`: 3 passed (drift-guard + 2 existing), 0 failed.
- `wafer build`: `OK  gizza-ai/ffmpeg v0.1.0 (424.1 KiB)` — wasm built + validated.
- CLI `gizza tool ffmpeg 'url=https://www.w3schools.com/html/mov_bbb.mp4'`:
  returned real ffprobe metadata (mov/mp4 container, h264 320x176 video stream,
  two AAC 48kHz stereo audio streams, 10.03s duration, 629 kb/s) inside the flat
  `{"url":…,"info":…}` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
