### PR TITLE
feat(imagine): retrofit onto shared tool abstraction

### DIFF
--- a/blocks/imagine/src/lib.rs
+++ b/blocks/imagine/src/lib.rs
@@ -23,7 +23,9 @@
 #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
 
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
-use gizza_ai_block_utils::{Envelope, ForUi, SkillError, SkillResultExt};
+use gizza_ai_block_utils::{
+    Envelope, ForUi, Input, Param, SkillError, SkillResultExt, ToolDescriptor,
+};
 use serde::Deserialize;
 #[cfg(target_arch = "wasm32")]
 use wafer_sdk::clients::image::{ImageParams, ImageRequest};
@@ -47,6 +49,22 @@ const WEBGPU_UNAVAILABLE_USER_MESSAGE: &str =
 #[derive(Deserialize)]
 struct Args {
     prompt: String,
+}
+
+/// Single-source param descriptor → chat schema (and CLI/page). See
+/// docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md.
+/// `Input::None` because the prompt is a plain `String` param, not a binary
+/// upload; the image is *generated*, not consumed.
+fn descriptor() -> ToolDescriptor {
+    ToolDescriptor::new(Input::None).param(
+        Param::string("prompt")
+            .required()
+            .describe("Description of the image to generate."),
+    )
+}
+
+fn schema_json() -> String {
+    descriptor().to_schema_json()
 }
 
 /// If `err` came from `requireWebGpuAdapter` (recognised via
@@ -88,14 +106,7 @@ struct Imagine;
         description = "Generate an image from a text prompt. Renders inline in the chat. \
                        Requires WebGPU in the browser (uses shader-f16 when available, \
                        falls back to fp32 otherwise). Output is a PNG.",
-        parameters = r#"{
-            "type": "object",
-            "properties": {
-                "prompt": { "type": "string", "description": "Description of the image to generate." }
-            },
-            "required": ["prompt"],
-            "additionalProperties": false
-        }"#
+        parameters = schema_json()
     ),
 )]
 impl Imagine {
@@ -160,6 +171,27 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Migration safety: the descriptor-derived chat schema must match the
+    /// pre-retrofit authored schema verbatim, so the LLM sees no drift.
+    /// imagine's authored schema already had `additionalProperties: false`,
+    /// so this is an exact match.
+    #[test]
+    fn schema_json_matches_authored_chat_schema() {
+        let authored: serde_json::Value = serde_json::from_str(
+            r#"{
+                "type": "object",
+                "properties": {
+                    "prompt": { "type": "string", "description": "Description of the image to generate." }
+                },
+                "required": ["prompt"],
+                "additionalProperties": false
+            }"#,
+        )
+        .unwrap();
+        let derived: serde_json::Value = serde_json::from_str(&schema_json()).unwrap();
+        assert_eq!(derived, authored, "no LLM-facing chat-schema drift");
+    }
 
     #[test]
     fn validate_prompt_trims_surrounding_whitespace() {


### PR DESCRIPTION
## What

Retrofit the `gizza-ai/imagine` text-to-image tool onto the shared tool
abstraction (`block-utils::descriptor`), matching the pattern already used by
`url-encode`, `calculator`, the `image-*`/`video-*` tools, etc.

The chat schema is now derived from a single-source `descriptor()` instead of a
hand-authored inline JSON blob:

- Added module-level `descriptor()` → `ToolDescriptor::new(Input::None)` with a
  single `Param::string("prompt").required().describe("Description of the image
  to generate.")`, plus `schema_json()` = `descriptor().to_schema_json()`.
- `#[wafer_block(skill(parameters = …))]` now uses `parameters = schema_json()`
  (was an inline `r#"{…}"#` JSON literal).

`Input::None` is correct: imagine *generates* an image from a text prompt — it
does not consume a binary upload, so there is no `url`/`ref` media input.

## Generation mechanism — PRESERVED unchanged

imagine does **not** fit `run_skill` (which shapes `{ "result": … }`). Its
handler is preserved exactly:

- `handle()` → `run()` dispatches to the `wafer-run/image` service via
  `wafer_sdk::clients::image::generate`. The actual inference runs page-side in
  the browser (`BrowserImageService` → transformers.js / Janus-Pro-1B on
  WebGPU). The wasm block only orchestrates and shapes the response.
- Success → an `Envelope { _for_llm, _for_ui }` (base64 `data:` URL) so the chat
  renders the image inline.
- WebGPU-unavailable → the recognised `webgpu-unavailable` marker is caught and
  surfaced as a flat `{ "message": … }` so the chat shows a plain explanation
  rather than a raw error chip.
- Errors still flow through `GuestResult::error(e.into())`.

Only the schema *source* changed (inline JSON → `schema_json()`); the
generation/delegation/Envelope/WebGPU-fallback paths are byte-for-byte the same.

## Drift guard

Added native `#[test] schema_json_matches_authored_chat_schema` that pastes the
exact pre-retrofit authored `parameters` JSON and asserts equality with
`schema_json()`. imagine's authored schema already had
`additionalProperties: false`, so this is an exact match — the LLM sees zero
schema drift.

## Verification

- `cargo test --manifest-path blocks/imagine/Cargo.toml --workspace` — **6
  passed, 0 failed** (incl. the drift guard).
- `wafer build` (in `blocks/imagine`) — **OK gizza-ai/imagine v0.1.0
  (441.9 KiB)**.
- CLI smoke is **N/A**: imagine requires browser WebGPU + the page-side t2i
  engine, which the headless CLI does not provide. A headless run would
  fail/return the WebGPU-unavailable path by design; that is not a regression.
  The gates for imagine are the drift guard + `wafer build`, both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
