### PR TITLE
feat(merge-pdf): retrofit onto shared tool abstraction (Recipe N, SourceList)

### DIFF
--- a/blocks/merge-pdf/src/lib.rs
+++ b/blocks/merge-pdf/src/lib.rs
@@ -1,18 +1,30 @@
 //! gizza-ai/merge-pdf — combine several PDFs into one, in order.
 //!
 //! Pipeline: parse `{ "inputs": [ {url|ref}, ... ] }` → load each PDF's bytes
-//! via `block-utils` (`fetch_from_url` for a URL, `load_from_attachment` for an
-//! uploaded `ref`), all validated as `application/pdf` → concatenate every page
-//! with the pure `merge-pdf-core` → base64-encode → emit an envelope
-//! `{_for_llm, _for_ui}` with a `data:application/pdf` URL the chat UI can
-//! offer for download. No page surface — chat + CLI only.
+//! via `block-utils` `resolve_source` (URL fetch through `wafer-run/network`,
+//! or an uploaded attachment `ref`), all validated as the `application/*`
+//! document MIME class → concatenate every page with the pure `merge-pdf-core`
+//! → base64-encode → emit an envelope `{_for_llm, _for_ui}` with a
+//! `data:application/pdf` URL the chat UI can offer for download.
+//!
+//! The chat schema is derived from `descriptor()` (single source — shared shape
+//! across chat + CLI): `Input::None` (the inputs arrive as an array param, not
+//! the scalar `url`⊕`ref` an `Input::Document` block takes) plus a required
+//! `inputs` [`Param::source_list`] of at least two `{ url | ref }` sources. No
+//! page surface — chat + CLI only.
 
-// The #[wafer_block] macro emits wasm-only registration; supporting imports
-// and the Args type are only used inside that impl.
+// The #[wafer_block] macro emits the impl gated to wasm32. The supporting
+// imports + the Args type are only used inside that impl, so they look "unused"
+// when running native unit tests. The descriptor stays native-compilable so the
+// drift-guard unit test below can exercise it.
 #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
 
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
-use gizza_ai_block_utils::{Envelope, ForUi, SkillError, SkillResultExt, Source, SourceFields};
+#[cfg(target_arch = "wasm32")]
+use gizza_ai_block_utils::resolve_source;
+use gizza_ai_block_utils::{
+    Envelope, ForUi, Input, Param, SkillError, SkillResultExt, SourceFields, ToolDescriptor,
+};
 use serde::Deserialize;
 use wafer_sdk::*;
 
@@ -20,11 +32,26 @@ use wafer_sdk::*;
 /// memory a single merge can pull into the wasm sandbox.
 const MAX_INPUT_BYTES: usize = 8 * 1024 * 1024;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 struct Args {
     /// At least two PDF sources, each exactly one of `url` or `ref`. Merged in
     /// the order given.
     inputs: Vec<SourceFields>,
+}
+
+/// Single-source param descriptor → chat schema (and CLI). See
+/// docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md.
+/// `Input::None` because merge-pdf takes its sources as an array param, not the
+/// scalar `url`⊕`ref` an `Input::Document` block emits; `inputs` is a required
+/// array of at least two `{ url | ref }` source objects.
+fn descriptor() -> ToolDescriptor {
+    ToolDescriptor::new(Input::None).param(Param::source_list("inputs", 2).required().describe(
+        "Ordered list of PDF sources to merge. Each item has exactly one of `url` or `ref`.",
+    ))
+}
+
+fn schema_json() -> String {
+    descriptor().to_schema_json()
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -39,26 +66,7 @@ struct MergePdf;
     requires = ["wafer-run/network"],
     skill(
         description = "Combine multiple PDF files into a single PDF, in the given order. Provide at least two PDF sources; each source is either a URL or a `ref` to an uploaded PDF attachment.",
-        parameters = r#"{
-            "type": "object",
-            "properties": {
-                "inputs": {
-                    "type": "array",
-                    "minItems": 2,
-                    "description": "Ordered list of PDF sources to merge. Each item has exactly one of `url` or `ref`.",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "url": { "type": "string", "description": "HTTP/HTTPS URL of a PDF to fetch." },
-                            "ref": { "type": "string", "description": "Reference id of an uploaded PDF attachment." }
-                        },
-                        "additionalProperties": false
-                    }
-                }
-            },
-            "required": ["inputs"],
-            "additionalProperties": false
-        }"#
+        parameters = schema_json()
     ),
 )]
 impl MergePdf {
@@ -72,7 +80,7 @@ impl MergePdf {
 
 #[cfg(target_arch = "wasm32")]
 fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
-    use gizza_ai_block_utils::{fetch_from_url, load_from_attachment, AssetKind};
+    use gizza_ai_block_utils::AssetKind;
 
     let args: Args = serde_json::from_slice(&body).invalid_args("merge-pdf")?;
     if args.inputs.len() < 2 {
@@ -82,13 +90,11 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
         )));
     }
 
-    // Load every source's bytes, validated as application/pdf.
+    // Load every source's bytes, validated as the application/* document class.
     let mut pdfs: Vec<Vec<u8>> = Vec::with_capacity(args.inputs.len());
     for field in args.inputs {
-        let (bytes, _mime, _filename) = match field.into_inner() {
-            Source::Url(url) => fetch_from_url(&url, AssetKind::Document, MAX_INPUT_BYTES)?,
-            Source::Ref(id) => load_from_attachment(&id, AssetKind::Document, MAX_INPUT_BYTES)?,
-        };
+        let (bytes, _mime, _filename) =
+            resolve_source(field.into_inner(), AssetKind::Document, MAX_INPUT_BYTES)?;
         pdfs.push(bytes);
     }
 
@@ -110,4 +116,79 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
         },
     };
     serde_json::to_vec(&env).map_err(|e| SkillError::Serialize(format!("serialize envelope: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Migration safety: the descriptor-derived chat schema must match the
+    /// pre-retrofit authored schema, so the LLM sees no drift. Two intentional,
+    /// documented deltas from the hand-authored blob:
+    ///   - the per-item `url`/`ref` descriptions — `Param::source_list` emits
+    ///     the centralized generic wording ("URL (HTTP/HTTPS). Use either url or
+    ///     ref." / "Reference id from a prior tool call. Use either url or
+    ///     ref."), so the expected blob uses those rather than merge-pdf's old
+    ///     bespoke "…PDF…" strings (the same centralization precedent the other
+    ///     retrofitted tools accepted for their scalar `url`/`ref`).
+    ///   - the top-level `inputs` `description` — `Param::describe` renders the
+    ///     authored summary, kept verbatim.
+    /// The `inputs` array shape — `type: array`, `minItems: 2`, the `items`
+    /// object (`additionalProperties: false`), `required: ["inputs"]`, and the
+    /// top-level `additionalProperties: false` — matches the authored schema
+    /// exactly. (The authored item objects carried no per-item `description`;
+    /// the descriptor adds them — the only structural addition, and a
+    /// documentation-only one.)
+    #[test]
+    fn schema_json_matches_authored_chat_schema() {
+        let authored: serde_json::Value = serde_json::from_str(
+            r#"{
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "minItems": 2,
+                        "description": "Ordered list of PDF sources to merge. Each item has exactly one of `url` or `ref`.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "url": { "type": "string", "description": "URL (HTTP/HTTPS). Use either url or ref." },
+                                "ref": { "type": "string", "description": "Reference id from a prior tool call. Use either url or ref." }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "required": ["inputs"],
+                "additionalProperties": false
+            }"#,
+        )
+        .unwrap();
+        let derived: serde_json::Value = serde_json::from_str(&schema_json()).unwrap();
+        assert_eq!(derived, authored, "no LLM-facing chat-schema drift");
+    }
+
+    #[test]
+    fn args_parse_two_url_inputs() {
+        let a: Args = serde_json::from_str(
+            r#"{"inputs":[{"url":"https://x/a.pdf"},{"url":"https://x/b.pdf"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(a.inputs.len(), 2);
+    }
+
+    #[test]
+    fn args_parse_mixed_url_and_ref() {
+        let a: Args =
+            serde_json::from_str(r#"{"inputs":[{"url":"https://x/a.pdf"},{"ref":"call_7"}]}"#)
+                .unwrap();
+        assert_eq!(a.inputs.len(), 2);
+    }
+
+    #[test]
+    fn args_reject_item_with_both_url_and_ref() {
+        let err =
+            serde_json::from_str::<Args>(r#"{"inputs":[{"url":"u","ref":"r"}]}"#).unwrap_err();
+        assert!(err.to_string().contains("exactly one"));
+    }
 }


### PR DESCRIPTION
## Summary

Retrofits the no-page `merge-pdf` tool onto the shared tool abstraction (Recipe N — the array-of-sources shape). `merge-pdf` is the **last** tool of the retrofit program.

The chat schema is no longer a hand-authored JSON blob: it is now derived from a module-level `descriptor()` (single source, shared across chat + CLI), exactly like the other retrofitted tools.

## What changed (only `blocks/merge-pdf/src/lib.rs`)

- Added `descriptor()` + `schema_json()` at module level: `ToolDescriptor::new(Input::None).param(Param::source_list("inputs", 2).required().describe(...))`.
  - `Input::None` because merge-pdf's sources arrive as an **array** param (`inputs`), not the scalar `url`⊕`ref` an `Input::Document` block emits.
  - `Param::source_list("inputs", 2)` (added to `block-utils` for exactly this tool) renders the `{ type: array, minItems: 2, items: { object url/ref, additionalProperties: false } }` schema.
- `#[wafer_block(skill(parameters = schema_json()))]` — was a hand-authored blob.
- Swapped per-input byte-loading from the `match Source::Url/Ref { fetch_from_url | load_from_attachment }` branch to the shared `resolve_source(src, AssetKind::Document, MAX_INPUT_BYTES)`. `AssetKind::Document` enforces the `application/*` document MIME class (PDFs need a proper content-type).
- The lopdf merge core, the run() loop over `args.inputs`, and the output envelope (`data:application/pdf;base64,…` `{_for_llm, _for_ui}`) are **unchanged**.

## Drift guard

Native `#[test] schema_json_matches_authored_chat_schema` pins the descriptor-derived schema against the pre-retrofit authored `parameters` JSON. Two documented, accepted deltas (same centralization precedent as the other retrofitted tools):

- per-item `url`/`ref` descriptions now use the generic centralized wording emitted by `source_list` (`"URL (HTTP/HTTPS). Use either url or ref."` / `"Reference id from a prior tool call. Use either url or ref."`) rather than merge-pdf's old bespoke "…PDF…" strings.
- the descriptor adds a per-item `description` (a documentation-only addition).

The `inputs` array structure — `type: array`, `minItems: 2`, the `items` object, top-level `additionalProperties: false`, and `required: ["inputs"]` — matches the authored schema exactly. `SourceList` fit the authored array structure cleanly; no `block-utils` change was needed.

## Verification

- `cargo test --workspace` (merge-pdf): 8 passed (4 block incl. drift guard, 4 core).
- `wafer build`: `OK  gizza-ai/merge-pdf v0.1.0  (1177.3 KiB)`.
- CLI (array input via `--json`, W3C `application/pdf` sources):
  ```
  gizza tool merge-pdf --json '{"inputs":[{"url":"…/dummy.pdf"},{"url":"…/dummy.pdf"}]}'
  merged 2 PDFs into a single 25660-byte PDF (merged.pdf)
  Written to merged.pdf
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
