### PR TITLE
docs: land shared-tool-abstraction Plan 1-4 + design spec

### DIFF
--- a/docs/superpowers/plans/2026-06-19-shared-tool-abstraction-plan-1-wafer-block-expr-params.md
+++ b/docs/superpowers/plans/2026-06-19-shared-tool-abstraction-plan-1-wafer-block-expr-params.md
@@ -1,0 +1,337 @@
+# Shared Tool Abstraction — Plan 1: `wafer_block` expression `parameters` (wafer-run)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `#[wafer_block(skill(parameters = …))]` accept an *expression* that evaluates to a JSON-schema string (e.g. `parameters = my_core::schema_json()`), not only a string literal — so gizza tools can derive their chat schema from a single-source descriptor.
+
+**Architecture:** One change to the `wafer-block-macro` proc-macro. `parameters` keeps the string-literal form (compile-time JSON validation, fully backward-compatible) and additionally accepts any expression (validated at runtime in the generated `block_info()` / by the consumer's test). The generated `SkillTool.parameters` is built by coercing the value to `&str` via `AsRef` and `serde_json::from_str`.
+
+**Tech Stack:** Rust proc-macro (`syn` 2, `quote` 1, `proc-macro2` 1), `serde_json`, `trybuild` for compile-fail tests.
+
+**Spec:** `gizza-ai/docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md` §3 ("2a").
+
+## Global Constraints
+
+- **Repo:** `wafer-run` (this plan is the producer step; merge to wafer-run `main`, then fast-forward the local `/workspace/wafer-run` tree, before any gizza consumer plan — and only when no gizza build is in flight: shared-tree hazard).
+- **Backward compatible:** the existing string-literal form must keep working unchanged, including its compile-time JSON validation (do not regress existing skill blocks).
+- **wafer-run rules** (CLAUDE.md): fix the real issue; no magic/implicit mapping; no sync bridges.
+- **CI parity:** CI clippy is 1.96 and fmt is nightly — run `cargo +1.96.0 clippy -p wafer-block-macro --all-targets -- -D warnings` and `cargo +nightly fmt` before pushing (see memory `wafer-run-ci-clippy-1-96`, `wafer-run-nightly-fmt`).
+- **No new deps:** `proc-macro2`, `quote`, `syn`, `serde_json` are already dependencies of `wafer-block-macro`.
+
+---
+
+### Task 1: Accept an expression for `skill(parameters = …)`
+
+**Files:**
+- Modify: `wafer-run/crates/wafer-block-macro/src/lib.rs`
+  - `struct SkillArgs` (≈ lines 254–258)
+  - `fn parse_skill` (≈ lines 261–339)
+  - `skill_tool_expr` emission (≈ lines 758–771)
+- Test: `wafer-run/crates/wafer-block-macro/tests/skill_macro.rs` (append a module + test)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: the macro now accepts `skill(parameters = <expr>)` where `<expr>: AsRef<str>` yielding JSON. Consumed by Plan 2 (`block-utils`) / the retrofit, where tools write `parameters = <core>::schema_json()`. The literal form `parameters = "…"` is unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `wafer-run/crates/wafer-block-macro/tests/skill_macro.rs` (after the existing `non_skill_block` module, before or after the `#[test]` fns — module order is irrelevant):
+
+```rust
+// A skill block whose `parameters` is an EXPRESSION (a `const &str`), not a
+// string literal — the single-source-descriptor pattern gizza uses. Also
+// exercises a `fn -> String` to prove the `AsRef<str>` coercion covers both.
+mod skill_block_expr {
+    use super::*;
+
+    pub const SCHEMA: &str = r#"{
+        "type": "object",
+        "properties": { "x": { "type": "integer" } },
+        "required": ["x"]
+    }"#;
+
+    pub fn schema_owned() -> String {
+        SCHEMA.to_string()
+    }
+
+    pub struct ConstExprSkill;
+
+    #[wafer_block(
+        name = "test/const-expr-skill",
+        version = "0.1.0",
+        interface = "handler@v1",
+        summary = "Schema via const expression",
+        skill(
+            description = "Schema supplied as a const &str expression.",
+            parameters = SCHEMA
+        )
+    )]
+    impl ConstExprSkill {
+        fn handle(_msg: Message, _body: Vec<u8>) -> GuestResult {
+            GuestResult::respond(b"{}".to_vec())
+        }
+    }
+    impl ConstExprSkill {
+        pub fn new() -> Self {
+            Self
+        }
+    }
+    #[wafer_async_trait]
+    impl wafer_block::block::Block for ConstExprSkill {
+        fn info(&self) -> wafer_block::types::BlockInfo {
+            Self::block_info()
+        }
+        async fn handle(
+            &self,
+            _ctx: &dyn wafer_block::context::Context,
+            _msg: wafer_block::core_types::Message,
+            _input: wafer_block::streams::input::InputStream,
+        ) -> wafer_block::streams::output::OutputStream {
+            wafer_block::streams::output::OutputStream::drop_request()
+        }
+    }
+
+    pub struct FnExprSkill;
+
+    #[wafer_block(
+        name = "test/fn-expr-skill",
+        version = "0.1.0",
+        interface = "handler@v1",
+        summary = "Schema via fn-call expression",
+        skill(
+            description = "Schema supplied as a fn() -> String expression.",
+            parameters = schema_owned()
+        )
+    )]
+    impl FnExprSkill {
+        fn handle(_msg: Message, _body: Vec<u8>) -> GuestResult {
+            GuestResult::respond(b"{}".to_vec())
+        }
+    }
+    impl FnExprSkill {
+        pub fn new() -> Self {
+            Self
+        }
+    }
+    #[wafer_async_trait]
+    impl wafer_block::block::Block for FnExprSkill {
+        fn info(&self) -> wafer_block::types::BlockInfo {
+            Self::block_info()
+        }
+        async fn handle(
+            &self,
+            _ctx: &dyn wafer_block::context::Context,
+            _msg: wafer_block::core_types::Message,
+            _input: wafer_block::streams::input::InputStream,
+        ) -> wafer_block::streams::output::OutputStream {
+            wafer_block::streams::output::OutputStream::drop_request()
+        }
+    }
+}
+
+#[test]
+fn skill_parameters_accepts_const_expression() {
+    let info = skill_block_expr::ConstExprSkill::block_info();
+    let tool = info.tool.expect("skill(...) with const expr must set tool");
+    assert_eq!(tool.description, "Schema supplied as a const &str expression.");
+    assert_eq!(tool.parameters["type"], "object");
+    assert_eq!(tool.parameters["properties"]["x"]["type"], "integer");
+    assert_eq!(tool.parameters["required"], serde_json::json!(["x"]));
+}
+
+#[test]
+fn skill_parameters_accepts_fn_call_expression() {
+    let info = skill_block_expr::FnExprSkill::block_info();
+    let tool = info.tool.expect("skill(...) with fn expr must set tool");
+    assert_eq!(tool.parameters["properties"]["x"]["type"], "integer");
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test -p wafer-block-macro --test skill_macro 2>&1 | tail -20`
+Expected: **compile error** at the new module — `#[wafer_block]: skill(parameters) value must be a string literal` (the macro currently rejects the non-literal `SCHEMA` / `schema_owned()`). This proves the test exercises the missing capability.
+
+- [ ] **Step 3: Change `SkillArgs.parameters` to hold an expression**
+
+In `wafer-run/crates/wafer-block-macro/src/lib.rs`, replace the struct (≈ lines 254–258):
+
+```rust
+/// Parsed skill(...) attribute — description and the JSON parameters schema for
+/// the LLM-facing tool definition.
+#[derive(Debug)]
+struct SkillArgs {
+    description: String,
+    /// Tokens of an expression evaluating to the JSON-schema string. For the
+    /// string-literal form this is the validated literal (JSON checked at
+    /// macro-expansion time); for the expression form (e.g.
+    /// `parameters = my_core::schema_json()`) these are the author's tokens,
+    /// with JSON validity enforced at runtime in `block_info()` (and by the
+    /// consumer's test) instead of at the macro site.
+    parameters: proc_macro2::TokenStream,
+}
+```
+
+- [ ] **Step 4: Rewrite `parse_skill` to accept a literal or an expression**
+
+Replace the whole body of `fn parse_skill` (≈ lines 261–339) with:
+
+```rust
+fn parse_skill(meta: &syn::MetaList) -> syn::Result<SkillArgs> {
+    let nested: Punctuated<syn::Meta, Token![,]> =
+        meta.parse_args_with(Punctuated::parse_terminated)?;
+    let mut description = None::<String>;
+    let mut parameters = None::<proc_macro2::TokenStream>;
+    for item in nested {
+        let nv = match item {
+            syn::Meta::NameValue(nv) => nv,
+            other => {
+                return Err(syn::Error::new(
+                    other.span(),
+                    "#[wafer_block]: unexpected token in skill(...)",
+                ));
+            }
+        };
+        let key = nv
+            .path
+            .get_ident()
+            .ok_or_else(|| {
+                syn::Error::new(
+                    nv.path.span(),
+                    "#[wafer_block]: expected identifier in skill(...)",
+                )
+            })?
+            .to_string();
+        match key.as_str() {
+            "description" => {
+                // description is always a string literal.
+                let s = match &nv.value {
+                    Expr::Lit(ExprLit {
+                        lit: Lit::Str(s), ..
+                    }) => s.value(),
+                    other => {
+                        return Err(syn::Error::new(
+                            other.span(),
+                            "#[wafer_block]: skill(description) value must be a string literal",
+                        ));
+                    }
+                };
+                description = Some(s);
+            }
+            "parameters" => {
+                // Two accepted forms:
+                //  1) a string literal — validate the JSON at macro-expansion
+                //     time (author-controlled, fully known here) and emit the
+                //     literal; preserves the original behavior exactly.
+                //  2) any expression evaluating to a value `AsRef<str>` (e.g.
+                //     `my_core::schema_json()`) — emit the tokens verbatim;
+                //     JSON validity is enforced at runtime in `block_info()`.
+                match &nv.value {
+                    Expr::Lit(ExprLit {
+                        lit: Lit::Str(s), ..
+                    }) => {
+                        let json = s.value();
+                        if let Err(e) = serde_json::from_str::<serde_json::Value>(&json) {
+                            return Err(syn::Error::new_spanned(
+                                s,
+                                format!(
+                                    "#[wafer_block]: skill `parameters` is not valid JSON: {e}"
+                                ),
+                            ));
+                        }
+                        parameters = Some(quote! { #s });
+                    }
+                    expr => {
+                        parameters = Some(quote! { #expr });
+                    }
+                }
+            }
+            other => {
+                return Err(syn::Error::new(
+                    nv.path.span(),
+                    format!("#[wafer_block]: unknown skill attribute '{other}'"),
+                ));
+            }
+        }
+    }
+    let description = description.ok_or_else(|| {
+        syn::Error::new(
+            meta.span(),
+            "#[wafer_block]: skill(...) requires description = \"...\"",
+        )
+    })?;
+    let parameters = parameters.ok_or_else(|| {
+        syn::Error::new(
+            meta.span(),
+            "#[wafer_block]: skill(...) requires parameters = \"...\" or an expression",
+        )
+    })?;
+    Ok(SkillArgs {
+        description,
+        parameters,
+    })
+}
+```
+
+- [ ] **Step 5: Update the emission to coerce the value to `&str`**
+
+Replace the `skill_tool_expr` block (≈ lines 758–774):
+
+```rust
+    // Build the optional SkillTool expression for `block_info()`.
+    let skill_tool_expr = if let Some(skill) = &skill_args {
+        let description = &skill.description;
+        let parameters_expr = &skill.parameters;
+        quote! {
+            info = info
+                .tool(wafer_block::types::SkillTool {
+                    description: #description.to_string(),
+                    // `parameters` is either a string literal that `parse_skill`
+                    // already validated as JSON, or an author-supplied expression
+                    // evaluating to `&str`/`String`. Coerce to `&str` and parse;
+                    // for the literal form this is infallible, for the expression
+                    // form a malformed schema panics here (covered by a test).
+                    parameters: serde_json::from_str(
+                        ::core::convert::AsRef::<str>::as_ref(&(#parameters_expr))
+                    )
+                    .expect(concat!("skill parameters JSON parse error in block ", #name)),
+                });
+        }
+    } else {
+        quote! {}
+    };
+```
+
+- [ ] **Step 6: Run the new tests to verify they pass**
+
+Run: `cargo test -p wafer-block-macro --test skill_macro 2>&1 | tail -20`
+Expected: PASS — including the existing `skill_attribute_sets_tool` / `no_skill_attribute_leaves_tool_unset` and the new `skill_parameters_accepts_const_expression` / `skill_parameters_accepts_fn_call_expression`.
+
+- [ ] **Step 7: Run the full macro suite (incl. trybuild compile-fail) to verify no regressions**
+
+Run: `cargo test -p wafer-block-macro 2>&1 | tail -30`
+Expected: PASS. The trybuild fixtures (`fail_caps_and_skill`, `fail_invalid_block_name`, `fail_missing_new`) are unaffected — none assert the removed "parameters must be a string literal" error (verified). If trybuild reports `.stderr` drift unrelated to this change, regenerate with `TRYBUILD=overwrite cargo test -p wafer-block-macro` and inspect the diff before keeping it.
+
+- [ ] **Step 8: Lint + format at CI parity**
+
+Run: `cargo +1.96.0 clippy -p wafer-block-macro --all-targets -- -D warnings`
+Expected: no warnings.
+Run: `cargo +nightly fmt`
+Expected: clean (no diff in this file after formatting; if fmt touches unrelated files, do not stage them).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git -C /home/joris/Programs/suppers-ai/workspace/wafer-run add crates/wafer-block-macro/src/lib.rs crates/wafer-block-macro/tests/skill_macro.rs
+git -C /home/joris/Programs/suppers-ai/workspace/wafer-run commit -m "feat(wafer-block-macro): accept an expression for skill(parameters)
+
+Allow #[wafer_block(skill(parameters = <expr>))] where <expr>: AsRef<str>
+yields a JSON schema string, alongside the existing string-literal form
+(which keeps its compile-time JSON validation). Lets consumers derive the
+chat schema from a single source. Validity for the expression form is
+enforced at runtime in block_info() and by tests.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+**Done when:** all `wafer-block-macro` tests pass (incl. trybuild), clippy/fmt clean. **Handoff:** open a wafer-run PR, merge to `main`, then `git -C /workspace/wafer-run checkout main && git pull` to fast-forward the local tree gizza's `.cargo` patch points at — do this only when no gizza build is in flight (shared-tree hazard). Plan 2 (block-utils foundation) depends on this being on wafer-run `main` for gizza CI (which clones wafer-run `main`).

--- a/docs/superpowers/plans/2026-06-19-shared-tool-abstraction-plan-2-block-utils-foundation.md
+++ b/docs/superpowers/plans/2026-06-19-shared-tool-abstraction-plan-2-block-utils-foundation.md
@@ -1,0 +1,763 @@
+# Shared Tool Abstraction — Plan 2: block-utils foundation (descriptor + helpers)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the single-source `ToolDescriptor` (and its surface derivations) plus the shared skill/media helper layer to `block-utils`, so a tool becomes "declare a descriptor + delegate to `core`" — no per-tool wrapper, schema, or media-orchestration copy-paste.
+
+**Architecture:** New `block-utils` module `descriptor.rs` holding `Input`/`ParamKind`/`Param`/`ToolDescriptor` (builders + `serde` + `to_schema_json()`). New helpers in `lib.rs`: `run_skill` + `respond_ok` (text shape), the media trio `resolve_source` + `dispatch_ffmpeg` + the pure `build_media_envelope`, and a shared `ArgvPlan` struct for ffmpeg page exports (a generic web-export macro proved not worth it — Task 5). This crate is consumed (path/git dep) by every tool; nothing here uses the wasm ABI directly except the wasm-gated host wrappers.
+
+**Tech Stack:** Rust, `serde`/`serde_json`, `thiserror`, `base64`, `wafer-sdk`/`wafer-block` (host calls wasm-gated).
+
+**Spec:** `docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md` §1, §4 (and the query-param §6 consumes `descriptor.json`, produced here).
+
+## Global Constraints
+
+- **Repo:** `gizza-ai`, crate `gizza-ai-block-utils` (`block-utils/`). Additive only — do not change existing public items' behavior (existing tools still compile against them until retrofit).
+- **No drift:** logical params are declared once in the descriptor; `to_schema_json()` is the single chat-schema source. Param `name` == chat-schema property == URL query-param name.
+- **Error consistency:** helpers return `Result<Vec<u8>, SkillError>`; the tool's `handle()` wraps `Ok(v) => GuestResult::respond(v)`, `Err(e) => GuestResult::error(e.into())`. (This standardizes on proper error signaling; the retrofit will drop url-encode's `{ "error": … }`-as-200 path.)
+- **Native-testable core:** descriptor logic, `to_schema_json`, `run_skill`, `respond_ok`, and `build_media_envelope` are native (`cargo test`). Host-calling helpers (`resolve_source`, `dispatch_ffmpeg`) are `#[cfg(target_arch = "wasm32")]` and are build-verified here, behavior-verified by the first media-tool retrofit (Plan 4).
+- **CI:** gizza CI = `cargo test` in `block-utils` is **not** a separate CI job today; this crate is built transitively. Add `cargo test --manifest-path block-utils/Cargo.toml` to `.github/workflows/test.yml` as part of Task 1 so the foundation is gated.
+- **wafer-run:** builds against the LOCAL wafer-run tree (`.cargo` patch) which already has Plan 1; no new wafer-run dependency is used by this plan (the expression-`parameters` feature is exercised in Plan 4).
+
+---
+
+### Task 1: Descriptor types (`Input`, `ParamKind`, `Param`, `ToolDescriptor`)
+
+**Files:**
+- Create: `block-utils/src/descriptor.rs`
+- Modify: `block-utils/src/lib.rs` (add `pub mod descriptor; pub use descriptor::*;` near the top, after the crate doc comment)
+- Modify: `.github/workflows/test.yml` (add a block-utils test step)
+- Test: in `block-utils/src/descriptor.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Produces: `Input`, `ParamKind`, `Param`, `ToolDescriptor` with the builder API below. Consumed by Task 2 (`to_schema_json`), Task 4/5, the generator (Plan 3, via `serde` JSON), and every tool's `core::descriptor()`.
+
+- [ ] **Step 1: Write the failing test** — create `block-utils/src/descriptor.rs` with the test first:
+
+```rust
+//! Single-source tool descriptor. One declaration per tool (in its `core`
+//! crate) from which the chat schema, page form, `build_argv` keying, and the
+//! URL query-param contract are all derived — see
+//! docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md.
+
+use serde::{Deserialize, Serialize};
+
+/// The binary/remote input a tool consumes. Varies by surface: chat/CLI take
+/// `url`⊕`ref`, the page takes a file upload or `?url=`. Plain text is a
+/// `String` [`Param`], not an `Input`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Input {
+    None,
+    Image,
+    Video,
+    Document,
+    File,
+}
+
+/// A logical parameter's type. Numeric bounds live on [`Param::minimum`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ParamKind {
+    String,
+    Integer,
+    Number,
+    Enum(Vec<String>),
+    Bool,
+}
+
+/// One logical parameter. `name` is the chat-schema property name, the page
+/// field name, AND the URL query-param name (single source, no drift).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Param {
+    pub name: String,
+    pub kind: ParamKind,
+    pub required: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minimum: Option<f64>,
+    pub description: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placeholder: Option<String>,
+    #[serde(default)]
+    pub multiline: bool,
+}
+
+impl Param {
+    fn new(name: &str, kind: ParamKind) -> Self {
+        Param {
+            name: name.to_string(),
+            kind,
+            required: false,
+            default: None,
+            minimum: None,
+            description: String::new(),
+            label: None,
+            placeholder: None,
+            multiline: false,
+        }
+    }
+    pub fn string(name: &str) -> Self {
+        Self::new(name, ParamKind::String)
+    }
+    pub fn integer(name: &str) -> Self {
+        Self::new(name, ParamKind::Integer)
+    }
+    pub fn number(name: &str) -> Self {
+        Self::new(name, ParamKind::Number)
+    }
+    pub fn boolean(name: &str) -> Self {
+        Self::new(name, ParamKind::Bool)
+    }
+    pub fn enumv<const N: usize>(name: &str, variants: [&str; N]) -> Self {
+        Self::new(
+            name,
+            ParamKind::Enum(variants.iter().map(|s| s.to_string()).collect()),
+        )
+    }
+    pub fn required(mut self) -> Self {
+        self.required = true;
+        self
+    }
+    pub fn default(mut self, v: impl Into<serde_json::Value>) -> Self {
+        self.default = Some(v.into());
+        self
+    }
+    pub fn min(mut self, n: f64) -> Self {
+        self.minimum = Some(n);
+        self
+    }
+    pub fn describe(mut self, s: &str) -> Self {
+        self.description = s.to_string();
+        self
+    }
+    pub fn label(mut self, s: &str) -> Self {
+        self.label = Some(s.to_string());
+        self
+    }
+    pub fn placeholder(mut self, s: &str) -> Self {
+        self.placeholder = Some(s.to_string());
+        self
+    }
+    pub fn multiline(mut self) -> Self {
+        self.multiline = true;
+        self
+    }
+}
+
+/// One declaration per tool. See module docs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolDescriptor {
+    pub input: Input,
+    pub params: Vec<Param>,
+}
+
+impl ToolDescriptor {
+    pub fn new(input: Input) -> Self {
+        ToolDescriptor {
+            input,
+            params: Vec::new(),
+        }
+    }
+    pub fn param(mut self, p: Param) -> Self {
+        self.params.push(p);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_descriptor_with_typed_params() {
+        let d = ToolDescriptor::new(Input::Image)
+            .param(Param::integer("width").min(1.0).label("Width (px)"))
+            .param(
+                Param::enumv("fit", ["contain", "cover", "stretch"])
+                    .default("contain")
+                    .describe("How to fit."),
+            );
+        assert_eq!(d.input, Input::Image);
+        assert_eq!(d.params.len(), 2);
+        assert_eq!(d.params[0].name, "width");
+        assert_eq!(d.params[0].kind, ParamKind::Integer);
+        assert_eq!(d.params[0].minimum, Some(1.0));
+        assert_eq!(d.params[1].default, Some(serde_json::json!("contain")));
+        assert_eq!(
+            d.params[1].kind,
+            ParamKind::Enum(vec!["contain".into(), "cover".into(), "stretch".into()])
+        );
+    }
+
+    #[test]
+    fn descriptor_round_trips_through_json() {
+        // The generator (Plan 3) reads an emitted descriptor.json — serde must
+        // round-trip losslessly.
+        let d = ToolDescriptor::new(Input::None)
+            .param(Param::string("expression").required().placeholder("2 + 2"));
+        let json = serde_json::to_string(&d).expect("serialize");
+        let back: ToolDescriptor = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(d, back);
+    }
+}
+```
+
+- [ ] **Step 2: Wire the module + verify the test fails**
+
+Add to `block-utils/src/lib.rs` after the crate-level doc comment / first `use`:
+
+```rust
+pub mod descriptor;
+pub use descriptor::*;
+```
+
+Run: `cargo test --manifest-path block-utils/Cargo.toml descriptor:: 2>&1 | tail -20`
+Expected: at first this **fails to compile** only if the module wiring is missing; once wired, the two tests compile and **pass** (this task is pure data types, so RED is the pre-wiring compile error). If both pass immediately after wiring, that is acceptable for plain data-type scaffolding — the meaningful RED/GREEN cycles are Tasks 2–5.
+
+- [ ] **Step 3: Add the CI gate**
+
+In `.github/workflows/test.yml`, alongside the existing `cargo test` steps, add:
+
+```yaml
+      - name: block-utils tests
+        run: cargo test --manifest-path block-utils/Cargo.toml
+```
+
+- [ ] **Step 4: Run + commit**
+
+Run: `cargo test --manifest-path block-utils/Cargo.toml descriptor:: 2>&1 | tail -10`
+Expected: `test result: ok. 2 passed`.
+
+```bash
+git -C /home/joris/Programs/suppers-ai/workspace/gizza-ai add block-utils/src/descriptor.rs block-utils/src/lib.rs .github/workflows/test.yml
+git -C /home/joris/Programs/suppers-ai/workspace/gizza-ai commit -m "feat(block-utils): ToolDescriptor/Param/Input descriptor types
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `ToolDescriptor::to_schema_json()` — derive the chat schema
+
+**Files:**
+- Modify: `block-utils/src/descriptor.rs`
+- Test: same file's `mod tests`
+
+**Interfaces:**
+- Consumes: `ToolDescriptor`, `Param`, `ParamKind`, `Input` (Task 1).
+- Produces: `pub fn to_schema_json(&self) -> String` — the JSON Schema string a tool passes to `#[wafer_block(skill(parameters = …))]` (Plan 1's expression form). Media inputs emit a `url`⊕`ref` `oneOf`; logical params become typed properties; required params go in `required`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `block-utils/src/descriptor.rs` `mod tests`:
+
+```rust
+    #[test]
+    fn schema_for_pure_text_tool() {
+        // calculator: Input::None + one required string param.
+        let d = ToolDescriptor::new(Input::None)
+            .param(Param::string("expression").required().describe("The expression."));
+        let v: serde_json::Value =
+            serde_json::from_str(&d.to_schema_json()).expect("valid JSON schema");
+        assert_eq!(v["type"], "object");
+        assert_eq!(v["properties"]["expression"]["type"], "string");
+        assert_eq!(v["properties"]["expression"]["description"], "The expression.");
+        assert_eq!(v["required"], serde_json::json!(["expression"]));
+        assert!(v.get("oneOf").is_none(), "no url/ref oneOf for Input::None");
+    }
+
+    #[test]
+    fn schema_for_media_tool_has_url_ref_oneof_and_typed_params() {
+        // image-resize: Input::Image + optional integer(min) + enum(default).
+        let d = ToolDescriptor::new(Input::Image)
+            .param(Param::integer("width").min(1.0).describe("Target width in pixels."))
+            .param(Param::integer("height").min(1.0).describe("Target height in pixels."))
+            .param(
+                Param::enumv("fit", ["contain", "cover", "stretch"])
+                    .default("contain")
+                    .describe("Resize mode."),
+            );
+        let v: serde_json::Value =
+            serde_json::from_str(&d.to_schema_json()).expect("valid JSON schema");
+        // url/ref properties + exclusive oneOf.
+        assert_eq!(v["properties"]["url"]["type"], "string");
+        assert_eq!(v["properties"]["ref"]["type"], "string");
+        assert_eq!(
+            v["oneOf"],
+            serde_json::json!([{ "required": ["url"] }, { "required": ["ref"] }])
+        );
+        // typed params.
+        assert_eq!(v["properties"]["width"]["type"], "integer");
+        assert_eq!(v["properties"]["width"]["minimum"], 1.0);
+        assert_eq!(v["properties"]["fit"]["enum"], serde_json::json!(["contain", "cover", "stretch"]));
+        assert_eq!(v["properties"]["fit"]["default"], "contain");
+        // optional params => no top-level required.
+        assert!(v.get("required").is_none());
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test --manifest-path block-utils/Cargo.toml descriptor::tests::schema 2>&1 | tail -15`
+Expected: FAIL — `no method named to_schema_json found for ToolDescriptor`.
+
+- [ ] **Step 3: Implement `to_schema_json`**
+
+Add to `impl ToolDescriptor` in `block-utils/src/descriptor.rs`:
+
+```rust
+    /// Render the chat-schema JSON for `#[wafer_block(skill(parameters = …))]`.
+    /// Single source: properties/enums/defaults/required and the media
+    /// `url`⊕`ref` `oneOf` are all derived from this descriptor.
+    pub fn to_schema_json(&self) -> String {
+        use serde_json::{json, Map, Value};
+
+        let mut properties = Map::new();
+
+        // Media/file/document tools take exactly one of `url` / `ref`.
+        let media_label = match self.input {
+            Input::Image => Some("Image"),
+            Input::Video => Some("Video"),
+            Input::Document => Some("Document"),
+            Input::File => Some("File"),
+            Input::None => None,
+        };
+        if let Some(label) = media_label {
+            properties.insert(
+                "url".into(),
+                json!({ "type": "string",
+                        "description": format!("{label} URL (HTTP/HTTPS). Use either url or ref.") }),
+            );
+            properties.insert(
+                "ref".into(),
+                json!({ "type": "string",
+                        "description": "Reference id from a prior tool call. Use either url or ref." }),
+            );
+        }
+
+        let mut required: Vec<Value> = Vec::new();
+        for p in &self.params {
+            let mut prop = Map::new();
+            match &p.kind {
+                ParamKind::String => {
+                    prop.insert("type".into(), json!("string"));
+                }
+                ParamKind::Integer => {
+                    prop.insert("type".into(), json!("integer"));
+                }
+                ParamKind::Number => {
+                    prop.insert("type".into(), json!("number"));
+                }
+                ParamKind::Bool => {
+                    prop.insert("type".into(), json!("boolean"));
+                }
+                ParamKind::Enum(variants) => {
+                    prop.insert("type".into(), json!("string"));
+                    prop.insert("enum".into(), json!(variants));
+                }
+            }
+            if let Some(m) = p.minimum {
+                prop.insert("minimum".into(), json!(m));
+            }
+            if let Some(d) = &p.default {
+                prop.insert("default".into(), d.clone());
+            }
+            if !p.description.is_empty() {
+                prop.insert("description".into(), json!(p.description));
+            }
+            properties.insert(p.name.clone(), Value::Object(prop));
+            if p.required {
+                required.push(json!(p.name));
+            }
+        }
+
+        let mut schema = Map::new();
+        schema.insert("type".into(), json!("object"));
+        schema.insert("properties".into(), Value::Object(properties));
+        if !required.is_empty() {
+            schema.insert("required".into(), Value::Array(required));
+        }
+        if media_label.is_some() {
+            schema.insert(
+                "oneOf".into(),
+                json!([{ "required": ["url"] }, { "required": ["ref"] }]),
+            );
+        }
+        Value::Object(schema).to_string()
+    }
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test --manifest-path block-utils/Cargo.toml descriptor::tests::schema 2>&1 | tail -10`
+Expected: `test result: ok. 2 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/joris/Programs/suppers-ai/workspace/gizza-ai add block-utils/src/descriptor.rs
+git -C /home/joris/Programs/suppers-ai/workspace/gizza-ai commit -m "feat(block-utils): ToolDescriptor::to_schema_json (single-source chat schema)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `run_skill` + `respond_ok` (text-shape helper)
+
+**Files:**
+- Modify: `block-utils/src/lib.rs` (add at the end, before `#[cfg(test)]` if present, else append a test module)
+- Test: `block-utils/src/lib.rs` `#[cfg(test)] mod helper_tests`
+
+**Interfaces:**
+- Consumes: `SkillError`, `SkillResultExt` (existing in lib.rs).
+- Produces:
+  - `pub fn respond_ok<T: Serialize>(value: &T) -> Result<Vec<u8>, SkillError>` — serializes `{ "result": value }`.
+  - `pub fn run_skill<A, T, F>(body: &[u8], block: &str, f: F) -> Result<Vec<u8>, SkillError>` where `A: serde::de::DeserializeOwned, T: Serialize, F: FnOnce(A) -> Result<T, SkillError>` — deserialize args (labeled via `block`), call `f`, shape `{result}`.
+  - Tool usage (documented, applied in Plan 4): `match run_skill(&body, "url-encode", |a: Args| core::convert(a)) { Ok(v) => GuestResult::respond(v), Err(e) => GuestResult::error(e.into()) }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `block-utils/src/lib.rs`:
+
+```rust
+#[cfg(test)]
+mod helper_tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Deserialize)]
+    struct EchoArgs {
+        text: String,
+    }
+    #[derive(Serialize)]
+    struct EchoOut {
+        echo: String,
+    }
+
+    #[test]
+    fn run_skill_shapes_result_on_ok() {
+        let body = br#"{"text":"hi"}"#;
+        let out = run_skill(body, "echo", |a: EchoArgs| {
+            Ok::<_, SkillError>(EchoOut { echo: a.text })
+        })
+        .expect("ok path");
+        let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(v["result"]["echo"], "hi");
+    }
+
+    #[test]
+    fn run_skill_labels_bad_json_as_invalid_args() {
+        let body = br#"{ not json"#;
+        let err = run_skill(body, "echo", |a: EchoArgs| {
+            Ok::<_, SkillError>(EchoOut { echo: a.text })
+        })
+        .expect_err("bad json must error");
+        assert!(matches!(err, SkillError::InvalidArgs(_)));
+        assert!(err.to_string().contains("invalid echo args"));
+    }
+
+    #[test]
+    fn run_skill_propagates_inner_error() {
+        let body = br#"{"text":"x"}"#;
+        let err = run_skill(body, "echo", |_a: EchoArgs| {
+            Err::<EchoOut, _>(SkillError::InvalidArgs("nope".into()))
+        })
+        .expect_err("inner error propagates");
+        assert!(matches!(err, SkillError::InvalidArgs(_)));
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test --manifest-path block-utils/Cargo.toml helper_tests 2>&1 | tail -15`
+Expected: FAIL — `cannot find function run_skill` / `respond_ok`.
+
+- [ ] **Step 3: Implement the helpers**
+
+Append to `block-utils/src/lib.rs` (module scope, not inside the test module):
+
+```rust
+// ---------------------------------------------------------------------------
+// Text-shape skill helper. Returns Result<Vec<u8>, SkillError>; the tool's
+// wasm `handle()` wraps Ok => GuestResult::respond, Err => GuestResult::error.
+// ---------------------------------------------------------------------------
+
+/// Serialize a success payload as `{ "result": <value> }`.
+pub fn respond_ok<T: serde::Serialize>(value: &T) -> Result<Vec<u8>, SkillError> {
+    serde_json::to_vec(&serde_json::json!({ "result": value }))
+        .map_err(|e| SkillError::Serialize(format!("serialize result: {e}")))
+}
+
+/// Run a text-shape skill: parse `A` from `body` (errors labeled
+/// `invalid <block> args: …`), call `f`, and shape `{ "result": … }`.
+pub fn run_skill<A, T, F>(body: &[u8], block: &str, f: F) -> Result<Vec<u8>, SkillError>
+where
+    A: serde::de::DeserializeOwned,
+    T: serde::Serialize,
+    F: FnOnce(A) -> Result<T, SkillError>,
+{
+    let args: A = serde_json::from_slice(body).invalid_args(block)?;
+    let out = f(args)?;
+    respond_ok(&out)
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test --manifest-path block-utils/Cargo.toml helper_tests 2>&1 | tail -10`
+Expected: `test result: ok. 3 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/joris/Programs/suppers-ai/workspace/gizza-ai add block-utils/src/lib.rs
+git -C /home/joris/Programs/suppers-ai/workspace/gizza-ai commit -m "feat(block-utils): run_skill + respond_ok text-shape helper
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Media helpers — pure `build_media_envelope` + wasm `resolve_source`/`dispatch_ffmpeg`
+
+**Files:**
+- Modify: `block-utils/Cargo.toml` (add `base64`)
+- Modify: `block-utils/src/lib.rs`
+- Test: `block-utils/src/lib.rs` `mod helper_tests`
+
+**Interfaces:**
+- Consumes: `Source`, `AssetKind`, `fetch_from_url`, `load_from_attachment`, `FfmpegReq`, `FfmpegResp`, `dispatch_ffmpeg_runtime`, `Envelope`, `ForUi`, `SkillError` (existing).
+- Produces:
+  - `pub fn build_media_envelope(out_bytes: &[u8], mime: &str, filename: String, for_llm: String, max_out: usize) -> Result<Vec<u8>, SkillError>` — **pure** (base64 → `data:` URL → `Envelope` → bytes, with the output size cap). Native-testable.
+  - `#[cfg(target_arch = "wasm32")] pub fn resolve_source(source: Source, kind: AssetKind, max_in: usize) -> Result<(Vec<u8>, String, String), SkillError>` — the `match`-on-`Source` every media tool repeats.
+  - `#[cfg(target_arch = "wasm32")] pub fn dispatch_ffmpeg(argv: Vec<String>, in_name: String, in_bytes: Vec<u8>, out_name: String) -> Result<Vec<u8>, SkillError>` — build `FfmpegReq`, dispatch, check exit code, return output bytes.
+
+- [ ] **Step 1: Add the `base64` dependency**
+
+In `block-utils/Cargo.toml` `[dependencies]`, add (match the version the image tools already use — confirm with `grep -h '^base64' blocks/image-*/Cargo.toml | head -1`; use that exact version, e.g.):
+
+```toml
+base64 = "0.22"
+```
+
+- [ ] **Step 2: Write the failing test (pure helper)**
+
+Add to `block-utils/src/lib.rs` `mod helper_tests`:
+
+```rust
+    #[test]
+    fn build_media_envelope_emits_data_url_and_caps_size() {
+        let bytes = b"\x89PNG\r\n\x1a\n";
+        let out = build_media_envelope(bytes, "image/png", "cat-resized.png".into(), "resized cat".into(), 1024)
+            .expect("under cap");
+        let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(v["for_llm"], "resized cat");
+        assert_eq!(v["for_ui"]["mime"], "image/png");
+        assert_eq!(v["for_ui"]["filename"], "cat-resized.png");
+        let data_url = v["for_ui"]["data_url"].as_str().unwrap();
+        assert!(data_url.starts_with("data:image/png;base64,"));
+
+        let err = build_media_envelope(bytes, "image/png", "x.png".into(), "x".into(), 4)
+            .expect_err("over cap");
+        assert!(matches!(err, SkillError::TooLarge { .. }));
+    }
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `cargo test --manifest-path block-utils/Cargo.toml helper_tests::build_media_envelope 2>&1 | tail -12`
+Expected: FAIL — `cannot find function build_media_envelope`.
+
+- [ ] **Step 4: Implement the media helpers**
+
+Append to `block-utils/src/lib.rs` (module scope):
+
+```rust
+// ---------------------------------------------------------------------------
+// Media helpers. `build_media_envelope` is pure (native-testable); the source
+// resolver and ffmpeg dispatcher call host imports and are wasm-only.
+// ---------------------------------------------------------------------------
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+
+/// Encode `out_bytes` (enforcing `max_out`) as a `data:` URL and wrap it in the
+/// standard image/video `Envelope` (`for_llm` summary + `for_ui` data URL).
+pub fn build_media_envelope(
+    out_bytes: &[u8],
+    mime: &str,
+    filename: String,
+    for_llm: String,
+    max_out: usize,
+) -> Result<Vec<u8>, SkillError> {
+    if out_bytes.len() > max_out {
+        return Err(SkillError::TooLarge {
+            kind: "output",
+            bytes: out_bytes.len(),
+            cap: max_out,
+        });
+    }
+    let data_url = format!("data:{mime};base64,{}", B64.encode(out_bytes));
+    let env = Envelope {
+        for_llm,
+        for_ui: ForUi {
+            data_url,
+            mime: mime.to_string(),
+            filename,
+        },
+    };
+    serde_json::to_vec(&env).map_err(|e| SkillError::Serialize(format!("serialize envelope: {e}")))
+}
+
+/// Resolve a `Source` to `(bytes, mime, filename)` — the `url` fetch vs `ref`
+/// attachment branch every media tool repeats.
+#[cfg(target_arch = "wasm32")]
+pub fn resolve_source(
+    source: Source,
+    kind: AssetKind,
+    max_in: usize,
+) -> Result<(Vec<u8>, String, String), SkillError> {
+    match source {
+        Source::Url(u) => fetch_from_url(&u, kind, max_in),
+        Source::Ref(id) => load_from_attachment(&id, kind, max_in),
+    }
+}
+
+/// Run one ffmpeg-runtime call and return the output bytes, mapping a non-zero
+/// exit to `SkillError::FfmpegExitNonZero` (200-char log snippet).
+#[cfg(target_arch = "wasm32")]
+pub fn dispatch_ffmpeg(
+    argv: Vec<String>,
+    in_name: String,
+    in_bytes: Vec<u8>,
+    out_name: String,
+) -> Result<Vec<u8>, SkillError> {
+    let req = FfmpegReq {
+        args: argv,
+        inputs: vec![(in_name, in_bytes)],
+        output: out_name,
+    };
+    let req_body = serde_json::to_vec(&req)
+        .map_err(|e| SkillError::Serialize(format!("serialize ffmpeg request: {e}")))?;
+    let resp_bytes = dispatch_ffmpeg_runtime(&req_body)?;
+    let ff: FfmpegResp = serde_json::from_slice(&resp_bytes)
+        .map_err(|e| SkillError::Serialize(format!("malformed ffmpeg response: {e}")))?;
+    if ff.exit_code != 0 {
+        return Err(SkillError::FfmpegExitNonZero {
+            exit: ff.exit_code,
+            snippet: ff.log.chars().take(200).collect(),
+        });
+    }
+    Ok(ff.output)
+}
+```
+
+- [ ] **Step 5: Run the pure test to verify pass + build for wasm**
+
+Run: `cargo test --manifest-path block-utils/Cargo.toml helper_tests::build_media_envelope 2>&1 | tail -10`
+Expected: `test result: ok. 1 passed`.
+Run (verify the wasm-gated helpers compile for the real target):
+`cargo build --manifest-path block-utils/Cargo.toml --target wasm32-unknown-unknown 2>&1 | tail -8`
+Expected: `Finished` (no errors). (If `wasm32-unknown-unknown` is missing: `rustup target add wasm32-unknown-unknown`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /home/joris/Programs/suppers-ai/workspace/gizza-ai add block-utils/Cargo.toml block-utils/Cargo.lock block-utils/src/lib.rs
+git -C /home/joris/Programs/suppers-ai/workspace/gizza-ai commit -m "feat(block-utils): media helpers (build_media_envelope/resolve_source/dispatch_ffmpeg)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Shared `ArgvPlan` struct (and dropping `gizza_web_export!`)
+
+**Decision (evidence-based):** the spec floated a `gizza_web_export!` macro, but the
+current web export is **tool-specifically typed** —
+`blocks/image-resize/web/src/lib.rs` exports
+`build_argv(width: f64, height: f64, fit: &str, in_name: &str) -> Result<JsValue, JsValue>`.
+Each ffmpeg tool's fields differ, so a generic `macro_rules!` can't capture the
+signature without the caller re-stating it (no saving), and `wasm-bindgen`
+requires concrete typed params (not a generic `JsValue` map). So **no macro.** The
+one genuinely shared piece is the per-tool `#[derive(Serialize)] struct Plan { argv, out_name }`
+duplicated in every ffmpeg web crate — promote it to `block-utils::ArgvPlan`. Web
+wrappers keep their ~10-line typed body (it forwards to `core`; that's the right
+amount of explicitness).
+
+**Files:**
+- Modify: `block-utils/src/lib.rs`
+- Test: `block-utils/src/lib.rs` `mod helper_tests`
+
+**Interfaces:**
+- Produces: `pub struct ArgvPlan { pub argv: Vec<String>, pub out_name: String }` (`Serialize`). Consumed (Plan 4) by each ffmpeg tool's `web/src/lib.rs`, which builds it from `core` and returns `serde_wasm_bindgen::to_value(&plan)` — replacing the per-tool `struct Plan`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `block-utils/src/lib.rs` `mod helper_tests`:
+
+```rust
+    #[test]
+    fn argv_plan_serializes_to_argv_and_out_name() {
+        let plan = ArgvPlan {
+            argv: vec!["-i".into(), "in.png".into()],
+            out_name: "out.png".into(),
+        };
+        let v = serde_json::to_value(&plan).unwrap();
+        assert_eq!(v["argv"], serde_json::json!(["-i", "in.png"]));
+        assert_eq!(v["out_name"], "out.png");
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cargo test --manifest-path block-utils/Cargo.toml helper_tests::argv_plan 2>&1 | tail -12`
+Expected: FAIL — `cannot find type ArgvPlan`.
+
+- [ ] **Step 3: Implement `ArgvPlan`**
+
+Append to `block-utils/src/lib.rs` (module scope):
+
+```rust
+/// The result an ffmpeg page tool's `build_argv` returns to the JS page driver:
+/// the ffmpeg argument vector plus the output filename. Shared so every web
+/// wrapper stops redefining an identical local `struct Plan`.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ArgvPlan {
+    pub argv: Vec<String>,
+    pub out_name: String,
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `cargo test --manifest-path block-utils/Cargo.toml helper_tests::argv_plan 2>&1 | tail -10`
+Expected: `test result: ok. 1 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/joris/Programs/suppers-ai/workspace/gizza-ai add block-utils/src/lib.rs
+git -C /home/joris/Programs/suppers-ai/workspace/gizza-ai commit -m "feat(block-utils): shared ArgvPlan struct for ffmpeg page exports
+
+Drops the speculative gizza_web_export! macro (web exports are per-tool typed;
+a generic macro can't capture them) in favor of sharing the one duplicated
+piece — the { argv, out_name } plan struct.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the whole crate suite: `cargo test --manifest-path block-utils/Cargo.toml 2>&1 | tail -15` → all pass.
+- [ ] Build for wasm: `cargo build --manifest-path block-utils/Cargo.toml --target wasm32-unknown-unknown 2>&1 | tail -5` → `Finished`.
+- [ ] Sanity: existing tools still compile against the unchanged public items — `cargo build --manifest-path blocks/image-resize/Cargo.toml --target wasm32-unknown-unknown 2>&1 | tail -5` → `Finished` (no behavior of existing exports changed; only additions).
+
+**Done when:** the foundation is in `block-utils` with green tests, wasm build clean, and no existing tool broken. **Handoff:** Plan 3 (generator + page runtime + docs) consumes `descriptor.json` (the serde from Task 1) and `to_schema_json`/`to_page_inputs` — note: `to_page_inputs()` is **generator-side** (Plan 3) reading the serialized descriptor, so it is *not* in this plan. Plan 4 (retrofit) wires `core::descriptor()`/`core::schema_json()` (Plan 1's expr `parameters`) and replaces each tool's `handle`/orchestration with these helpers (and `ArgvPlan` in the web crates) — that retrofit is what behavior-verifies `resolve_source`/`dispatch_ffmpeg`.

--- a/docs/superpowers/plans/2026-06-19-shared-tool-abstraction-plan-3-query-param-deeplinks.md
+++ b/docs/superpowers/plans/2026-06-19-shared-tool-abstraction-plan-3-query-param-deeplinks.md
@@ -1,0 +1,339 @@
+# Shared Tool Abstraction — Plan 3: query-param deep-linking + auto-run + docs
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every tool page can be opened pre-filled and auto-run via URL query parameters named by the tool's inputs — e.g. `/tools/calculator/?expr=2%2B2*3` shows the result immediately; media tools accept `?url=` to fetch and run. The accepted params + an example deep-link are documented on the page and in the markdown twin so LLMs can drive tools by URL.
+
+**Architecture:** Pure additions to the existing page runtime — the generator already emits `window.GIZZA_TOOL` (input names + elementIds) and `site/tool.js` drives the page from it, so query-params need only (1) a small pure `queryPrefill` helper, (2) wiring it into `tool.js`'s two paths (pure-text auto-run; ffmpeg field-prefill + `?url=` fetch), and (3) the two doc generators. **No descriptor dependency.**
+
+**Tech Stack:** Vanilla ES modules (`site/*.js`), Rust generator (maud + plain string for markdown), Playwright (headless, per the build-notes caveat).
+
+**Spec:** `docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md` §6.
+
+## Re-sequencing note (from the code map)
+
+The spec's Plan 3 also bundled "generator derives the page form from `descriptor.json` (replacing `meta.toml [[input]]`) + slim `meta.toml`." The code map shows the generator already builds the page + `window.GIZZA_TOOL` from `meta.toml`'s `[[input]]`, and the query-param feature works on that existing config. The descriptor-derived page form requires every page tool to have a `core::descriptor()` (i.e. the retrofit), so it is **moved into Plan 4** (where each tool gains its descriptor and emits `descriptor.json`; the generator then sources `[[input]]` from the descriptor and `meta.toml` slims to chrome). Plan 3 ships the user-facing deep-link feature now; the query-param names are the input names either way, so nothing here changes when Plan 4 lands.
+
+## Global Constraints
+
+- **Repo:** `gizza-ai`. Query-param names == input `name` from `window.GIZZA_TOOL` (== `meta.toml [[input]].name`). `source="clock"` inputs are never query-params; `source="file"` inputs are driven by `?url=`.
+- **No magic:** the same input `name` is the page field id suffix, the chat-schema property, and the URL query param (consistent with the descriptor design).
+- **Auto-run:** pure-text tools auto-run once prefilled (reusing the existing initial `compute()`); media tools auto-run only when `?url=` resolves to a file (scalar-only query just prefills and waits).
+- **`?url=` is best-effort:** cross-origin fetch may be blocked; on failure show a clear, non-fatal message and fall back to manual upload. Never a broken state.
+- **CI:** gizza CI runs `cargo test` (generator suite included) + a Node test step (`js/*.test.js`). Playwright `tests/fixtures.ts` throws on import in this env (pre-existing) — verify pages with a standalone `@playwright/test` headless spec serving the built `pkg/tools/<slug>/` (see `docs/checks/2026-06-18-gizza-new-tool-build-notes.md` "Playwright").
+
+---
+
+### Task 1: Pure `queryPrefill` helper + Node unit test + generator copies it
+
+**Files:**
+- Create: `site/query-prefill.js`
+- Create: `js/query-prefill.test.js`
+- Modify: `tools/generator/src/main.rs` (copy `query-prefill.js` into each `pkg/tools/<slug>/`)
+- Test: `js/query-prefill.test.js`
+
+**Interfaces:**
+- Produces: `export function queryPrefill(inputs, searchString) -> { fields: [{elementId, value}], url: string|null }`. `inputs` is `cfg.inputs` (each `{name, source, elementId}`). Consumed by `tool.js` (Tasks 2-3). Pure (no DOM/window) → Node-testable.
+
+- [ ] **Step 1: Write the failing test** — `js/query-prefill.test.js`:
+
+```js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { queryPrefill } from "../site/query-prefill.js";
+
+const inputs = [
+  { name: "expr", source: "field", elementId: "in-expr" },
+  { name: "mode", source: "field", elementId: "in-mode" },
+  { name: "unix", source: "clock", elementId: "in-unix" },
+  { name: "image", source: "file", elementId: "in-image" },
+];
+
+test("prefills only field inputs present in the query", () => {
+  const r = queryPrefill(inputs, "?expr=2%2B2&mode=decode&unix=123&nope=x");
+  assert.deepEqual(r.fields, [
+    { elementId: "in-expr", value: "2+2" },
+    { elementId: "in-mode", value: "decode" },
+  ]);
+  assert.equal(r.url, null); // no ?url= given; clock ignored; unknown ignored
+});
+
+test("captures ?url= for media tools", () => {
+  const r = queryPrefill(inputs, "?url=https%3A%2F%2Fx.test%2Fcat.jpg&fit=cover");
+  assert.equal(r.url, "https://x.test/cat.jpg");
+  assert.deepEqual(r.fields, []); // 'fit' isn't a declared input here
+});
+
+test("empty search yields nothing", () => {
+  const r = queryPrefill(inputs, "");
+  assert.deepEqual(r.fields, []);
+  assert.equal(r.url, null);
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `node --test js/query-prefill.test.js 2>&1 | tail -15`
+Expected: FAIL — cannot find module `../site/query-prefill.js`.
+
+- [ ] **Step 3: Implement `site/query-prefill.js`**
+
+```js
+// Pure URL-query → field-value mapping for tool pages. No DOM/window access so
+// it is Node-unit-testable; tool.js applies the result to the page.
+export function queryPrefill(inputs, searchString) {
+  const params = new URLSearchParams(searchString || "");
+  const fields = [];
+  for (const inp of inputs || []) {
+    if (inp.source === "field") {
+      const v = params.get(inp.name);
+      if (v != null) fields.push({ elementId: inp.elementId, value: v });
+    }
+  }
+  return { fields, url: params.get("url") };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `node --test js/query-prefill.test.js 2>&1 | tail -10`
+Expected: `# pass 3`.
+
+- [ ] **Step 5: Make the generator copy it to each tool page**
+
+In `tools/generator/src/main.rs`, in the per-tool copy block (alongside `copy_file(&root.join("site/tool.js"), &out.join("tool.js"))?;`), add:
+
+```rust
+        copy_file(&root.join("site/query-prefill.js"), &out.join("query-prefill.js"))?;
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /home/joris/Programs/suppers-ai/workspace/gizza-ai add site/query-prefill.js js/query-prefill.test.js tools/generator/src/main.rs
+git -C /home/joris/Programs/suppers-ai/workspace/gizza-ai commit -m "feat(tools): queryPrefill helper + generator copies it to each page
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Wire prefill + auto-run into `tool.js` (pure-text path)
+
+**Files:**
+- Modify: `site/tool.js`
+- Test: `tests/tool-page-query-params.spec.ts` (committed for the repo) + a standalone headless verification
+
+**Interfaces:**
+- Consumes: `queryPrefill` (Task 1). On load, prefills `field` inputs from `location.search` before the existing initial `compute()` (which then auto-runs and renders).
+
+- [ ] **Step 1: Add the import** at the top of `site/tool.js`:
+
+```js
+import { queryPrefill } from "./query-prefill.js";
+```
+
+- [ ] **Step 2: Prefill before the initial compute()**
+
+In the non-ffmpeg path, immediately BEFORE the wiring/initial-compute block (the code at lines ~117-131 that wires `input` listeners and calls `compute()`), insert:
+
+```js
+  // Deep-link: prefill fields from the URL query, then the initial compute()
+  // below auto-runs with those values. Param names == input names.
+  for (const f of queryPrefill(cfg.inputs, location.search).fields) {
+    const el = document.getElementById(f.elementId);
+    if (el) el.value = f.value;
+  }
+```
+
+(The existing `for (const inp of cfg.inputs) { if field … addEventListener("input", compute) }` and the trailing `compute()` are unchanged — prefilling before them makes the initial `compute()` render the deep-linked result.)
+
+- [ ] **Step 3: Commit a Playwright spec following the repo pattern**
+
+Create `tests/tool-page-query-params.spec.ts` mirroring an existing `tests/tool-page-*.spec.ts` (same import of `tests/fixtures.ts`, same python `webServer` serving the built `pkg/`). Assert: navigating `/tools/calculator/?expr=2%2B2*3` (use calculator's real input name — confirm via `blocks/calculator/page/meta.toml`) results in `#tool-output` containing the computed value; and `/tools/url-encode/?text=a%20b&mode=encode` yields the encoded output.
+
+- [ ] **Step 4: Verify yourself (standalone headless — the repo `fixtures.ts` is broken)**
+
+Per the build-notes: build the pages, then drive them with a standalone `@playwright/test` headless spec + a tiny temp config serving `pkg/`. Concretely:
+```
+# build calculator + url-encode pages
+bash -c 'cd /home/joris/Programs/suppers-ai/workspace/gizza-ai && wasm-pack build blocks/calculator/web --target web --release --out-dir pkg'
+bash -c 'cd /home/joris/Programs/suppers-ai/workspace/gizza-ai && wasm-pack build blocks/url-encode/web --target web --release --out-dir pkg'
+# (build every page block's web/pkg, then:) cargo run --manifest-path tools/generator/Cargo.toml -- .
+```
+Then a temp spec navigates `http://localhost:PORT/tools/calculator/?expr=2%2B2*3` and asserts `#tool-output` text is `8`. Remove temp files after. Record the actual observed output in the commit/PR.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C /home/joris/Programs/suppers-ai/workspace/gizza-ai add site/tool.js tests/tool-page-query-params.spec.ts
+git -C /home/joris/Programs/suppers-ai/workspace/gizza-ai commit -m "feat(tools): query-param prefill + auto-run on pure-text tool pages
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: ffmpeg path — field prefill + `?url=` fetch + CORS fallback
+
+**Files:**
+- Modify: `site/tool.js` (the `cfg.runtime === "ffmpeg"` branch, ~lines 46-96)
+- Test: extend the standalone headless verification (Task 2) for a media tool
+
+**Interfaces:**
+- Consumes: `queryPrefill`. Prefills `field` inputs; if `?url=` present, fetches it into the file input and triggers `run()`. On fetch/CORS failure, calls `showError(...)` with the documented message and leaves the manual file input usable.
+
+- [ ] **Step 1: Add a fetch-into-file-input helper + prefill + auto-run**
+
+In the ffmpeg branch of `site/tool.js`, after `fieldInputs`/`fileInput` are resolved and `run()` is defined (and before/replacing the final event wiring), insert:
+
+```js
+  // Deep-link: prefill scalar fields from the query.
+  const { fields: qpFields, url: qpUrl } = queryPrefill(cfg.inputs, location.search);
+  for (const f of qpFields) {
+    const el = document.getElementById(f.elementId);
+    if (el) el.value = f.value;
+  }
+
+  // ?url= → fetch the remote media into the file input, then auto-run.
+  async function loadUrlIntoFile(url) {
+    try {
+      const resp = await fetch(url);
+      if (!resp.ok) throw new Error("HTTP " + resp.status);
+      const blob = await resp.blob();
+      const name = (url.split("/").pop() || "input").split("?")[0] || "input";
+      const dt = new DataTransfer();
+      dt.items.add(new File([blob], name, { type: blob.type }));
+      fileInput.files = dt.files;
+      return true;
+    } catch (e) {
+      showError(
+        "Couldn't fetch " + url + " — the host may block cross-origin access. " +
+        "Download it and choose the file instead."
+      );
+      return false;
+    }
+  }
+  if (qpUrl && fileInput) {
+    loadUrlIntoFile(qpUrl).then((ok) => { if (ok) run(); });
+  }
+```
+
+(The existing `fileInput.addEventListener("change", run)` and field `input` listeners remain — manual use still works, and a successful `?url=` fetch triggers `run()` directly.)
+
+- [ ] **Step 2: Verify (standalone headless)**
+
+Build a media page (e.g. `image-resize`) and drive `…/tools/image-resize/?width=64&url=<same-origin-fixture-image>` — assert `#tool-output-media` becomes visible with a `data:` src. For the CORS path, point `?url=` at a host that blocks CORS and assert `#tool-output` shows the fallback message and `#tool-output-media` stays hidden. Use a fixture image served by the same temp `webServer` for the success case to avoid external flakiness. Record observed results.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /home/joris/Programs/suppers-ai/workspace/gizza-ai add site/tool.js
+git -C /home/joris/Programs/suppers-ai/workspace/gizza-ai commit -m "feat(tools): ?url= deep-link fetch + field prefill on ffmpeg tool pages
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Document the query params — markdown twin + page section
+
+**Files:**
+- Modify: `tools/generator/src/markdown.rs` (`tool_markdown`)
+- Modify: `tools/generator/src/template.rs` (`render_page`)
+- Test: `tools/generator/` test suite (add tests, or extend existing)
+
+**Interfaces:**
+- Produces: a "Query parameters" section in `index.md` and a "Use via URL" section on the page, both listing the field params (+ `url` for media) and a concrete example deep-link, derived from `meta.inputs`.
+
+- [ ] **Step 1: Write the failing generator test**
+
+In the generator's test module (find it: `grep -rn "#\[cfg(test)\]" tools/generator/src/`), add a test that builds a `ToolMeta` with two `field` inputs and asserts `tool_markdown(&meta, "")` contains `"## Query parameters"`, each param name, and an example URL containing `/tools/<slug>/?`. (Mirror how existing generator tests construct a `ToolMeta` — reuse their helper/fixture.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test --manifest-path tools/generator/Cargo.toml query 2>&1 | tail -12`
+Expected: FAIL — the section/string is absent.
+
+- [ ] **Step 3: Add an `example_deeplink` helper + the markdown section**
+
+In `tools/generator/src/markdown.rs`, add a helper and a section. Insert the section between the "## Output" block and the `"---\n\n"` separator in `tool_markdown`:
+
+```rust
+fn example_deeplink(meta: &ToolMeta) -> String {
+    let mut pairs: Vec<String> = Vec::new();
+    for i in &meta.inputs {
+        if i.source == "file" {
+            pairs.push("url=https://example.com/input".to_string());
+        } else if i.source == "field" {
+            let sample = if i.placeholder.is_empty() { "value" } else { &i.placeholder };
+            pairs.push(format!("{}={}", i.name, urlencode(sample)));
+        }
+    }
+    format!("{}/tools/{}/?{}", SITE, meta.slug, pairs.join("&"))
+}
+
+/// Minimal percent-encoding for example URLs (space, &, =, +, non-ASCII).
+fn urlencode(s: &str) -> String {
+    let mut out = String::new();
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+```
+
+Then in `tool_markdown`, before the `"---\n\n"` line:
+
+```rust
+    let qp: Vec<&Input> = meta.inputs.iter().filter(|i| i.source == "field").collect();
+    let has_file = meta.inputs.iter().any(|i| i.source == "file");
+    if !qp.is_empty() || has_file {
+        s.push_str("## Query parameters\n\n");
+        s.push_str("Open the tool pre-filled and auto-run via URL:\n\n");
+        for i in &qp {
+            let label = if i.label.is_empty() { i.name.as_str() } else { i.label.as_str() };
+            s.push_str(&format!("- `{}` — {}\n", i.name, label));
+        }
+        if has_file {
+            s.push_str("- `url` — fetch the input file from a public URL (CORS-permitting)\n");
+        }
+        s.push_str(&format!("\nExample: `{}`\n\n", example_deeplink(meta)));
+    }
+```
+
+(Confirm `SITE` is in scope in `markdown.rs` — the map shows it is, used by the "## Run it" web URL.)
+
+- [ ] **Step 4: Add the page "Use via URL" section**
+
+In `tools/generator/src/template.rs` `render_page`, after the inputs/output block and before the prose/content section, add a maud block rendering the same param list + example (reuse `example_deeplink` — make it `pub(crate)` in `markdown.rs` and `use` it, or duplicate the tiny logic in `template.rs`; prefer the shared `pub(crate)` import to avoid drift). Render a `<details>`/section with a copyable `<code>` example. Keep it visually minor (it's a power-user/AI affordance).
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `cargo test --manifest-path tools/generator/Cargo.toml 2>&1 | tail -12`
+Expected: all generator tests pass, including the new query-params test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /home/joris/Programs/suppers-ai/workspace/gizza-ai add tools/generator/src/markdown.rs tools/generator/src/template.rs
+git -C /home/joris/Programs/suppers-ai/workspace/gizza-ai commit -m "feat(tools): document query-param deep-links in index.md + on the page
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+- [ ] `node --test js/query-prefill.test.js` → pass.
+- [ ] `cargo test --manifest-path tools/generator/Cargo.toml` → pass.
+- [ ] Standalone headless: `/tools/calculator/?expr=2%2B2*3` auto-renders the result; a media tool `?url=<fixture>` fetches+runs; `?url=<cors-blocked>` shows the fallback message. Record observed output.
+- [ ] Built `pkg/tools/<slug>/` contains `query-prefill.js` (generator copy) and `index.md` has the "Query parameters" section.
+
+**Done when:** deep-linking works on a pure tool and a media tool, the docs are generated, and the generator + JS tests are green. **Handoff:** Plan 4 (retrofit) gives each tool a `core::descriptor()`, wires Plan 1's expr `parameters` + Plan 2's helpers, emits `descriptor.json`, and switches the generator to source `[[input]]` from the descriptor (slimming `meta.toml`) — query-params keep working unchanged because the names are identical.

--- a/docs/superpowers/plans/2026-06-19-shared-tool-abstraction-plan-4-retrofit.md
+++ b/docs/superpowers/plans/2026-06-19-shared-tool-abstraction-plan-4-retrofit.md
@@ -1,0 +1,169 @@
+# Shared Tool Abstraction — Plan 4: retrofit all ~25 tools (recipe + batched rollout)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. This plan is a **recipe applied per tool**, not 25 hand-written task specs — each tool follows the matching shape recipe below, exemplar-first then batched.
+
+**Goal:** Convert every tool to the single-source abstraction: a `core::descriptor()` drives the chat schema (via Plan 1's `parameters = core::schema_json()`), and the per-tool wrapper/orchestration collapses into Plan 2's helpers (`run_skill`, `respond_ok`, `build_media_envelope`, `resolve_source`, `dispatch_ffmpeg`, `ArgvPlan`). Less code, one schema source, uniform errors — across all tools.
+
+**Architecture:** Per tool, edit `core` (add `descriptor()` + `schema_json()`), `src/lib.rs` (delete the inline JSON schema + hand-written `handle`/`respond_error`; delegate to helpers), and `web/src/lib.rs` (use `ArgvPlan` for ffmpeg). A **drift-guard test** per tool asserts the derived schema matches the current authored schema so LLM tool-calling quality is preserved.
+
+**Tech Stack:** Rust (block crates + block-utils), the Plan 1 macro feature, Plan 2 helpers.
+
+**Spec:** `docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md` §1/§4 (retrofit) + the migration-safety gate.
+
+## Prerequisites (DONE)
+
+- Plan 1 on **origin** wafer-run main (`48926f4`), Plan 2 + Plan 3 on **origin** gizza main (`b3bb642`). So retrofit PRs' gizza CI (clones wafer-run main, builds gizza) has the macro feature + helpers. ✅ pushed 2026-06-19.
+
+## Scope decision (read before executing)
+
+This plan does the **chat-side** retrofit (the bulk of the code reduction + the single-source chat schema) and **keeps `meta.toml [[input]]` as the page-form source**, guarded by a per-tool test that the page inputs stay consistent with `core::descriptor()`. 
+
+**Deferred to Plan 4b (optional):** fully eliminating `meta.toml [[input]]` by having the generator render the page form from an emitted `descriptor.json`. That needs a descriptor.json-emission mechanism (per-tool `build.rs` writing the file, or a small workspace binary) + a generator rewrite. It removes the *remaining* page-side duplication but is mechanically heavier and not required for the chat-schema single-sourcing or the code reduction. **Decide 4b after 4 lands** — the drift-guard test below keeps page↔descriptor honest in the meantime, so there is no correctness gap.
+
+## Global Constraints
+
+- **Repo:** `gizza-ai`. One PR per batch (~4–6 tools), worktree-per-batch (the build-program pattern; see the build-notes + [[workflow-durability-protocol]]).
+- **Migration safety (hard gate):** for each tool, the schema produced by `core::schema_json()` must be **semantically equal** to that tool's *current* authored `parameters` JSON (same property names, types, enums, defaults, `required`, and the `url`⊕`ref` `oneOf`). A per-tool test asserts this. Descriptions may be reworded only intentionally.
+- **Error unification:** replace any `{ "error": … }`-as-200 path (e.g. url-encode's `respond_error`) with `Err(SkillError) → GuestResult::error(e.into())`.
+- **Additive-only to shared crates:** do not change `block-utils` public items here (Plan 2 is frozen); only consume them.
+- **Per-tool tests stay green:** existing `core`/block unit tests + the tool's behavior must be unchanged.
+
+## The drift-guard / migration test (every tool)
+
+In each tool's `core` (native-testable), add:
+
+```rust
+#[test]
+fn schema_json_matches_authored_chat_schema() {
+    // Paste the tool's CURRENT authored `parameters` JSON here verbatim.
+    let authored: serde_json::Value = serde_json::from_str(r#"{ …current schema… }"#).unwrap();
+    let derived: serde_json::Value = serde_json::from_str(&descriptor().to_schema_json()).unwrap();
+    assert_eq!(derived, authored, "derived schema must match the authored one (no LLM-facing drift)");
+}
+```
+
+Author `descriptor()` until this passes — that *is* the proof the migration is lossless. (Object key order is irrelevant: `serde_json::Value` compares maps structurally.)
+
+---
+
+## Recipe P — pure-text tool (exemplar: `url-encode`)
+
+**Before** (`blocks/url-encode/src/lib.rs`): an `Args` struct, a big inline `parameters` JSON literal in `#[wafer_block(skill(...))]`, a `handle` that matches Ok/Err, and a re-defined `respond_error` returning `{error}` as a 200.
+
+**After:**
+
+1. **`core/src/lib.rs`** — add:
+
+```rust
+use gizza_ai_block_utils::{ToolDescriptor, Input, Param};
+
+pub fn descriptor() -> ToolDescriptor {
+    ToolDescriptor::new(Input::None)
+        .param(Param::string("text").required()
+            .describe("The text or URL to encode or decode."))
+        .param(Param::enumv("mode", ["encode", "decode"]).default("encode")
+            .describe("Direction: 'encode' (default) percent-encodes, 'decode' reverses it."))
+        .param(Param::enumv("target", ["component", "uri"]).default("component")
+            .describe("Encode mode only: 'component' (default) escapes reserved chars for a single value; 'uri' preserves URL delimiters. Ignored when decoding."))
+}
+
+pub fn schema_json() -> String { descriptor().to_schema_json() }
+```
+…then the drift-guard test (paste url-encode's current authored schema).
+
+2. **`src/lib.rs`** — replace the body with:
+
+```rust
+#[wafer_block(
+    name = "gizza-ai/url-encode", version = "0.1.0", interface = "handler@v1",
+    summary = "URL Encode skill",
+    skill(description = "…unchanged…", parameters = gizza_ai_url_encode_core::schema_json())
+)]
+impl UrlEncode {
+    fn handle(_msg: Message, body: Vec<u8>) -> GuestResult {
+        // `run_skill` wraps the returned value in `{ "result": … }` — exactly
+        // url-encode's current success shape — so return the encoded String.
+        match gizza_ai_block_utils::run_skill(&body, "url-encode", |a: Args| {
+            gizza_ai_url_encode_core::convert(&a.text, &a.mode, &a.target)
+                .map_err(gizza_ai_block_utils::SkillError::InvalidArgs)
+        }) {
+            Ok(v) => GuestResult::respond(v),
+            Err(e) => GuestResult::error(e.into()),
+        }
+    }
+}
+```
+Delete the inline schema literal, the old `respond_error`, and the manual parse. Keep `Args` (typed deserialize). The exact current result shape is preserved by `run_skill`'s `{ "result": … }` wrapping — confirm against each tool's current output (some return `{result}`, media tools return an `Envelope` via Recipe M).
+
+3. **`web/src/lib.rs`** — unchanged for pure tools (it already forwards to `core`).
+
+4. **Verify:** `cargo test` in core (drift-guard + existing) + `wafer build` in the block + a CLI smoke (`gizza tool url-encode 'text=a b'`).
+
+**Other pure tools:** `phone-format`, `word-count`, `calculator`, `clock` (clock = `Input::None`, no params).
+
+---
+
+## Recipe M — media / ffmpeg-page tool (exemplar: `image-resize`)
+
+**Before:** inline schema with `url`/`ref`/`width`/`height`/`fit` + `oneOf`; a `run()` that does `pick_source → fetch/load → build argv → FfmpegReq → dispatch → exit/size checks → Envelope` by hand; `web/src/lib.rs` with a local `struct Plan`.
+
+**After:**
+
+1. **`core/src/lib.rs`** — add `descriptor()` (`Input::Image`, params `width`/`height` `Param::integer().min(1.0)`, `fit` enum default `contain`) + `schema_json()` + drift-guard test (paste the current schema, incl. the `oneOf`).
+
+2. **`src/lib.rs`** `run()` collapses to:
+
+```rust
+fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
+    let args: Args = serde_json::from_slice(&body).invalid_args("image-resize")?;
+    // tool-specific validation stays (width/height required, fit=cover needs both)…
+    let (bytes, mime, in_name) = resolve_source(args.source.into_inner(), AssetKind::Image, MAX_INPUT_BYTES)?;
+    let ext = mime_to_ext(&mime).ok_or_else(|| SkillError::InvalidArgs(format!("unsupported input mime: {mime}")))?;
+    let (argv, out_name) = core::plan_resize(&format!("in.{ext}"), &format!("out.{ext}"), args.width, args.height, fit);
+    let output = dispatch_ffmpeg(argv, format!("in.{ext}"), bytes, out_name)?;
+    let filename = filename_with_suffix(&in_name, &dim_suffix(args.width, args.height), ext);
+    build_media_envelope(&output, &mime, filename, summary(&in_name, args.width, args.height, output.len(), &mime), MAX_OUTPUT_BYTES)
+}
+```
+i.e. `resolve_source` + `dispatch_ffmpeg` + `build_media_envelope` (Plan 2) replace ~50 lines of hand-orchestration; `parameters = core::schema_json()`.
+
+3. **`web/src/lib.rs`** — return `gizza_ai_block_utils::ArgvPlan { argv, out_name }` instead of a local `struct Plan`.
+
+4. **Verify:** core tests + `wafer build` + page build (`wasm-pack` + generator) + a CLI smoke against a public image URL.
+
+**Other media tools:** `image-compress`, `image-convert`, `image-crop`, `image-grayscale`, `image-fetch`, `video-compress`, `video-transcode`, `video-trim`, `video-frame-extract`.
+
+---
+
+## Recipe N — no-page chat+CLI / network tool (exemplar: `web-fetch`)
+
+**Before:** `Args` + a typed `ToolResp` + inline schema + hand-written `handle`.
+
+**After:** add `core::descriptor()` (`Input::None` for param-only tools like web-fetch/http-request; `Input::Document`/`File` for byte-input tools like pdf-extract-text/xlsx-to-csv/merge-pdf, which emit the `url`⊕`ref` `oneOf`) + `schema_json()` + drift-guard; `src/lib.rs` uses `run_skill(&body, "<slug>", |a: Args| -> Result<ToolResp, SkillError>)` and returns the typed result (wrapped `{result}` by `respond_ok`). Byte-input tools use `resolve_source(..)` with the appropriate `AssetKind`. No page, no `web/` change beyond what already exists.
+
+**Other no-page tools:** `http-request`, `pdf-extract-text`, `xlsx-to-csv`, `merge-pdf`, `vectorize`, `code-screenshot`, `css-select-extract`, `imagine`, `ffmpeg` (ffprobe). (Note: `merge-pdf` takes an **array** of inputs → add a `ParamKind::Array` variant to `block-utils` first, as an additive Plan 2 follow-up, before retrofitting it.)
+
+---
+
+## Batching & sequencing
+
+1. **Exemplar PR (one per shape):** retrofit `url-encode` (P), `image-resize` (M), `web-fetch` (N) in one PR. Proves all three recipes + the drift-guard. Review carefully.
+2. **Batch PRs (~4–6 tools each), worktree-per-batch:**
+   - Batch P: `phone-format`, `word-count`, `calculator`, `clock`.
+   - Batch M1: `image-compress`, `image-convert`, `image-crop`, `image-grayscale`, `image-fetch`.
+   - Batch M2: `video-compress`, `video-transcode`, `video-trim`, `video-frame-extract`.
+   - Batch N1: `http-request`, `css-select-extract`, `imagine`, `ffmpeg`.
+   - Batch N2 (byte-input): `pdf-extract-text`, `xlsx-to-csv`, `vectorize`, `code-screenshot`, then `merge-pdf` (after `ParamKind::Array`).
+3. Each batch PR: per tool — recipe edits, drift-guard green, `wafer build`, `cargo test`, fmt; one `gizza tool` CLI smoke per tool. Open PR (review-only), CI green, merge.
+
+This is a candidate for **parallel agents** (one per tool, worktree-isolated) given the uniform recipe — opt into that scale explicitly if desired; otherwise execute batches sequentially.
+
+## Testing / done
+
+- Per tool: drift-guard (`schema_json_matches_authored_chat_schema`) green; existing core/block tests green; `wafer build` ok; one CLI smoke recorded.
+- Whole-repo: `cargo test` (with block.wasm artifacts built), generator suite, JS suite — green.
+- **Done when** all ~25 tools are on the abstraction, every drift-guard passes (proving no chat-schema drift), and the code-reduction is realized (no inline schema literals, no per-tool `respond_error`, no hand-rolled media orchestration).
+
+## Handoff
+
+After Plan 4: **Plan 5** updates `/new-tool` + `scaffold-tool.sh` + the build-notes to emit the descriptor-based shape so future tools are born consistent. **Plan 4b** (optional) eliminates `meta.toml [[input]]` via generator-from-descriptor.json if the remaining page-side duplication is worth the mechanism.

--- a/docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md
+++ b/docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md
@@ -1,0 +1,282 @@
+# Design — gizza shared tool abstraction (single-source descriptor)
+
+**Date:** 2026-06-19
+**Status:** Design approved (brainstorming); pending writing-plans.
+**Repos:** `wafer-run` (producer, one small change) → `gizza-ai` (consumer).
+**Related:** [[gizza-new-tool-skill]] (`/new-tool`), the `gizza-search-tools` backlog, the build-notes (`docs/checks/2026-06-18-gizza-new-tool-build-notes.md`).
+
+## Problem
+
+gizza now has ~25 tools and a 1000-tool backlog. Each tool is an independent
+crate (so the worktree-per-tool parallel build model works), with shared code
+already factored into two path/git-dep crates: `block-utils` (I/O: fetch,
+attachment, `Envelope`/`ForUi`, `AssetKind`, ffmpeg dispatch, filename/mime
+helpers, `SkillError`) and `chrome` (header/footer UI).
+
+What is **still duplicated** across every tool:
+
+1. **The skill wrapper boilerplate** — an `Args` struct, a `handle()` that does
+   parse → call `core` → wrap `{result}`/`{error}`, a re-defined `respond_error`,
+   and the `web/src/lib.rs` `wasm-bindgen` export. Copy-pasted 25×.
+2. **The param declaration, declared twice** — the chat JSON schema (the
+   `parameters` literal in `src/lib.rs`'s `#[wafer_block(skill(...))]`, which also
+   drives the CLI via `cli/args.rs::map_args(schema, …)`) **and** the page form
+   fields (`page/meta.toml` `[[input]]` blocks). Nothing enforces these agree, and
+   `build_argv`'s positional order is also coupled to the page field order. This is
+   the primary correctness/consistency risk.
+
+A subtlety that shapes the whole design: the chat and page surfaces do **not**
+share the same param *set*. For a media tool the *input* differs by surface —
+chat takes `{url|ref}`, the page takes a file upload — while the *logical* params
+(width/height/fit, mode/target, …) are identical but written out twice. So the
+single source of truth cannot be "the JSON schema"; it must be one level up.
+
+## Goals
+
+- **Reduce code:** a tool is essentially its `core` logic + one declaration; the
+  wrapper, the chat schema, the page fields, and the web export are derived/shared.
+- **Reduce error surface:** the chat↔page param drift becomes structurally
+  impossible; the `url⊕ref` oneOf and the media fetch→ffmpeg→envelope orchestration
+  (recurring per-tool bug sources) are written once.
+- **Consistency:** every tool returns the same `{result}`/`{error}` shape and
+  validates inputs the same way; global fixes land in one place.
+- **Retrofit all ~25 existing tools** (not just new ones).
+- **Deep-linkable, AI-discoverable tools:** every tool page accepts URL **query
+  parameters** named by the descriptor, pre-fills the form, and auto-runs when the
+  inputs are satisfied (e.g. `/tools/calculator/?expression=2%2B2*3` opens already
+  showing the result). The accepted params + an example deep-link are documented on
+  the page **and** in the markdown twin so an LLM can drive the tool by URL.
+
+## Non-goals / out of scope
+
+- A full `#[gizza_skill]` proc-macro that also generates the impl (Approach C). The
+  descriptor introduced here is exactly what such a macro would consume later; this
+  spec stops short of it deliberately (YAGNI / risk).
+- New browser loaders (transformers.js / onnx / pyodide) for the model-backed
+  backlog tools — separate effort.
+- The `/improve-tool` competitor-research skill — separate spec.
+- `chrome` (header/footer) — already shared, untouched here.
+
+## Design
+
+### 1. The descriptor (single source, lives in `core`)
+
+Each tool's `core` crate exposes one declaration. The `ToolDescriptor`, `Param`,
+and `Input` types live in `block-utils` (shared dep):
+
+```rust
+pub enum Input { None, Image, Video, Document, File }  // the binary/remote input
+                                                       // that varies by surface;
+                                                       // plain text is just a String Param.
+
+pub struct Param {
+    name: String,             // = chat-schema property AND URL query-param name
+    kind: ParamKind,          // String | U32 | F64 | Enum(Vec<String>) | Bool
+    required: bool,
+    default: Option<Value>,
+    description: String,       // LLM-facing → chat schema
+    label: Option<String>,    // UI-facing → page form
+    placeholder: Option<String>,
+    multiline: bool,          // page hint: render a String param as a textarea
+}
+
+pub struct ToolDescriptor { input: Input, params: Vec<Param> }
+```
+
+```rust
+// blocks/image-resize/core/src/lib.rs
+pub fn descriptor() -> ToolDescriptor {
+    ToolDescriptor::new(Input::Image)
+        .param(Param::u32("width").label("Width (px)").placeholder("640")
+                    .describe("Target width in pixels."))
+        .param(Param::u32("height").label("Height (px)").placeholder("(optional)")
+                    .describe("Target height in pixels; omit to scale by width."))
+        .param(Param::enumv("fit", ["contain","cover","stretch"]).default("contain")
+                    .label("Fit (contain|cover|stretch)")
+                    .describe("How to fit the image into the box."))
+}
+
+// blocks/calculator/core/src/lib.rs — pure text, the deep-link example
+pub fn descriptor() -> ToolDescriptor {
+    ToolDescriptor::new(Input::None)
+        .param(Param::string("expression").required()
+                    .label("Expression").placeholder("2 + 2 * 3")
+                    .describe("The arithmetic expression to evaluate."))
+}
+// → chat: { "expression": {...}, required:["expression"] }
+// → page field "expression"; → /tools/calculator/?expression=2%2B2*3 auto-runs.
+```
+
+### 2. Deriving each surface
+
+| Surface | Derivation |
+|---|---|
+| **Chat schema** (`block.info()` JSON `parameters`) | `Input::Image/Video/Document/File` → a `url`⊕`ref` `oneOf` (exactly one); `Input::None` → no input property. **+** each `Param` (including plain `String`/text params) → a JSON property with description/enum/default, listed in `required` when `required`. Produced by `descriptor().to_schema_json()`. |
+| **CLI** | reads the chat schema from `block.info()` via `cli/args.rs::map_args` → already single-sourced, no change. |
+| **Page form** (`[[input]]`) | `Input::Image/Video/…` → a `source="file"` upload with the right `accept`; **+** each `Param` → a `source="field"` input (text, or textarea when `multiline`) using its label/placeholder. Produced by `descriptor().to_page_inputs()`, consumed by the generator. |
+| **`build_argv`** | receives a `name → value` map keyed by `Param.name` (no positional-order coupling to the page). |
+| **Page query params + auto-run** | the shared page runtime hydrates each field from the URL query param of the same name (`?width=…&fit=…`); the media/file/document input is hydrated from `?url=` (fetched in-browser, fed to the same ffmpeg path). Auto-runs once required inputs are satisfied. Generic — no per-tool JS (see §6). |
+| **Docs** (page + markdown twin) | the generator renders a "Use via URL" section on the page (param table + copyable example deep-link) and the same in `/tools/<slug>/index.md` (the LLM-facing surface). Produced from `descriptor()`. |
+
+`page/meta.toml` is slimmed to **page chrome only**: `slug`, `title`, `tags`,
+`h1`, `hero_subtitle`, `wasm`, `export`, `runtime`, `output_label`, `format`,
+SEO. It no longer contains `[[input]]` blocks.
+
+### 3. Chat-schema injection (wafer-run change — "2a")
+
+The `wafer_block` macro currently requires `skill(parameters = …)` to be a string
+**literal** (`parse_skill` accepts only a `syn::LitStr` and validates the JSON at
+macro-expansion time). Change: **allow `parameters` to be an expression** that
+evaluates to `&str`/`String` (a `const`/`fn` path), keeping the string-literal form
+for backward compatibility. When an expression is given, compile-time JSON
+validation is replaced by a runtime/test check.
+
+Then a gizza skill writes:
+
+```rust
+#[wafer_block(
+    name = "gizza-ai/image-resize", version = "0.1.0", interface = "handler@v1",
+    summary = "Resize an image",
+    skill(description = "...", parameters = gizza_ai_image_resize_core::schema_json())
+)]
+```
+
+`schema_json()` is `descriptor().to_schema_json()` (cached). The hand-written
+chat-schema literal is **deleted**.
+
+### 4. The helper layer (`block-utils`)
+
+- `run_skill<A: DeserializeOwned, T: Serialize>(body, |A| -> Result<T, SkillError>) -> GuestResult`
+  — deserialize → call → shape `{result}`/`{error}`. Replaces every `handle` +
+  `respond_error`.
+- `respond_ok(value)` / `respond_err(SkillError)` — the one canonical result/error
+  shape.
+- `run_media_skill(body, descriptor, |fields, in_name| -> Argv)` — the whole media
+  path once: `pick_source` → `fetch_from_url`/`load_from_attachment` →
+  `dispatch_ffmpeg_runtime` → `Envelope`.
+- `gizza_web_export!` (`macro_rules!`) — generates the `web/src/lib.rs`
+  `wasm-bindgen` export from `core`'s `convert`/`build_argv`.
+
+**Every** tool declares a `core::descriptor()` — it is what derives the chat
+schema (and thus the CLI) for all shapes. Only tools that have a page additionally
+use `to_page_inputs()`. Resulting tool shapes:
+- **pure text** (`Input::None` + a `String` param, e.g. `expression`) → `core` (`convert`) + `descriptor()` + `run_skill(body, |a| core::convert(a))`; page derives from `to_page_inputs()`.
+- **media / ffmpeg page** (`Input::Image|Video`) → `core` (`build_argv`) + `descriptor()` + `run_media_skill(body, core::descriptor(), core::build_argv)`; page derives from `to_page_inputs()`.
+- **no-page chat+CLI / network** (`Input::Document|File|None`) → `descriptor()` (drives chat schema only) + `run_skill` (+ `block-utils` input helpers). No `meta.toml`, no `to_page_inputs()` call.
+
+The typed `Args` struct stays (ergonomic deserialize); its field names overlap the
+descriptor's, but that is local and low-risk (covered by the per-tool tests).
+
+### 5. Generator reads the descriptor
+
+A pre-generator build step serializes `core::descriptor()` to a gitignored
+`blocks/<tool>/descriptor.json` (one per page tool). The generator reads
+`descriptor.json` (form fields) + `meta.toml` (page chrome) and renders the page.
+The generator does **not** link the 25 tool crates — it reads JSON. This mirrors
+the existing build-notes step "build each page block's `web/pkg` before the
+generator"; add "emit `descriptor.json`" alongside it.
+
+### 6. Query parameters & deep-linking (page + docs)
+
+The query-param contract **is** the descriptor's param set — same names as the
+chat schema, so it costs nothing extra to keep consistent.
+
+**Runtime (shared, generic — no per-tool JS).** The existing shared page script
+(`site/tool.js`) gains a hydrate-and-run step: on load it parses
+`location.search` and, for each descriptor field, sets the matching input by name
+(`?expression=…`, `?text=…&mode=…`, `?width=…&height=…&fit=…`). For media/file/
+document tools the input is hydrated from **`?url=`**: the page fetches the remote
+bytes in-browser and feeds them into the *same* path a file upload uses (browser
+ffmpeg via the existing engine). After hydration, if every required input is
+present the page **auto-runs** and renders the result; otherwise it just pre-fills
+and waits (e.g. a media page with only `?width=` set waits for a file). Param names
+match `Param.name`, values are standard percent-encoded. This is driven entirely by
+the generic descriptor field list, so it applies to all page tools at once.
+
+**`?url=` failure handling.** A cross-origin fetch can be blocked by the remote
+host's CORS policy. On failure the page shows a clear, non-fatal message — e.g.
+"Couldn't fetch `<url>` (the host may not allow cross-origin access). Download it
+and drop it in instead." — and falls back to the manual file input. No silent
+failure, no broken auto-run state.
+
+**Docs (the AI-facing requirement).** From `descriptor()` the generator emits, on
+both the page and the markdown twin `/tools/<slug>/index.md`:
+- a **parameter table** — name, type, required, default, description (and, for
+  media/file tools, that `url` fetches a remote input);
+- a **copyable example deep-link**, e.g.
+  `https://gizza.ai/tools/calculator/?expression=2%2B2*3` or
+  `https://gizza.ai/tools/image-resize/?url=https://example.com/cat.jpg&width=512`.
+
+Because `index.md` is what `llms.txt` already points LLMs to, this is how an agent
+learns to drive a tool by URL. `llms.txt` page-tool entries gain a short
+"supports query-param deep-linking — see index.md" note.
+
+## Sequencing (producer → consumer)
+
+1. **wafer-run** — `wafer_block` accepts an expression `parameters` (PR → merge →
+   fast-forward the local `/workspace/wafer-run` tree, respecting the shared-tree
+   hazard: do it when no gizza build is in flight).
+2. **gizza `block-utils`** — `ToolDescriptor`/`Param`/`Input` (+ serde),
+   `to_schema_json()`, `to_page_inputs()`, `to_descriptor_json()`, `run_skill`,
+   `respond_*`, `run_media_skill`, `gizza_web_export!`. Land as one infra PR
+   **before** fanning out retrofits (lesson from the `AssetKind` reconciliation:
+   shared infra goes first, not ad hoc per tool).
+3. **gizza generator + page runtime** — read `descriptor.json` + emit step; slim
+   `meta.toml`; render the "Use via URL" param table + example deep-link on the page
+   and in `index.md`; add the generic query-param hydrate-and-run (incl. `?url=`
+   fetch + CORS fallback) to the shared `site/tool.js`. Prove on 2–3 exemplars (one
+   pure, one media).
+4. **Retrofit all 25** — grouped by shape (pure-text · ffmpeg-page · no-page
+   chat+CLI · network), ~4–6 tools per PR, worktree-per-batch + adversarial
+   review (the build-program pattern; see [[workflow-durability-protocol]]).
+5. **`/new-tool` + `scaffold-tool.sh` + build-notes** — emit the descriptor-based
+   shape so future tools are born consistent.
+
+## Testing / drift guards
+
+- `block-utils` unit tests: descriptor → schema (string/u32/f64/enum/default/
+  required; the media `url⊕ref` oneOf) and descriptor → page fields.
+- **Migration safety:** during retrofit, diff each tool's *derived* schema against
+  its *current authored* schema — param names/descriptions/enums/defaults must
+  match so LLM tool-calling quality is preserved. A tool ships only when the diff
+  is intentional/empty.
+- CI check that `descriptor.json` regenerates clean (cannot go stale).
+- Existing per-tool behavior tests + generator page tests stay green.
+- `wafer_block` macro: a test that the expression form produces info() with valid
+  JSON parameters (replacing the lost compile-time validation).
+- **Query-param deep-linking** (Playwright, per the build-notes headless pattern):
+  a pure tool loaded with `?<param>=…` pre-fills and auto-renders the result; a
+  media tool with `?url=…` fetches + runs; the `?url=` CORS-failure path shows the
+  fallback message (not a broken state); a media page with only scalar params set
+  pre-fills and waits for the file.
+- Generator/markdown tests: `index.md` and the page contain the param table + a
+  correctly percent-encoded example deep-link derived from the descriptor.
+
+## Risks & mitigations
+
+- **Schema fidelity on retrofit.** Hand-tuned descriptions/enums/defaults matter
+  for LLM tool-calling. Mitigation: the per-tool derived-vs-authored schema diff
+  gate above.
+- **`url⊕ref` oneOf shape.** The derived oneOf must match what the chat agent and
+  CLI expect today. Mitigation: encode the exact current shape in
+  `to_schema_json()` and assert against a real tool's current schema.
+- **wafer-run shared-tree hazard.** The producer change + local fast-forward must
+  not race a concurrent gizza build. Mitigation: do the ff when idle; gizza's
+  `.cargo` patch points at the local tree so no push is needed for local builds,
+  but CI clones wafer-run main → the wafer-run PR must merge before gizza retrofit
+  PRs' CI can pass (producer-merge-first; see [[gizza-ci-pin-vs-wafer-main-drift]]).
+- **`?url=` CORS for media deep-links.** Arbitrary remote media may block
+  cross-origin fetch. Mitigation: graceful fallback message + manual upload (§6);
+  deep-linking still works for same-origin / CORS-permissive hosts and for all
+  text tools. Not a correctness risk, a coverage limit — documented, not silent.
+- **Scope.** ~9 PRs (1 wafer-run + 1 infra + 1 generator/runtime + ~5 retrofit + 1
+  skill-update); the query-param surface rides the generator/runtime + retrofit
+  work, not a separate phase. Phased and reviewable; matches "retrofit everything".
+
+## Open questions (for writing-plans)
+
+- Exact `ParamKind` set — do any current tools need types beyond
+  String/U32/F64/Enum/Bool (e.g., arrays for multi-input tools like `merge-pdf`)?
+  Likely add `Array(Box<ParamKind>)`; confirm against the no-page tools.
+- Whether `run_media_skill` fully covers every current ffmpeg tool's quirks
+  (e.g., `video-trim` stream-copy vs re-encode) or needs a small per-tool hook.


### PR DESCRIPTION
## What

Lands the 5 planning/design docs for the **shared tool abstraction** (single-source descriptor) onto `main`:

- `docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md` (282 lines)
- `docs/superpowers/plans/2026-06-19-shared-tool-abstraction-plan-1-wafer-block-expr-params.md` (337)
- `…-plan-2-block-utils-foundation.md` (763)
- `…-plan-3-query-param-deeplinks.md` (339)
- `…-plan-4-retrofit.md` (169)

## Why

The **implementation** of this abstraction (block-utils foundation, expr params, query-param deeplinks, and the retrofit of all ~25 tools onto it) is already fully merged into `main`. Only the design/plan docs never landed — they lived solely on `feat/shared-tool-abstraction`. This records the architecture rationale in `main` so it isn't lost when that branch is cleaned up.

## Scope

Docs only — no code. Cherry-picked verbatim from `feat/shared-tool-abstraction` (the only genuinely-unmerged content on that branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)