### PR TITLE
feat(blocks): video-silence-cut — correct two-pass silence removal

### DIFF
--- a/blocks/video-silence-cut/Cargo.toml
+++ b/blocks/video-silence-cut/Cargo.toml
@@ -1,0 +1,20 @@
+[workspace]
+resolver = "2"
+members = [".", "core"]
+
+[package]
+name = "gizza-ai-video-silence-cut-block"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.82"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wafer-sdk = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
+wafer-block = { git = "https://github.com/wafer-run/wafer-run.git", branch = "main" }
+gizza-ai-block-utils = { path = "../../block-utils" }
+gizza-ai-video-silence-cut-core = { path = "core" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/blocks/video-silence-cut/core/Cargo.toml
+++ b/blocks/video-silence-cut/core/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "gizza-ai-video-silence-cut-core"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.82"
+
+[dependencies]

--- a/blocks/video-silence-cut/core/src/lib.rs
+++ b/blocks/video-silence-cut/core/src/lib.rs
@@ -1,0 +1,344 @@
+//! gizza-ai/video-silence-cut core — pure, native-testable logic for a *correct*
+//! two-pass silence cut. No wafer/wasm-bindgen deps.
+//!
+//! # Why two-pass (and why this is correct, unlike the earlier draft)
+//!
+//! Removing silent gaps from a video while keeping audio and video in sync is
+//! classically a **two-pass** operation:
+//!
+//!   1. **detect** — run ffmpeg's `silencedetect` audio filter, which prints
+//!      `silence_start` / `silence_end` timestamps to stderr. Produces no output
+//!      file (`-f null -`); the result is the log.
+//!   2. **cut** — from the detected silences (and the clip duration) compute the
+//!      complementary **keep** segments, then re-encode keeping only those time
+//!      ranges of *both* streams via `select`/`aselect` with matching `between(t,…)`
+//!      expressions and `setpts`/`asetpts` to close the gaps. Because video and
+//!      audio select the *same* time ranges, they stay in sync.
+//!
+//! A single ffmpeg invocation cannot read its own first-pass stderr, and the
+//! single-pass `silenceremove` filter is audio-only (it desyncs the video). The
+//! gizza ffmpeg bridge returns each exec's log and the block can dispatch twice,
+//! so the two-pass flow runs in chat + CLI. This module owns the pure pieces:
+//! argv construction, log parsing, and keep-segment computation.
+
+/// A detected silent range. `end` is `None` when the silence runs to EOF (ffmpeg
+/// prints a trailing `silence_start` with no matching `silence_end`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Silence {
+    pub start: f64,
+    pub end: Option<f64>,
+}
+
+/// Keep segments shorter than this (seconds) are dropped — a sub-10ms sliver
+/// between two silences is not worth a frame and would produce empty output.
+const MIN_KEEP_S: f64 = 1e-3;
+
+/// Validate the user params. `threshold_db` must be a finite value `<= 0`
+/// (silence is below 0 dB); `min_silence` must be a finite value `> 0` seconds.
+pub fn validate(threshold_db: f64, min_silence_s: f64) -> Result<(), String> {
+    if !threshold_db.is_finite() {
+        return Err("threshold_db must be a finite number (e.g. -30)".into());
+    }
+    if threshold_db > 0.0 {
+        return Err("threshold_db must be <= 0 dB (silence is below 0 dB; e.g. -30)".into());
+    }
+    if !min_silence_s.is_finite() || min_silence_s <= 0.0 {
+        return Err("min_silence must be a finite number > 0 (seconds)".into());
+    }
+    Ok(())
+}
+
+/// Format an `f64` for an ffmpeg arg without a trailing `.0` (`-30` not `-30.0`,
+/// `0.5` stays `0.5`) — compact and locale-independent.
+pub fn fmt_num(v: f64) -> String {
+    if v.fract() == 0.0 && v.is_finite() {
+        format!("{}", v as i64)
+    } else {
+        let s = format!("{v:.3}");
+        s.trim_end_matches('0').trim_end_matches('.').to_string()
+    }
+}
+
+/// Pass 1 argv (no leading "ffmpeg"): detect silent ranges, no output file.
+pub fn detect_argv(in_name: &str, threshold_db: f64, min_silence_s: f64) -> Vec<String> {
+    vec![
+        "-i".into(),
+        in_name.into(),
+        "-af".into(),
+        format!(
+            "silencedetect=noise={}dB:d={}",
+            fmt_num(threshold_db),
+            fmt_num(min_silence_s)
+        ),
+        "-f".into(),
+        "null".into(),
+        "-".into(),
+    ]
+}
+
+/// Parse the clip duration (seconds) from an ffmpeg log's `Duration: HH:MM:SS.ss`
+/// line. Returns `None` if absent/unparseable.
+pub fn parse_duration(log: &str) -> Option<f64> {
+    let idx = log.find("Duration:")?;
+    let rest = log[idx + "Duration:".len()..].trim_start();
+    // Up to the first comma: "00:00:12.50"
+    let hms = rest.split(',').next()?.trim();
+    let mut parts = hms.split(':');
+    let h: f64 = parts.next()?.trim().parse().ok()?;
+    let m: f64 = parts.next()?.trim().parse().ok()?;
+    let s: f64 = parts.next()?.trim().parse().ok()?;
+    Some(h * 3600.0 + m * 60.0 + s)
+}
+
+/// Parse `silence_start:` / `silence_end:` markers from an ffmpeg silencedetect
+/// log into ordered `Silence` ranges. A `silence_end` attaches to the most recent
+/// open `silence_start`.
+pub fn parse_silences(log: &str) -> Vec<Silence> {
+    let mut out: Vec<Silence> = Vec::new();
+    for line in log.lines() {
+        if let Some(v) = marker_value(line, "silence_start:") {
+            out.push(Silence {
+                start: v,
+                end: None,
+            });
+        } else if let Some(v) = marker_value(line, "silence_end:") {
+            if let Some(last) = out.last_mut() {
+                if last.end.is_none() {
+                    last.end = Some(v);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Extract the float that follows `marker` on a line, stopping at whitespace or
+/// `|` (ffmpeg appends `| silence_duration: …` to silence_end lines).
+fn marker_value(line: &str, marker: &str) -> Option<f64> {
+    let idx = line.find(marker)?;
+    let rest = line[idx + marker.len()..].trim_start();
+    let tok: String = rest
+        .chars()
+        .take_while(|c| !c.is_whitespace() && *c != '|')
+        .collect();
+    tok.parse().ok()
+}
+
+/// Compute the non-silent **keep** segments within `[0, duration]` as the
+/// complement of `silences` (assumed ordered, non-overlapping). Segments shorter
+/// than [`MIN_KEEP_S`] are dropped. An empty result means the whole clip is silent.
+pub fn keep_segments(duration: f64, silences: &[Silence]) -> Vec<(f64, f64)> {
+    let mut keeps = Vec::new();
+    let mut cursor = 0.0_f64;
+    for s in silences {
+        if s.start > cursor {
+            push_keep(&mut keeps, cursor, s.start.min(duration));
+        }
+        match s.end {
+            Some(e) => cursor = cursor.max(e),
+            None => {
+                cursor = duration; // silence runs to EOF — nothing left to keep
+                break;
+            }
+        }
+    }
+    if cursor < duration {
+        push_keep(&mut keeps, cursor, duration);
+    }
+    keeps
+}
+
+fn push_keep(keeps: &mut Vec<(f64, f64)>, start: f64, end: f64) {
+    if end - start > MIN_KEEP_S {
+        keeps.push((start, end));
+    }
+}
+
+/// The shared `select`/`aselect` predicate keeping the union of `keeps`:
+/// `between(t,s0,e0)+between(t,s1,e1)+…`.
+pub fn keep_expr(keeps: &[(f64, f64)]) -> String {
+    keeps
+        .iter()
+        .map(|(s, e)| format!("between(t,{},{})", fmt_num(*s), fmt_num(*e)))
+        .collect::<Vec<_>>()
+        .join("+")
+}
+
+/// Pass 2 argv (no leading "ffmpeg"): keep only `keeps` of both streams, closing
+/// the gaps (`setpts`/`asetpts`), re-encode to H.264/AAC mp4.
+pub fn cut_argv(in_name: &str, out_name: &str, keeps: &[(f64, f64)]) -> Vec<String> {
+    let expr = keep_expr(keeps);
+    vec![
+        "-i".into(),
+        in_name.into(),
+        "-vf".into(),
+        format!("select='{expr}',setpts=N/FRAME_RATE/TB"),
+        "-af".into(),
+        format!("aselect='{expr}',asetpts=N/SR/TB"),
+        "-c:v".into(),
+        "libx264".into(),
+        "-pix_fmt".into(),
+        "yuv420p".into(),
+        "-c:a".into(),
+        "aac".into(),
+        out_name.into(),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- validate ---------------------------------------------------------
+    #[test]
+    fn validate_accepts_sane_defaults() {
+        assert!(validate(-30.0, 0.5).is_ok());
+    }
+    #[test]
+    fn validate_rejects_positive_threshold() {
+        assert!(validate(5.0, 0.5).is_err());
+    }
+    #[test]
+    fn validate_rejects_nonpositive_min_silence() {
+        assert!(validate(-30.0, 0.0).is_err());
+        assert!(validate(-30.0, -1.0).is_err());
+    }
+    #[test]
+    fn validate_rejects_nonfinite() {
+        assert!(validate(f64::NAN, 0.5).is_err());
+        assert!(validate(-30.0, f64::INFINITY).is_err());
+    }
+
+    // --- fmt_num ----------------------------------------------------------
+    #[test]
+    fn fmt_num_drops_trailing_zero() {
+        assert_eq!(fmt_num(-30.0), "-30");
+        assert_eq!(fmt_num(8.0), "8");
+        assert_eq!(fmt_num(0.5), "0.5");
+        assert_eq!(fmt_num(9.75), "9.75");
+    }
+
+    // --- detect_argv ------------------------------------------------------
+    #[test]
+    fn detect_argv_builds_silencedetect_null_sink() {
+        assert_eq!(
+            detect_argv("in.mp4", -30.0, 0.5),
+            vec![
+                "-i", "in.mp4", "-af", "silencedetect=noise=-30dB:d=0.5", "-f", "null", "-"
+            ]
+        );
+    }
+
+    // --- parse_duration ---------------------------------------------------
+    #[test]
+    fn parse_duration_reads_hms() {
+        let log = "  Duration: 00:00:12.50, start: 0.000000, bitrate: 1000 kb/s\n";
+        assert_eq!(parse_duration(log), Some(12.5));
+    }
+    #[test]
+    fn parse_duration_reads_minutes_hours() {
+        let log = "  Duration: 01:02:03.00, start: 0\n";
+        assert_eq!(parse_duration(log), Some(3723.0));
+    }
+    #[test]
+    fn parse_duration_none_when_absent() {
+        assert_eq!(parse_duration("no duration here"), None);
+    }
+
+    // --- parse_silences ---------------------------------------------------
+    const SAMPLE_LOG: &str = "\
+Input #0, mov,mp4,m4a
+  Duration: 00:00:12.50, start: 0.000000, bitrate: 1000 kb/s
+[silencedetect @ 0x55] silence_start: 2.5
+[silencedetect @ 0x55] silence_end: 4.3 | silence_duration: 1.8
+[silencedetect @ 0x55] silence_start: 8
+[silencedetect @ 0x55] silence_end: 9.75 | silence_duration: 1.75
+";
+
+    #[test]
+    fn parse_silences_pairs_start_end() {
+        assert_eq!(
+            parse_silences(SAMPLE_LOG),
+            vec![
+                Silence { start: 2.5, end: Some(4.3) },
+                Silence { start: 8.0, end: Some(9.75) },
+            ]
+        );
+    }
+    #[test]
+    fn parse_silences_trailing_silence_to_eof_has_no_end() {
+        let log = "[silencedetect @ 0x1] silence_start: 5\n"; // no silence_end
+        assert_eq!(parse_silences(log), vec![Silence { start: 5.0, end: None }]);
+    }
+    #[test]
+    fn parse_silences_empty_when_none() {
+        assert!(parse_silences("nothing").is_empty());
+    }
+
+    // --- keep_segments ----------------------------------------------------
+    #[test]
+    fn keep_segments_complement_in_middle() {
+        let s = parse_silences(SAMPLE_LOG);
+        assert_eq!(
+            keep_segments(12.5, &s),
+            vec![(0.0, 2.5), (4.3, 8.0), (9.75, 12.5)]
+        );
+    }
+    #[test]
+    fn keep_segments_silence_at_start_has_no_leading_keep() {
+        let s = vec![Silence { start: 0.0, end: Some(3.0) }];
+        assert_eq!(keep_segments(10.0, &s), vec![(3.0, 10.0)]);
+    }
+    #[test]
+    fn keep_segments_trailing_silence_to_eof_drops_tail() {
+        let s = vec![Silence { start: 5.0, end: None }];
+        assert_eq!(keep_segments(10.0, &s), vec![(0.0, 5.0)]);
+    }
+    #[test]
+    fn keep_segments_no_silence_keeps_whole_clip() {
+        assert_eq!(keep_segments(10.0, &[]), vec![(0.0, 10.0)]);
+    }
+    #[test]
+    fn keep_segments_all_silence_keeps_nothing() {
+        let s = vec![Silence { start: 0.0, end: Some(10.0) }];
+        assert!(keep_segments(10.0, &s).is_empty());
+    }
+    #[test]
+    fn keep_segments_drops_subms_sliver() {
+        // 0.5ms gap between two silences — below MIN_KEEP_S, dropped.
+        let s = vec![
+            Silence { start: 0.0, end: Some(4.9995) },
+            Silence { start: 5.0, end: Some(10.0) },
+        ];
+        assert!(keep_segments(10.0, &s).is_empty());
+    }
+
+    // --- cut_argv ---------------------------------------------------------
+    #[test]
+    fn keep_expr_sums_between_clauses() {
+        let keeps = vec![(0.0, 2.5), (4.3, 8.0)];
+        assert_eq!(keep_expr(&keeps), "between(t,0,2.5)+between(t,4.3,8)");
+    }
+    #[test]
+    fn cut_argv_selects_both_streams_and_reencodes() {
+        let argv = cut_argv("in.mp4", "out.mp4", &[(0.0, 2.5)]);
+        assert_eq!(
+            argv,
+            vec![
+                "-i",
+                "in.mp4",
+                "-vf",
+                "select='between(t,0,2.5)',setpts=N/FRAME_RATE/TB",
+                "-af",
+                "aselect='between(t,0,2.5)',asetpts=N/SR/TB",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                "-c:a",
+                "aac",
+                "out.mp4",
+            ]
+        );
+    }
+}

--- a/blocks/video-silence-cut/manifest.json
+++ b/blocks/video-silence-cut/manifest.json
@@ -1,0 +1,23 @@
+{
+  "name": "gizza-ai/video-silence-cut",
+  "version": "0.1.0",
+  "interface": "handler@v1",
+  "summary": "Remove silent gaps from a video (correct two-pass, A/V stays in sync).",
+  "role": "skill",
+  "tool": {
+    "description": "Remove silent gaps from a video to tighten pacing (jump-cut style), keeping audio and video in sync via a two-pass detect-then-cut flow. Provide either url or ref. threshold_db is the silence loudness cutoff in dB (default -30) and min_silence is the shortest gap in seconds to trim (default 0.5). Output is mp4 (re-encoded H.264/AAC).",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "url":          { "type": "string", "description": "Video URL (HTTP/HTTPS)." },
+        "ref":          { "type": "string", "description": "Reference id from a prior video tool call. Use either url or ref." },
+        "threshold_db": { "type": "number", "maximum": 0, "description": "Silence threshold in dB (default -30). Audio quieter than this counts as silence." },
+        "min_silence":  { "type": "number", "minimum": 0, "description": "Minimum silent-gap length in seconds to trim (default 0.5). Must be > 0." }
+      },
+      "oneOf": [
+        { "required": ["url"] },
+        { "required": ["ref"] }
+      ]
+    }
+  }
+}

--- a/blocks/video-silence-cut/src/lib.rs
+++ b/blocks/video-silence-cut/src/lib.rs
@@ -1,0 +1,202 @@
+//! gizza-ai/video-silence-cut — fetch a video URL or attachment ref, remove its
+//! silent gaps with a **correct two-pass** ffmpeg flow, return an mp4 envelope.
+//!
+//! Pass 1 runs `silencedetect` (no output file) and we parse its log for the
+//! silent ranges + clip duration. Pass 2 keeps only the complementary non-silent
+//! segments of *both* streams (`select`/`aselect` + `setpts`/`asetpts`), so audio
+//! and video stay in sync — unlike a single-pass `silenceremove`, which desyncs
+//! the video. The gizza ffmpeg bridge returns each exec's log and the block can
+//! dispatch twice, so this runs in chat + CLI. There is no standalone page (the
+//! generic page driver is single-pass); this is a chat+CLI tool like `web-fetch`.
+//!
+//! The chat schema is derived from `descriptor()` (single source — shared across
+//! chat + CLI). The pure argv/parse/segment logic lives in `core`. See
+//! docs/superpowers/specs/2026-06-19-gizza-shared-tool-abstraction-design.md.
+
+// The #[wafer_block] macro emits the impl gated to wasm32 (it generates a native
+// registration call that requires ::new()). Supporting imports, constants, and
+// the Args type are only used inside that impl, so they look "unused" under a
+// native build; `descriptor()`/`schema_json()` stay native-compilable so the
+// sanity test below can exercise them. See video-compress for the full rationale.
+#![cfg_attr(not(target_arch = "wasm32"), allow(dead_code, unused_imports))]
+
+use gizza_ai_block_utils::{
+    build_media_envelope, filename_with_suffix, mime_to_ext, AssetKind, Input, Param, SkillError,
+    SkillResultExt, ToolDescriptor,
+};
+#[cfg(target_arch = "wasm32")]
+use gizza_ai_block_utils::{dispatch_ffmpeg_runtime, resolve_source, FfmpegReq, FfmpegResp};
+use gizza_ai_video_silence_cut_core::{
+    cut_argv, detect_argv, keep_segments, parse_duration, parse_silences, validate,
+};
+use serde::Deserialize;
+use wafer_sdk::*;
+
+const MAX_INPUT_BYTES: usize = 10 * 1024 * 1024; // 10 MiB
+const MAX_OUTPUT_BYTES: usize = 10 * 1024 * 1024;
+
+const DEFAULT_THRESHOLD_DB: f64 = -30.0;
+const DEFAULT_MIN_SILENCE_S: f64 = 0.5;
+
+#[derive(Deserialize, Debug)]
+struct Args {
+    #[serde(flatten)]
+    source: gizza_ai_block_utils::SourceFields,
+    #[serde(default)]
+    threshold_db: Option<f64>,
+    #[serde(default)]
+    min_silence: Option<f64>,
+}
+
+/// Single-source param descriptor → chat schema (and CLI). `Input::Video` adds
+/// the `url`⊕`ref` `oneOf`. `min_silence`'s schema minimum is 0 (inclusive);
+/// `validate()` enforces the real `> 0` at runtime with a clear message.
+fn descriptor() -> ToolDescriptor {
+    ToolDescriptor::new(Input::Video)
+        .param(
+            Param::number("threshold_db")
+                .max(0.0)
+                .describe("Silence threshold in dB (default -30). Audio quieter than this counts as silence."),
+        )
+        .param(
+            Param::number("min_silence")
+                .min(0.0)
+                .describe("Minimum silent-gap length in seconds to trim (default 0.5). Must be > 0."),
+        )
+}
+
+fn schema_json() -> String {
+    descriptor().to_schema_json()
+}
+
+#[cfg(target_arch = "wasm32")]
+struct VideoSilenceCut;
+
+// The #[wafer_block] macro emits a native registration call requiring ::new();
+// skill-style impls don't have one. Gate the struct + impl to wasm32 so the
+// descriptor sanity test still compiles natively.
+#[cfg(target_arch = "wasm32")]
+#[wafer_block(
+    name = "gizza-ai/video-silence-cut",
+    version = "0.1.0",
+    interface = "handler@v1",
+    summary = "Remove silent gaps from a video (correct two-pass, A/V stays in sync)",
+    requires = ["wafer-run/network", "gizza-ai/ffmpeg-runtime"],
+    skill(
+        description = "Remove silent gaps from a video to tighten pacing (jump-cut style), keeping audio and video in sync. Provide either url (HTTP/HTTPS) or ref (id from a prior tool call). threshold_db sets the silence loudness cutoff in dB (default -30; quieter than this counts as silence) and min_silence is the shortest gap in seconds to trim (default 0.5). Output is mp4 (re-encoded H.264/AAC). Uses a correct two-pass detect-then-cut flow.",
+        parameters = schema_json()
+    ),
+)]
+impl VideoSilenceCut {
+    fn handle(_msg: Message, body: Vec<u8>) -> GuestResult {
+        match run(body) {
+            Ok(v) => GuestResult::respond(v),
+            Err(e) => GuestResult::error(e.into()),
+        }
+    }
+}
+
+/// Run one ffmpeg-runtime exec and return the full response (so callers can read
+/// the log on pass 1 and the output bytes on pass 2). Maps a non-zero exit to
+/// `FfmpegExitNonZero`.
+#[cfg(target_arch = "wasm32")]
+fn run_pass(
+    argv: Vec<String>,
+    in_name: &str,
+    in_bytes: Vec<u8>,
+    out_name: &str,
+) -> Result<FfmpegResp, SkillError> {
+    let req = FfmpegReq {
+        args: argv,
+        inputs: vec![(in_name.to_string(), in_bytes)],
+        output: out_name.to_string(),
+    };
+    let req_body = serde_json::to_vec(&req)
+        .map_err(|e| SkillError::Serialize(format!("serialize ffmpeg request: {e}")))?;
+    let resp_bytes = dispatch_ffmpeg_runtime(&req_body)?;
+    let resp: FfmpegResp = serde_json::from_slice(&resp_bytes)
+        .map_err(|e| SkillError::Serialize(format!("malformed ffmpeg response: {e}")))?;
+    if resp.exit_code != 0 {
+        return Err(SkillError::FfmpegExitNonZero {
+            exit: resp.exit_code,
+            snippet: resp.log.chars().take(200).collect(),
+        });
+    }
+    Ok(resp)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
+    // 1. Parse + validate args.
+    let args: Args = serde_json::from_slice(&body).invalid_args("video-silence-cut")?;
+    let threshold_db = args.threshold_db.unwrap_or(DEFAULT_THRESHOLD_DB);
+    let min_silence = args.min_silence.unwrap_or(DEFAULT_MIN_SILENCE_S);
+    validate(threshold_db, min_silence)
+        .map_err(|e| SkillError::InvalidArgs(format!("invalid video-silence-cut args: {e}")))?;
+
+    // 2. Resolve source.
+    let (input_bytes, in_mime, in_filename) =
+        resolve_source(args.source.into_inner(), AssetKind::Video, MAX_INPUT_BYTES)?;
+    let in_ext = mime_to_ext(&in_mime).unwrap_or("mp4");
+    let ffmpeg_in = format!("in.{in_ext}");
+
+    // 3. Pass 1 — detect silences (no output file; the result is the log).
+    let detect = run_pass(
+        detect_argv(&ffmpeg_in, threshold_db, min_silence),
+        &ffmpeg_in,
+        input_bytes.clone(),
+        "detect.null",
+    )?;
+    let duration = parse_duration(&detect.log).ok_or_else(|| {
+        SkillError::FfmpegExitNonZero {
+            exit: 0,
+            snippet: "could not read clip duration from ffmpeg output".into(),
+        }
+    })?;
+    let silences = parse_silences(&detect.log);
+    let removed = silences.len();
+    let keeps = keep_segments(duration, &silences);
+    if keeps.is_empty() {
+        return Err(SkillError::InvalidArgs(
+            "the entire clip is silent at this threshold — nothing to keep".into(),
+        ));
+    }
+
+    // 4. Pass 2 — keep only the non-silent segments of both streams.
+    let out_name = "out.mp4";
+    let cut = run_pass(
+        cut_argv(&ffmpeg_in, out_name, &keeps),
+        &ffmpeg_in,
+        input_bytes,
+        out_name,
+    )?;
+
+    // 5. Envelope.
+    let output_size = cut.output.len();
+    let kept: f64 = keeps.iter().map(|(s, e)| e - s).sum();
+    let filename = filename_with_suffix(&in_filename, "-cut", "mp4");
+    let for_llm = format!(
+        "cut {removed} silent gap(s) from {in_filename}: kept {kept:.2}s of {duration:.2}s \
+         ({output_size} bytes video/mp4)"
+    );
+    build_media_envelope(&cut.output, "video/mp4", filename, for_llm, MAX_OUTPUT_BYTES)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The descriptor renders to a valid JSON schema with both numeric params and
+    /// the `url`⊕`ref` `oneOf` (from `Input::Video`).
+    #[test]
+    fn schema_json_is_valid_and_has_params() {
+        let v: serde_json::Value = serde_json::from_str(&schema_json()).expect("valid JSON schema");
+        let props = v.get("properties").expect("properties");
+        assert!(props.get("threshold_db").is_some());
+        assert!(props.get("min_silence").is_some());
+        assert!(props.get("url").is_some());
+        assert!(props.get("ref").is_some());
+        assert!(v.get("oneOf").is_some(), "Input::Video adds url/ref oneOf");
+        assert_eq!(props["threshold_db"]["maximum"], serde_json::json!(0));
+    }
+}

--- a/blocks/video-silence-cut/wafer.toml
+++ b/blocks/video-silence-cut/wafer.toml
@@ -1,0 +1,6 @@
+[package]
+org = "gizza-ai"
+name = "video-silence-cut"
+version = "0.1.0"
+abi = 1
+summary = "Remove silent gaps from a video (correct two-pass, A/V stays in sync)."

--- a/cli/tests/ffmpeg_tool.rs
+++ b/cli/tests/ffmpeg_tool.rs
@@ -27,3 +27,29 @@ async fn image_resize_dispatch_does_not_panic() {
         "dispatch should return a body or error, not panic: {r:?}"
     );
 }
+
+#[tokio::test]
+async fn video_silence_cut_is_registered_and_dispatches() {
+    if !have_ffmpeg() {
+        eprintln!("skipping: ffmpeg not installed");
+        return;
+    }
+    let rt = runtime::boot_full().await.expect("boot");
+    // The two-pass tool must be registered (embedded skill wasm).
+    assert!(
+        rt.tool("gizza-ai/video-silence-cut").is_some(),
+        "video-silence-cut should be a registered tool"
+    );
+    // bad url → structured error (fails at source-resolution, before pass 1),
+    // must not panic. Exercises arg-parsing + descriptor + dispatch wiring.
+    let r = rt
+        .run_tool(
+            "gizza-ai/video-silence-cut",
+            serde_json::json!({"url": "http://127.0.0.1:0/nope.mp4"}),
+        )
+        .await;
+    assert!(
+        r.is_ok(),
+        "dispatch should return a body or error, not panic: {r:?}"
+    );
+}

--- a/tests/skills_embed.rs
+++ b/tests/skills_embed.rs
@@ -238,3 +238,19 @@ fn video_compress_skill_is_embedded() {
     assert!(!bytes.is_empty());
     assert_eq!(&bytes[..4], b"\0asm");
 }
+
+#[test]
+fn video_silence_cut_skill_is_embedded() {
+    assert!(
+        gizza_ai::skills::SKILLS
+            .iter()
+            .any(|(n, _)| *n == "gizza-ai/video-silence-cut"),
+        "gizza-ai/video-silence-cut should be embedded — did you forget to build the block first?"
+    );
+    let (_, bytes) = gizza_ai::skills::SKILLS
+        .iter()
+        .find(|(n, _)| *n == "gizza-ai/video-silence-cut")
+        .expect("video-silence-cut");
+    assert!(!bytes.is_empty());
+    assert_eq!(&bytes[..4], b"\0asm");
+}


### PR DESCRIPTION
## What

A new `gizza-ai/video-silence-cut` tool that removes silent gaps from a video to tighten pacing (jump-cut style), **keeping audio and video in sync**.

This replaces the never-merged single-pass draft (`feat/tool-video-silence-cut`), whose author correctly documented that its `silenceremove` approach is audio-only and **desyncs the video** after the first removed gap.

## How — correct two-pass

1. **detect** — `ffmpeg … -af silencedetect=noise=<db>dB:d=<min> -f null -` (no output file). Parse `silence_start` / `silence_end` + the clip `Duration` from the returned log.
2. **cut** — compute the complementary non-silent **keep** segments and re-encode keeping only those time ranges of *both* streams: `select='between(t,…)+…',setpts=N/FRAME_RATE/TB` + `aselect='…',asetpts=N/SR/TB`. Because video and audio select the same ranges, they stay in sync.

The gizza ffmpeg bridge returns each exec's log and a block's `run()` can dispatch twice, so the two-pass flow works in **chat + CLI**.

## Surface — chat + CLI, no page

No standalone `/tools/` page: the generic page driver (`site/tool-ffmpeg.js`) is single-pass (one `build_argv` → one `ffmpegExec`). This is a chat+CLI tool, same shape as `web-fetch` / the other no-page tools. Auto-embeds via `build.rs` (`target/block.wasm` + `manifest.json`).

## Params (derived from `descriptor()`, single source)

- `url` ⊕ `ref` (video source) — from `Input::Video`
- `threshold_db` (number, ≤ 0; default −30) — silence loudness cutoff
- `min_silence` (number, > 0; default 0.5) — shortest gap to trim

## Tested

- **Core unit tests (20)** — argv builders, `silencedetect` log parsing, duration parsing, keep-segment computation (silence-at-start, trailing-to-EOF, all-silent, sub-ms sliver, no-silence). Verified the tests *bite* (broke the impl, watched them fail, reverted).
- **Descriptor sanity test** — schema is valid JSON with the params + `url`/`ref` `oneOf`.
- **Direct ffmpeg recipe validation** — generated a 6s clip with a known 2s silent gap; ran my exact pass-1 + pass-2 argv against system ffmpeg → output **4.02s** (gap removed), still valid **h264 + aac**, re-running `silencedetect` finds **no remaining silence** (A/V in sync).
- **`wafer build`** — wasm32 block compiles + validates OK (552 KiB).
- **Embed test** — `tests/skills_embed.rs` asserts the tool is embedded (16/16 pass).
- **CLI integration** — `cli/tests/ffmpeg_tool.rs` asserts the tool is registered and dispatch is panic-free.

## Not exercised

A live successful fetch-then-cut through chat/CLI was not run: `wafer-run/network` SSRF protection rejects localhost URLs (this is why the existing `image-resize` ffmpeg test also only asserts "bad url → no panic"). The two-pass ffmpeg recipe itself is proven directly (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)