### PR TITLE
Tool-loop quality hardening: generated manifests, strict per-slug hygiene, builder-prompt drift fixes

### DIFF
--- a/.claude/skills/create-next-tool/SKILL.md
+++ b/.claude/skills/create-next-tool/SKILL.md
@@ -14,6 +14,9 @@ Read the two sibling skills for the actual recipes:
 - `.claude/skills/new-tool/{SKILL.md,reference.md}` — the build procedure.
 - `.claude/skills/improve-tool/{SKILL.md,reference.md}` — the verify+improve procedure.
 
+Plus this skill's `references/` files (see the index at the bottom) — they encode every dead end
+already hit; read the relevant one BEFORE implementing.
+
 Follow these steps in order:
 
 0. **Toolchain.** This skill needs `cargo`, `wafer`, `wasm-pack`, `solobase`, `gizza`, Playwright,
@@ -46,7 +49,9 @@ Follow these steps in order:
 2. **Build** — follow `/new-tool` **steps 3–8** (classify type → `scripts/scaffold-tool.sh <slug> <type>`
    → implement `core`/`descriptor`/`web`/`page` → build → type-aware tests) using the `name` +
    `description` from step 1. **SKIP** `/new-tool` step 2 (branch) and steps 9–10 (push/PR/code-review)
-   — git is owned by step 4 here.
+   — git is owned by step 4 here. The manifest `tool.*` section is GENERATED, not hand-written:
+   after `cargo install --path cli`, run `python3 scripts/sync-tool-manifest.py <slug>` (see
+   "Manifest sync + hygiene gate" below).
 
    **Throughput note (verified):** the per-tool validation is `cd blocks/<slug> && cargo test
    --workspace` + `wafer build` (validates the chat block.wasm) + `wasm-pack build blocks/<slug>/web`
@@ -83,249 +88,55 @@ be headlessly verified (gpu has no page; chat-ffmpeg can't run in a Service Work
 state it explicitly rather than claiming a pass. **One tool per run**; re-invoke (or `/loop`) for the
 next.
 
-**Page output formats:** the page driver renders `format = "image" | "video" | "audio"` (media,
-with a download link) or anything else as `text`. Audio output (`format = "audio"` → `<audio
-controls>`) was added with `extract-audio-from-video` — so **video→audio** ffmpeg tools are fully
-supported now (set the page `format = "audio"`, give the block an `audio/*` mime via the core
-`Format::mime()`, and use `build_media_envelope`; CLI-test with a video that actually has an audio
-track — many small test clips are silent and will fail with "nothing to encode"). Still missing:
-audio-**input** tools (audio-convert/normalize/…) need an `AssetKind::Audio` + `accept="audio/*"`
-page input, which is unbuilt — keep those skiplisted.
-
 **Known limitation (mitigated):** the picker matches built tools by exact slug, so a semantic
 near-dup (e.g. `pdf-to-text` vs the built `pdf-extract-text`) isn't auto-detected. `docs/tool-skiplist.txt`
 holds the confirmed dups found so far; when you spot a NEW one mid-build, add it there (step 1) rather
-than shipping a redundant tool. Token-overlap auto-detection was tried and rejected — it false-flags
-distinct tools (`age-calculator` is not a dup of `calculator`), so dups stay hand-curated.
+than shipping a redundant tool. Always `ls blocks/ | grep -i <topic>` before building, and grep the
+named block's `core/src/lib.rs` to confirm a shaky skiplist reason. Token-overlap auto-detection was
+tried and rejected — it false-flags distinct tools (`age-calculator` is not a dup of `calculator`),
+so dups stay hand-curated.
 
-## Findings log (2026-06, opus loop)
+## Manifest sync + hygiene gate
 
-Reusable facts discovered while building ~20 tools. Trust these to skip dead ends.
+The page form reads `manifest.json` `tool.parameters` (NOT the live descriptor) to pick each
+field's control — a stub/stale manifest renders every field as a plain text box, enums included.
+The manifest is therefore **generated, never hand-edited**: after `cargo install --path cli`, run
 
-**Hygiene gate — sync the descriptor to everything it feeds (2026-07-01).** The page form
-reads `manifest.json` `tool.parameters` (NOT the live descriptor), so a stub/unsynced manifest
-renders every field as a text box — enums included. After editing `descriptor()`, re-sync
-`manifest.json` `tool.parameters` to `schema_json()`. Write FAQ as `<details>` accordions with a
-blank line inside each (plain `## FAQ` renders as bare headings). Fill every scaffold `TODO` and
-write one clean `summary` across the wafer_block macro + `wafer.toml` + `manifest.json` (no
-`"… skill"` suffix). `python3 scripts/check-tool-hygiene.py <slug>` enforces the manifest/enum
-sync, the FAQ-accordion presence, the no-scaffold-TODO rule, and summary consistency (the
-blank-line-inside-`<details>` convention is advisory, not gated); CI runs it repo-wide — run it
-before committing.
+```bash
+python3 scripts/sync-tool-manifest.py <slug>
+```
 
-**Page input field types (meta.toml `[[input]]`):** the generator renders each field by the
-descriptor's Param type, NOT the meta — so Playwright must match: `Param::enumv` → `<select>`
-(`page.selectOption('#in-<name>', value)`); `Param::boolean` → `<input type=checkbox>` (use
-`page.check`/`uncheck`, default reflects `.default(true)`); `Param::integer`/`number` → a field
-(`page.fill`); `Param::string` → `<input>` UNLESS the meta `[[input]]` sets `multiline = true`,
-which renders a `<textarea>`. **Use `multiline = true` for any text/code/key field** so pasted
-newlines are preserved (a plain `<input>` strips them — this is why multi-line keys can't go in a
-plain field). Pages still need `format = "text"` or output is gated off.
+which regenerates `tool.parameters` + `tool.description` from the installed CLI's live descriptor
+and syncs the one-line `summary` from the `#[wafer_block(summary = "…")]` macro into
+`manifest.json` + `wafer.toml` (one clean summary, no `"… skill"` suffix). Then
 
-**Crypto / encoding crates that instantiate in wafer (wasm32-wasip1):** `rsa` 0.9 (sign: pkcs1v15 +
-pss, `features=["sha2"]`), `p256/p384/p521` (+`spki`+`pkcs8`, EC needs `features=["arithmetic",
-"pkcs8"]`), `pgp` 0.14 (rPGP, `default-features=false`; encrypt/sign; for multi-recipient encryption
-wrap primary/subkey in a small enum impl'ing `PublicKeyTrait` since the slice must be homogeneous),
-`lopdf` 0.36 encryption (`Document::encrypt` + `EncryptionVersion::V5` AES-256, not feature-gated),
-`hmac`+`sha1`+`sha2`+`base32` (TOTP), `pem`, `quick-xml` 0.36, `qrcode` 0.14 (`features=["svg"]` → SVG
-string, no image dep), `zip` 8 (`default-features=false, features=["deflate"]`, read + write).
+```bash
+python3 scripts/check-tool-hygiene.py <slug>
+```
 
-**QR decode: use `quircs`, NOT `rqrr`.** `rqrr` compiles to wasm but pulls filesystem WASI imports
-(`path_open`/`fd_close`) the wafer runtime doesn't provide → fails to instantiate. `quircs` decodes
-from a raw grayscale buffer (`image::load_from_memory(..).to_luma8()` → `Quirc::identify`) and
-instantiates fine. (General rule: an engine crate must INSTANTIATE, not just compile — `wafer build`
-is the gate; watch for `cannot find import wasi_snapshot_preview1::{poll_oneoff,path_open,fd_close}`.)
+must exit 0 before committing — per-slug mode is STRICT: enum→manifest sync, FAQ as `<details>`
+accordions (blank line inside each), no scaffold TODOs, summary consistency, plus placeholders on
+text/number fields, ≥3 FAQ entries, and meta description length. CI runs the same gate repo-wide.
 
-**Time:** `std::time::SystemTime::now()` and `chrono::Utc::now()` DO instantiate in the chat block
-(wafer provides the clock import) and work natively in the CLI. But the PAGE target
-(wasm32-unknown-unknown) has NO std clock — get time in the web crate via `js_sys::Date::now()/1000`
-(add `js-sys` to web/Cargo.toml). Make the core take an explicit timestamp so it's deterministic and
-each surface supplies its own clock.
+## References (read the relevant one BEFORE implementing)
 
-**CLI verification fetch is SSRF-guarded:** `gizza tool … url=…` only fetches PUBLIC http(s); `data:`
-URLs and localhost are rejected ("request to private/internal address is not allowed"), and GitHub
-`/archive/` URLs redirect (the fetcher doesn't follow) — use a direct host. Handy public test inputs:
-zip → `https://codeload.github.com/octocat/Hello-World/zip/refs/heads/master`; live QR PNG →
-`https://api.qrserver.com/v1/create-qr-code/?data=...&size=300x300`.
+- `references/wasm-crates.md` — proven wasm-safe crates with full recipes (crypto, PGP,
+  ECDSA/Ed25519, EPUB/ZIP, mail parsing, GIF encoding, misc). Check here before adding ANY
+  dependency — an engine crate must INSTANTIATE under `wafer build`, not just compile.
+- `references/page-patterns.md` — how params render on the page (select/checkbox/textarea),
+  boolean checkbox defaults, drift-guard `N.0` gotcha, clocks across surfaces, recurring tool
+  shapes, page output formats (incl. audio), what's un-buildable (audio-input, multi-input ffmpeg).
+- `references/ops.md` — disk cleanup, the never-delete-web/pkg rule, cwd resets, SSRF-guarded CLI
+  fetch + public test URLs, hardware/concurrency reality, usage limits.
 
-**Tool shapes that recur:** SVG/PDF/image-bytes output → `build_media_envelope` (mime
-`image/svg+xml` / `application/pdf` / `image/png`), chat+CLI, NO page (image-bytes have no page render
-mode); hand-build SVG with `format!`/`r##"..."##` (colours like `#fff` need the `##` raw delimiter).
-File-input→JSON (strings/unzip/detect-file-type) use `AssetKind::Any` (there is no `AssetKind::File`)
-+ flat `Resp` via `GuestResult::respond`. Text+passphrase/key tools can reuse another block's core via
-`path = "../../<other>/core"` (text-encrypt reuses encrypt-file's AES-GCM core).
+When you resolve a NOVEL build-level finding (a new wasm-safe crate, a page pattern, an ops
+gotcha), append it to the matching `references/` file — not to this SKILL.md, which stays the
+procedure. Dispatcher/operational findings go to `create-tool-loop/SKILL.md`.
 
-**Disk:** per-block `target/` dirs are ~0.3–2.5 GB each and fill the disk after ~12 tools. Reclaim
-with: `for d in blocks/*/target; do find "$d" -mindepth 1 -maxdepth 1 ! -name block.wasm -exec rm -rf
-{} +; done` (keeps the committed `block.wasm` the CLI build embeds).
+## Sub-agent dispatch mode (long `/loop` runs)
 
-**Ops gotcha:** `wafer build` must run from inside `blocks/<slug>/`; `cargo install --path cli` and
-`wasm-pack build blocks/<slug>/web …` must run from the repo ROOT — after any `/tmp` poll the shell
-cwd resets to `/root`, so always cd to the absolute repo path before those.
-
-**Multi-input ffmpeg (e.g. video-concat) is effectively un-buildable here:** the page file-input is a
-single upload and ffmpeg can't run in the chat SW, so it'd be CLI-only — skiplist + defer.
-
-**NEVER delete `blocks/<slug>/web/pkg`** during cleanup — the page generator copies each tool's
-`web/pkg/*` into `pkg/tools/<slug>/`, so deleting one tool's pkg makes the *next* generator run fail
-(`No such file or directory` copying that slug). The disk-cleanup loop above only touches `target/`,
-which is correct; do not additionally `rm -rf` any `web/pkg`. If a pkg does go missing, rebuild it with
-`wasm-pack build blocks/<slug>/web --target web --release --out-dir pkg` before re-running the generator.
-
-**ECDSA signing (ecdsa-sign):** use `p256`/`p384 = { default-features=false, features=["arithmetic",
-"pkcs8","ecdsa","pem"] }` (the `pem` feature is what enables `SigningKey::from_pkcs8_pem`; there is no
-`sec1` feature flag) + `ecdsa = { features=["der"] }`. Sign with `use pXXX::ecdsa::{signature::Signer,
-Signature, SigningKey}; use pXXX::pkcs8::DecodePrivateKey;` then `let sig: Signature = sk.sign(msg)`
-(deterministic RFC-6979 — no RNG, instantiates clean in wafer, no getrandom needed). DER bytes =
-`sig.to_der().as_bytes().to_vec()` (NOT `.to_bytes()`); raw r||s = `sig.to_bytes().to_vec()` (64 B P-256,
-96 B P-384). **Skip P-521**: `p521`'s ECDSA `Signer` impl is randomized-only (gated on `getrandom`, uses
-`OsRng`, no RFC-6979 path), so it breaks determinism and pulls getrandom — support P-256/P-384 only.
-Verify DER output cross-tool with `openssl dgst -sha256 -verify pub.pem -signature sig.der msg`.
-
-**Ed25519 (ed25519-key-pair-generator):** `ed25519-dalek = { default-features=false, features=["pkcs8",
-"pem","rand_core"] }` + `rand="0.8"`. `SigningKey::generate(&mut rand::rngs::OsRng)`, then
-`sk.to_pkcs8_pem(LineEnding::LF)` (import `ed25519_dalek::pkcs8::spki::der::pem::LineEnding` +
-`EncodePrivateKey`/`EncodePublicKey`), `vk.to_public_key_pem(...)`, raw via `sk.to_bytes()`/`vk.to_bytes()`
-(32 B each). Re-parse with `SigningKey::from_pkcs8_pem` (needs `DecodePrivateKey`). Like key-gen generally
-(see generate-rsa-key-pair): **no page** — a zero-input non-deterministic generator doesn't fit the page's
-recompute-on-input model. No-input chat tool: empty `#[derive(Deserialize,Default)] #[serde(default)] struct
-Args {}`, descriptor `ToolDescriptor::new(Input::None)` (no params) → authored schema is just
-`{"type":"object","properties":{},"additionalProperties":false}`.
-
-**More proven wasm-safe crates (this loop):** `mail-parser = "0.11"` (default-features=false) — RFC 5322/MIME
-email parsing; `MessageParser::default().parse(bytes)`, `msg.from()/to()/cc()` return `Option<&Address>`
-(use `.iter()` → `Addr::name()/address()`), `msg.body_text(0)/body_html(0)`, `msg.attachments()` →
-`MessagePart` (`use mail_parser::MimeHeaders` for `.attachment_name()/.content_type()`; ContentType has
-`.ctype()/.subtype()`), `msg.date().to_rfc3339()`. `htmd = "0.5"` (HTML→Markdown) + `nanohtml2text = "0.1"`
-(`html2text(&s)`, HTML→plain) + `quick-xml = "0.40"` (default-features=false) all instantiate in wafer.
-
-**EPUB / ZIP-container parsing (epub-to-markdown):** an EPUB is a ZIP — read with
-`zip::ZipArchive::new(Cursor::new(bytes))`, find OPF via `META-INF/container.xml` (`<rootfile full-path>`),
-parse the OPF with quick-xml for `<manifest><item id href media-type>` + `<spine><itemref idref>` to get
-**reading order** (don't use ZIP/alphabetical order), resolve hrefs relative to the OPF dir, convert each
-XHTML. quick-xml: match elements by local name (strip `ns:` prefix), handle both `Event::Start` and
-`Event::Empty` for self-closing `<item/>`. Binary-file-in/text-out → **no page** (file-input pattern).
-
-**An "ffmpeg"-tagged image→GIF/animation tool often needs NO ffmpeg** (gif-from-images): the `image` crate
-(features incl. `gif`) encodes animated GIFs purely — `use image::codecs::gif::{GifEncoder, Repeat};
-enc.set_repeat(Repeat::Infinite); enc.encode_frame(Frame::from_parts(rgba, 0, 0,
-Delay::from_numer_denom_ms(ms, 1)))`. Building it pure-Rust makes it run on ALL backends (incl. chat SW),
-strictly better than ffmpeg-only. Multi-image-in + image-bytes-out → chat+CLI, **no page** (use
-`Param::source_list("images", 1)` + `Vec<SourceFields>`, resolve each via `resolve_source`, like
-image-collage/images-to-pdf). Don't reflexively skiplist a media tool as "ffmpeg" — check if `image`/a
-pure crate covers it first.
-
-**OpenPGP key generation (generate-pgp-key-pair):** rPGP `pgp = "0.14"` (default-features=false) + rand 0.8
-+ chrono(`clock`) + smallvec. `SecretKeyParamsBuilder::default().key_type(KeyType::EdDSALegacy /
-Rsa(bits)).can_certify(true).can_sign(true).primary_user_id(uid).subkey(SubkeyParamsBuilder…
-.key_type(KeyType::ECDH(ECCCurve::Curve25519) / Rsa(bits)).can_encrypt(true).build()?)` →
-`.build()?.generate(&mut OsRng)?` → `.sign(&mut rng, || passphrase)?` = `SignedSecretKey`. Armor:
-`sk.to_armored_string(None.into())?`; public = `let pk: SignedPublicKey = sk.into(); pk.to_armored_string(
-None.into())?`. Fingerprint: `sk.fingerprint().as_bytes()`. Tests need `use pgp::types::SecretKeyTrait` for
-`.unlock()`. Curve25519 = fast (good for tests); RSA-4096 slow. Non-deterministic generator → **no page**.
-Cross-verify a generated public key by feeding it to the existing `pgp-encrypt` tool.
-
-**OpenPGP key inspection with a page (pgp-key-info):** `pgp = "0.14"` works for read-only key
-metadata on both wafer and wasm-pack, but the browser `wasm32-unknown-unknown` build may pull
-`getrandom` transitively through crypto crates even when the code only parses keys. Add
-`getrandom = { version = "0.2", features = ["js"] }` in the core crate so
-`wasm-pack --target web` doesn't fail with "wasm*-unknown-unknown targets are not supported by
-default". The same crate still builds under `wafer build` for `wasm32-wasip1`.
-
-**Dup-skiplist:** generate-totp (= existing totp-generator), generate-pgp-key… no — built. Always grep
-`ls blocks/ | grep -i <topic>` before building; a near-dup of an existing block → skiplist + re-pick.
-
-**PAGE BOOLEAN CHECKBOX DEFAULT:** the page generator renders a boolean param as `<input type=checkbox
-checked[default]>` — i.e. the box is **checked iff the descriptor `Param::boolean(...).default(true)`**. So a
-`default(true)` boolean shows CHECKED on load, and the web `run()` receives `"true"`; unchecked sends
-`"false"`. In the web wrapper use **positive truthy** (`matches!(v, "true"|"1"|"on"|"yes")`). In Playwright,
-a default-true checkbox is already checked — to test the off-path call `page.uncheck('#in-<name>')` (not just
-leaving it). HTML-tokenizer tools (html-formatter pretty / html-minifier) are a clean pair: a forgiving
-quote-aware tag scanner (`scan_tag` skipping quoted `>`), VOID elements don't indent, and pre/textarea/
-script/style are emitted verbatim — HTML is NOT well-formed XML so quick-xml (used by xml-formatter) can't
-parse it.
-**DRIFT GOTCHA — number-param defaults serialize as `N.0`:** `Param::number("x").default(1.0)` renders
-`"default": 1.0` in the schema. In the authored drift JSON write `"default": 1.0` (NOT `1`) — serde_json
-treats `1` as an integer and `1.0` as a float, so they compare unequal and the drift test fails. (Integer
-params with `.default(1)` correctly render `1`.) `color_quant = "1"` (NeuQuant) is wasm-safe — image color
-quantization to N colors. HSL image edits: hand-roll RGB↔HSL (no extra dep) for hue-shift / sat / lightness.
-
-## Orchestration / environment findings (2026-06-21)
-
-**Hardware reality on this box: 2 CPUs, ~3.9 GB total RAM (~2.9 GB free), 78 GB disk.** A single Rust
-release build (rustc + `wasm-opt` in wasm-pack + `cargo install cli`) peaks around 1–2 GB and saturates
-both cores. **Parallel tool builds are NOT viable here** — two concurrent heavy builds risk OOM on ~3 GB
-free, and the 2-core CPU means wall-clock barely improves. RAM-adaptive concurrency
-(`free -m` → floor(available_GB / ~3)) computes ≈1 on this machine. So the loop is effectively
-**sequential, one tool at a time**. (Also: `cargo install --path cli`, the page generator, and `git push`
-all touch global/shared state — parallel builders would need separate worktrees AND serialized
-CLI-install/generate/push, negating the gain.)
-
-**The real win from sub-agents here is CONTEXT, not speed:** a thin dispatcher that spawns a FRESH
-general-purpose sub-agent per tool (pick→build→test→commit→push, return a one-line result) keeps the
-loop's own context tiny and effectively "clears context" every tool, letting the loop run indefinitely.
-No races because only one builder runs at a time.
-
-**5-hour usage limit:** there is NO local JSON recording the rolling 5-hour usage window / reset time.
-`~/.claude/.credentials.json` holds only OAuth (`accessToken`/`refreshToken`/`expiresAt` = token expiry,
-not the usage window) plus `subscriptionType=max`, `rateLimitTier=default_claude_max_20x`. The 5-hour
-quota + reset are enforced server-side and only surfaced on a rate-limit error response — so the loop
-can't pre-read remaining budget from disk; it must react to a limit error (back off / stop) when it hits one.
-
-**More proven wasm-safe crates (this loop):** `toml = "0.8"` (config; TOML needs a table root + has no
-null), `color_quant = "1"` (NeuQuant palette quantization), `kamadak-exif = "0.6"` (EXIF/TIFF read —
-`Reader::new().read_from_container(Cursor)`, `field.tag`/`field.display_value().with_unit(&exif)`, GPS
-rationals → decimal), `serde_json` `preserve_order` feature (keeps object key order). PDF *generation*
-needs no new crate — build content streams with the already-proven `lopdf` (base-14 Helvetica, BT/Tf/Td/Tj/ET).
-For exact RFC test vectors (e.g. RFC 7638 jwk-thumbprint) WebFetch the RFC rather than trusting memory —
-a mis-remembered constant fails the vector.
-
-## Sub-agent dispatch mode (preferred for long `/loop` runs)
-
-To keep the loop's own context small (so it can run for hours without hitting the context window), the
-loop should act as a **thin dispatcher**: per iteration, spawn ONE fresh general-purpose sub-agent that
-builds the next tool end-to-end and returns only a one-line result. The heavy per-tool transcript
-(scaffold, build logs, test output) stays inside the sub-agent and never enters the dispatcher's context.
-**Sequential only** (one builder at a time) on this 2-CPU / ~4 GB box — parallel builders OOM and race on
-the shared CLI/generator/git (see environment findings above).
-
-Dispatcher per iteration:
-1. `Agent(subagent_type:"general-purpose", description:"build next gizza tool", prompt: <BUILDER PROMPT below>)`.
-2. Read the returned one-liner; if it says a tool was built+pushed or skiplisted, continue. If it says
-   FAILED or hit a usage/rate limit, back off (longer ScheduleWakeup) and report.
-3. `ScheduleWakeup` to re-enter `/loop` (dispatch the next one). Do NOT build inline anymore.
-
-**The full long-running loop now lives in the sibling `create-tool-loop` skill** (dispatcher +
-pacing + failure/limit back-off + task-leak cleanup + operational findings). Prefer invoking that
-to run the loop. The BUILDER PROMPT below is kept here for reference and must stay in sync with it.
-
-**FOREGROUND builds only (2026-06-22):** the builder MUST run every build in the foreground (Bash
-timeout up to 600000 ms covers any single step) and must NOT use `run_in_background` or `sleep`/poll
-loops — those leak as orphan "running" tasks that pile up by the hundreds. Kill any background job
-before returning.
-
-BUILDER PROMPT (self-contained — the sub-agent has a fresh context, so it must be told everything):
-> Build the next gizza backlog tool end-to-end. Working dir /root/gizza-ai/gizza-ai; `source $HOME/.cargo/env`
-> in every bash command; use absolute paths; for `wafer build` cd into blocks/<slug>/ first; cwd resets to
-> /root after /tmp commands. Steps: (1) `python3 scripts/pick-next-tool.py 2>/dev/null | grep -v '^skip' | head -1`.
-> (2) Read `.claude/skills/create-next-tool/SKILL.md` (esp. the Findings log) and follow the new-tool build
-> procedure: classify type, `scripts/scaffold-tool.sh <slug> <type>`, implement core (+unit tests)/descriptor
-> (+drift-guard schema test)/web/page, build (`cargo test`, then `wafer build` in blocks/<slug>/ and
-> `wasm-pack build blocks/<slug>/web --target web --release --out-dir pkg` — run heavy builds in background +
-> poll), `cargo install --path cli`, `cargo run --manifest-path tools/generator/Cargo.toml -- .`, verify all
-> applicable surfaces (CLI `gizza tool <slug>`; page Playwright `cd tests && xvfb-run npx playwright test
-> tool-page-<slug>.spec.ts`). (2b) Apply the /improve-tool usability standards to the page: model every
-> fixed-choice param as `Param::enumv` (the page renders it as a <select>); write the FAQ as
-> `<details>`/`<summary>` accordions with a BLANK LINE inside each (so the answer markdown renders + wraps
-> in <p> — plain `## FAQ` markdown is a hard-fail); and SYNC `manifest.json` `tool.parameters` to the
-> descriptor schema — the page form reads the MANIFEST, not the live descriptor, so a stub/`{input:string}`
-> manifest renders EVERY field as a plain text box. Then run `python3 scripts/check-tool-hygiene.py <slug>`
-> and fix any violation before continuing (it is the same gate CI enforces). (3) Write
-> `docs/checks/<today>-improve-<slug>-competitor-analysis.md`.
-> (4) If it's a semantic dup of an existing block, instead append `<slug>  # reason` to
-> `docs/tool-skiplist.txt`, commit that, and re-pick. (5) Honesty gate: if it can't be built+verified in
-> ≤3 fix attempts, `git clean -fd blocks/<slug>`, skiplist or report, do NOT commit broken. (6) Clean
-> per-block target dirs (`for d in blocks/*/target; do find "$d" -mindepth 1 -maxdepth 1 ! -name block.wasm
-> -exec rm -rf {} + ; done`), NEVER delete web/pkg. (7) `git add -A && git commit && git push origin
-> feat/tool-creating-2`. Return ONE line only: `<slug>: built+pushed <short-sha>` OR `skiplisted <slug>: <reason>`
-> OR `FAILED <slug>: <reason>`.
+The long-running loop — dispatcher algorithm, pacing, failure/limit back-off, task-leak cleanup,
+and the ONLY copy of the **BUILDER PROMPT** — lives in the sibling
+`.claude/skills/create-tool-loop/SKILL.md`. Do NOT duplicate the builder prompt here: a second
+copy drifted once (it kept telling builders to run heavy builds in background + poll after the
+loop had banned that for leaking orphan tasks by the hundreds) and was removed on 2026-07-02.

--- a/.claude/skills/create-next-tool/references/ops.md
+++ b/.claude/skills/create-next-tool/references/ops.md
@@ -1,0 +1,33 @@
+# Ops / environment findings (disk, cwd, verification inputs, limits)
+
+**Disk:** per-block `target/` dirs are ~0.3–2.5 GB each and fill a small disk after ~12 tools. Reclaim
+with: `for d in blocks/*/target; do find "$d" -mindepth 1 -maxdepth 1 ! -name block.wasm -exec rm -rf
+{} +; done` (keeps the committed `block.wasm` the CLI build embeds).
+
+**NEVER delete `blocks/<slug>/web/pkg`** during cleanup — the page generator copies each tool's
+`web/pkg/*` into `pkg/tools/<slug>/`, so deleting one tool's pkg makes the *next* generator run fail
+(`No such file or directory` copying that slug). The disk-cleanup loop above only touches `target/`,
+which is correct; do not additionally `rm -rf` any `web/pkg`. If a pkg does go missing, rebuild it with
+`wasm-pack build blocks/<slug>/web --target web --release --out-dir pkg` before re-running the generator.
+
+**cwd gotcha:** `wafer build` must run from inside `blocks/<slug>/`; `cargo install --path cli` and
+`wasm-pack build blocks/<slug>/web …` must run from the repo ROOT — after any `/tmp` command the shell
+cwd resets, so always cd to the absolute repo path before those.
+
+**CLI verification fetch is SSRF-guarded:** `gizza tool … url=…` only fetches PUBLIC http(s); `data:`
+URLs and localhost are rejected ("request to private/internal address is not allowed"), and GitHub
+`/archive/` URLs redirect (the fetcher doesn't follow) — use a direct host. Handy public test inputs:
+zip → `https://codeload.github.com/octocat/Hello-World/zip/refs/heads/master`; live QR PNG →
+`https://api.qrserver.com/v1/create-qr-code/?data=...&size=300x300`.
+
+**Hardware / concurrency (probe, don't assume):** a single Rust release build (rustc + `wasm-opt` in
+wasm-pack + `cargo install cli`) peaks around 1–2 GB and saturates its cores. On a small box (the
+original loop ran on 2 CPUs / ~3.9 GB RAM) parallel tool builds OOM; on any box, parallel builders
+race on the shared `cargo install`/page-generator/`git push` state — so the loop is **sequential, one
+tool at a time** regardless of hardware. The real win from sub-agents is CONTEXT, not speed: a fresh
+builder per tool keeps the dispatcher's context tiny so the loop runs indefinitely.
+
+**5-hour usage limit:** there is NO local JSON recording the rolling 5-hour usage window / reset time.
+`~/.claude/.credentials.json` holds only OAuth tokens (token expiry, not the usage window). The quota
++ reset are enforced server-side and only surfaced on a rate-limit error response — the loop can't
+pre-read remaining budget from disk; it must react to a limit error (back off / stop) when it hits one.

--- a/.claude/skills/create-next-tool/references/page-patterns.md
+++ b/.claude/skills/create-next-tool/references/page-patterns.md
@@ -1,0 +1,48 @@
+# Page / surface patterns (input rendering, defaults, drift, tool shapes)
+
+**Page input field types (meta.toml `[[input]]`):** the generator renders each field by the
+descriptor's Param type, NOT the meta — so Playwright must match: `Param::enumv` → `<select>`
+(`page.selectOption('#in-<name>', value)`); `Param::boolean` → `<input type=checkbox>` (use
+`page.check`/`uncheck`, default reflects `.default(true)`); `Param::integer`/`number` → a field
+(`page.fill`); `Param::string` → `<input>` UNLESS the meta `[[input]]` sets `multiline = true`,
+which renders a `<textarea>`. **Use `multiline = true` for any text/code/key field** so pasted
+newlines are preserved (a plain `<input>` strips them — this is why multi-line keys can't go in a
+plain field). Pages still need `format = "text"` or output is gated off.
+
+**PAGE BOOLEAN CHECKBOX DEFAULT:** the page generator renders a boolean param as `<input type=checkbox
+checked[default]>` — i.e. the box is **checked iff the descriptor `Param::boolean(...).default(true)`**. So a
+`default(true)` boolean shows CHECKED on load, and the web `run()` receives `"true"`; unchecked sends
+`"false"`. In the web wrapper use **positive truthy** (`matches!(v, "true"|"1"|"on"|"yes")`). In Playwright,
+a default-true checkbox is already checked — to test the off-path call `page.uncheck('#in-<name>')` (not just
+leaving it).
+
+**DRIFT GOTCHA — number-param defaults serialize as `N.0`:** `Param::number("x").default(1.0)` renders
+`"default": 1.0` in the schema. In the authored drift JSON write `"default": 1.0` (NOT `1`) — serde_json
+treats `1` as an integer and `1.0` as a float, so they compare unequal and the drift test fails. (Integer
+params with `.default(1)` correctly render `1`.)
+
+**Clocks across surfaces:** `std::time::SystemTime::now()` and `chrono::Utc::now()` DO instantiate in the
+chat block (wafer provides the clock import) and work natively in the CLI. But the PAGE target
+(wasm32-unknown-unknown) has NO std clock — get time in the web crate via `js_sys::Date::now()/1000`
+(add `js-sys` to web/Cargo.toml). Make the core take an explicit timestamp so it's deterministic and
+each surface supplies its own clock.
+
+**Tool shapes that recur:** SVG/PDF/image-bytes output → `build_media_envelope` (mime
+`image/svg+xml` / `application/pdf` / `image/png`), chat+CLI, NO page (image-bytes have no page render
+mode); hand-build SVG with `format!`/`r##"..."##` (colours like `#fff` need the `##` raw delimiter).
+File-input→JSON (strings/unzip/detect-file-type) use `AssetKind::Any` (there is no `AssetKind::File`)
++ flat `Resp` via `GuestResult::respond`. Text+passphrase/key tools can reuse another block's core via
+`path = "../../<other>/core"` (text-encrypt reuses encrypt-file's AES-GCM core).
+
+**Page output formats:** the page driver renders `format = "image" | "video" | "audio"` (media,
+with a download link) or anything else as `text`. Audio output (`format = "audio"` → `<audio
+controls>`) works — **video→audio** ffmpeg tools are fully supported (set the page `format = "audio"`,
+give the block an `audio/*` mime via the core `Format::mime()`, and use `build_media_envelope`;
+CLI-test with a video that actually has an audio track — many small test clips are silent and fail
+with "nothing to encode"). Still missing: audio-**input** tools (audio-convert/normalize/…) need an
+`AssetKind::Audio` + `accept="audio/*"` page input, which is unbuilt — keep those skiplisted.
+
+**Multi-input ffmpeg (e.g. video-concat) is effectively un-buildable here:** the page file-input is a
+single upload and ffmpeg can't run in the chat SW, so it'd be CLI-only — skiplist + defer.
+(Multi-IMAGE pure-Rust tools ARE buildable as chat+CLI, no page — see the gif-from-images entry in
+wasm-crates.md.)

--- a/.claude/skills/create-next-tool/references/wasm-crates.md
+++ b/.claude/skills/create-next-tool/references/wasm-crates.md
@@ -1,0 +1,91 @@
+# Proven wasm-safe crates + recipes (wafer wasm32-wasip1 / wasm-pack wasm32-unknown-unknown)
+
+Read this before adding ANY new dependency. An engine crate must INSTANTIATE, not just compile —
+`wafer build` is the gate; watch for `cannot find import
+wasi_snapshot_preview1::{poll_oneoff,path_open,fd_close}`.
+
+**Crypto / encoding crates that instantiate in wafer (wasm32-wasip1):** `rsa` 0.9 (sign: pkcs1v15 +
+pss, `features=["sha2"]`), `p256/p384/p521` (+`spki`+`pkcs8`, EC needs `features=["arithmetic",
+"pkcs8"]`), `pgp` 0.14 (rPGP, `default-features=false`; encrypt/sign; for multi-recipient encryption
+wrap primary/subkey in a small enum impl'ing `PublicKeyTrait` since the slice must be homogeneous),
+`lopdf` 0.36 encryption (`Document::encrypt` + `EncryptionVersion::V5` AES-256, not feature-gated),
+`hmac`+`sha1`+`sha2`+`base32` (TOTP), `pem`, `quick-xml` 0.36, `qrcode` 0.14 (`features=["svg"]` → SVG
+string, no image dep), `zip` 8 (`default-features=false, features=["deflate"]`, read + write).
+
+**QR decode: use `quircs`, NOT `rqrr`.** `rqrr` compiles to wasm but pulls filesystem WASI imports
+(`path_open`/`fd_close`) the wafer runtime doesn't provide → fails to instantiate. `quircs` decodes
+from a raw grayscale buffer (`image::load_from_memory(..).to_luma8()` → `Quirc::identify`) and
+instantiates fine.
+
+**ECDSA signing (ecdsa-sign):** use `p256`/`p384 = { default-features=false, features=["arithmetic",
+"pkcs8","ecdsa","pem"] }` (the `pem` feature is what enables `SigningKey::from_pkcs8_pem`; there is no
+`sec1` feature flag) + `ecdsa = { features=["der"] }`. Sign with `use pXXX::ecdsa::{signature::Signer,
+Signature, SigningKey}; use pXXX::pkcs8::DecodePrivateKey;` then `let sig: Signature = sk.sign(msg)`
+(deterministic RFC-6979 — no RNG, instantiates clean in wafer, no getrandom needed). DER bytes =
+`sig.to_der().as_bytes().to_vec()` (NOT `.to_bytes()`); raw r||s = `sig.to_bytes().to_vec()` (64 B P-256,
+96 B P-384). **Skip P-521**: `p521`'s ECDSA `Signer` impl is randomized-only (gated on `getrandom`, uses
+`OsRng`, no RFC-6979 path), so it breaks determinism and pulls getrandom — support P-256/P-384 only.
+Verify DER output cross-tool with `openssl dgst -sha256 -verify pub.pem -signature sig.der msg`.
+
+**Ed25519 (ed25519-key-pair-generator):** `ed25519-dalek = { default-features=false, features=["pkcs8",
+"pem","rand_core"] }` + `rand="0.8"`. `SigningKey::generate(&mut rand::rngs::OsRng)`, then
+`sk.to_pkcs8_pem(LineEnding::LF)` (import `ed25519_dalek::pkcs8::spki::der::pem::LineEnding` +
+`EncodePrivateKey`/`EncodePublicKey`), `vk.to_public_key_pem(...)`, raw via `sk.to_bytes()`/`vk.to_bytes()`
+(32 B each). Re-parse with `SigningKey::from_pkcs8_pem` (needs `DecodePrivateKey`). Like key-gen generally
+(see generate-rsa-key-pair): **no page** — a zero-input non-deterministic generator doesn't fit the page's
+recompute-on-input model. No-input chat tool: empty `#[derive(Deserialize,Default)] #[serde(default)] struct
+Args {}`, descriptor `ToolDescriptor::new(Input::None)` (no params) → authored schema is just
+`{"type":"object","properties":{},"additionalProperties":false}`.
+
+**Text/parsing crates:** `mail-parser = "0.11"` (default-features=false) — RFC 5322/MIME
+email parsing; `MessageParser::default().parse(bytes)`, `msg.from()/to()/cc()` return `Option<&Address>`
+(use `.iter()` → `Addr::name()/address()`), `msg.body_text(0)/body_html(0)`, `msg.attachments()` →
+`MessagePart` (`use mail_parser::MimeHeaders` for `.attachment_name()/.content_type()`; ContentType has
+`.ctype()/.subtype()`), `msg.date().to_rfc3339()`. `htmd = "0.5"` (HTML→Markdown) + `nanohtml2text = "0.1"`
+(`html2text(&s)`, HTML→plain) + `quick-xml = "0.40"` (default-features=false) all instantiate in wafer.
+
+**EPUB / ZIP-container parsing (epub-to-markdown):** an EPUB is a ZIP — read with
+`zip::ZipArchive::new(Cursor::new(bytes))`, find OPF via `META-INF/container.xml` (`<rootfile full-path>`),
+parse the OPF with quick-xml for `<manifest><item id href media-type>` + `<spine><itemref idref>` to get
+**reading order** (don't use ZIP/alphabetical order), resolve hrefs relative to the OPF dir, convert each
+XHTML. quick-xml: match elements by local name (strip `ns:` prefix), handle both `Event::Start` and
+`Event::Empty` for self-closing `<item/>`. Binary-file-in/text-out → **no page** (file-input pattern).
+
+**An "ffmpeg"-tagged image→GIF/animation tool often needs NO ffmpeg** (gif-from-images): the `image` crate
+(features incl. `gif`) encodes animated GIFs purely — `use image::codecs::gif::{GifEncoder, Repeat};
+enc.set_repeat(Repeat::Infinite); enc.encode_frame(Frame::from_parts(rgba, 0, 0,
+Delay::from_numer_denom_ms(ms, 1)))`. Building it pure-Rust makes it run on ALL backends (incl. chat SW),
+strictly better than ffmpeg-only. Multi-image-in + image-bytes-out → chat+CLI, **no page** (use
+`Param::source_list("images", 1)` + `Vec<SourceFields>`, resolve each via `resolve_source`, like
+image-collage/images-to-pdf). Don't reflexively skiplist a media tool as "ffmpeg" — check if `image`/a
+pure crate covers it first.
+
+**OpenPGP key generation (generate-pgp-key-pair):** rPGP `pgp = "0.14"` (default-features=false) + rand 0.8
++ chrono(`clock`) + smallvec. `SecretKeyParamsBuilder::default().key_type(KeyType::EdDSALegacy /
+Rsa(bits)).can_certify(true).can_sign(true).primary_user_id(uid).subkey(SubkeyParamsBuilder…
+.key_type(KeyType::ECDH(ECCCurve::Curve25519) / Rsa(bits)).can_encrypt(true).build()?)` →
+`.build()?.generate(&mut OsRng)?` → `.sign(&mut rng, || passphrase)?` = `SignedSecretKey`. Armor:
+`sk.to_armored_string(None.into())?`; public = `let pk: SignedPublicKey = sk.into(); pk.to_armored_string(
+None.into())?`. Fingerprint: `sk.fingerprint().as_bytes()`. Tests need `use pgp::types::SecretKeyTrait` for
+`.unlock()`. Curve25519 = fast (good for tests); RSA-4096 slow. Non-deterministic generator → **no page**.
+Cross-verify a generated public key by feeding it to the existing `pgp-encrypt` tool.
+
+**OpenPGP key inspection with a page (pgp-key-info):** `pgp = "0.14"` works for read-only key
+metadata on both wafer and wasm-pack, but the browser `wasm32-unknown-unknown` build may pull
+`getrandom` transitively through crypto crates even when the code only parses keys. Add
+`getrandom = { version = "0.2", features = ["js"] }` in the core crate so
+`wasm-pack --target web` doesn't fail with "wasm*-unknown-unknown targets are not supported by
+default". The same crate still builds under `wafer build` for `wasm32-wasip1`.
+
+**Misc proven crates:** `toml = "0.8"` (config; TOML needs a table root + has no null),
+`color_quant = "1"` (NeuQuant palette quantization to N colors), `kamadak-exif = "0.6"` (EXIF/TIFF read —
+`Reader::new().read_from_container(Cursor)`, `field.tag`/`field.display_value().with_unit(&exif)`, GPS
+rationals → decimal), `serde_json` `preserve_order` feature (keeps object key order). PDF *generation*
+needs no new crate — build content streams with the already-proven `lopdf` (base-14 Helvetica, BT/Tf/Td/Tj/ET).
+HSL image edits: hand-roll RGB↔HSL (no extra dep) for hue-shift / sat / lightness. For exact RFC test
+vectors (e.g. RFC 7638 jwk-thumbprint) WebFetch the RFC rather than trusting memory — a mis-remembered
+constant fails the vector.
+
+**HTML tokenizing (html-formatter / html-minifier):** HTML is NOT well-formed XML so quick-xml (used by
+xml-formatter) can't parse it. A forgiving quote-aware tag scanner (`scan_tag` skipping quoted `>`) works;
+VOID elements don't indent; pre/textarea/script/style are emitted verbatim.

--- a/.claude/skills/create-tool-loop/SKILL.md
+++ b/.claude/skills/create-tool-loop/SKILL.md
@@ -10,18 +10,23 @@ iteration spawns ONE fresh `general-purpose` sub-agent that builds the next back
 end-to-end and returns a single one-line result. The heavy build transcript stays inside the
 sub-agent so the dispatcher's own context stays tiny and the loop can run for hours.
 
-This skill is the orchestration layer. The per-tool build recipe and all crate/wasm build-level
-findings live in the sibling **`.claude/skills/create-next-tool/SKILL.md`** — each builder reads
-that itself. Keep build-level findings (wasm-safe crates, page patterns, etc.) THERE; keep
-dispatcher/operational findings in this file's **Operational findings log** below, and append to
-it whenever you learn something new (see "Self-update").
+This skill is the orchestration layer. The per-tool build recipe lives in the sibling
+**`.claude/skills/create-next-tool/SKILL.md`** and its **`references/`** files (wasm-safe
+crates, page patterns, ops gotchas) — each builder reads those itself. Keep build-level
+findings THERE (in the matching references/ file); keep dispatcher/operational findings in
+this file's **Operational findings log** below, and append to it whenever you learn something
+new (see "Self-update").
 
-Working context (defaults; override if the user says otherwise):
-- Working dir: `/root/gizza-ai/gizza-ai`
-- Branch: `feat/tool-creating-2` (no new branch, no PR — just commit + push)
-- Box: **2 CPU / ~3.9 GB RAM**. **Sequential only — one builder at a time** (parallel Rust release
-  builds OOM and contend on the shared `cargo install`/generator/git state; 2 cores mean
-  parallelism barely helps wall-clock anyway).
+Working context (DERIVE at dispatch time — never hardcode; boxes and branches change between runs):
+- **`<REPO>`** = the gizza-ai checkout root: `git rev-parse --show-toplevel` from the invocation cwd.
+- **`<BRANCH>`** = `git branch --show-current`. No new branch, no PR — just commit + push to
+  `<BRANCH>`. **If it is `main`, STOP and ask the user for a feature branch first** (workspace
+  rule: PRs, not direct-to-main).
+- **Concurrency:** probe with `nproc` + `free -g`. Default **sequential — one builder at a time**:
+  even on a big box, parallel builders race on the shared `cargo install`/generator/git state,
+  and a Rust release build peaks 1–2 GB/core. Sequential is the safe default everywhere.
+- Substitute `<REPO>`, `<BRANCH>`, and `<TODAY>` (current date) into the BUILDER PROMPT at every
+  dispatch — the sub-agent gets a fresh context and only knows what you paste.
 
 ## Dispatcher algorithm (per iteration)
 
@@ -30,7 +35,7 @@ Working context (defaults; override if the user says otherwise):
    the `ScheduleWakeup` you set is only a **fallback heartbeat** in case a build hangs.
 2. **(First iteration / sanity)** Confirm branch and next tool:
    ```bash
-   cd /root/gizza-ai/gizza-ai && git branch --show-current
+   cd <REPO> && git branch --show-current   # must NOT be main — see Working context
    python3 scripts/pick-next-tool.py 2>/dev/null | grep -v '^skip' | head -1
    ```
    `pick-next-tool.py` prints `<slug>\t<name>\t<description>\t<type_hint>` or a sentinel
@@ -49,11 +54,14 @@ Working context (defaults; override if the user says otherwise):
 6. **Report each result** to the user as a one-liner and keep a running tally
    (`built / skiplisted` counts). Keep dispatcher messages short.
 
-## BUILDER PROMPT (self-contained — paste verbatim to each sub-agent)
+## BUILDER PROMPT (canonical copy — paste verbatim, after substituting `<REPO>`/`<BRANCH>`/`<TODAY>`)
 
-> Build the next gizza backlog tool end-to-end. Working dir /root/gizza-ai/gizza-ai; `source
-> $HOME/.cargo/env` in every bash command; use absolute paths; for `wafer build` cd into
-> blocks/<slug>/ first; cwd resets to /root after /tmp commands.
+This is the ONLY copy of the builder prompt; `create-next-tool/SKILL.md` points here. Edit it
+here or nowhere (a second copy WILL drift — it did once, re-introducing banned background builds).
+
+> Build the next gizza backlog tool end-to-end. Working dir `<REPO>` (a gizza-ai checkout), branch
+> `<BRANCH>`. Use absolute paths; `source $HOME/.cargo/env` in every bash command; `wafer build`
+> runs from INSIDE blocks/<slug>/; cwd resets after /tmp commands.
 >
 > CRITICAL — NO BACKGROUND JOBS / NO TASK LEAKS: Run every build in the FOREGROUND with a generous
 > timeout (the Bash tool supports timeout up to 600000 ms = 10 min; cargo test / wafer build /
@@ -62,37 +70,53 @@ Working context (defaults; override if the user says otherwise):
 > a background job, you MUST kill it before returning (e.g. `kill $(jobs -p) 2>/dev/null`). Do NOT
 > end your turn while any build is still running. There is no external monitor.
 >
-> Steps: (1) `python3 scripts/pick-next-tool.py 2>/dev/null | grep -v '^skip' | head -1`. (2) Read
-> `.claude/skills/create-next-tool/SKILL.md` (esp. the Findings log) and follow the new-tool build
-> procedure: classify type, `scripts/scaffold-tool.sh <slug> <type>`, implement core (+unit
-> tests)/descriptor (+drift-guard schema test)/web/page, build in the foreground (`cargo test`, then
-> `wafer build` in blocks/<slug>/ and `wasm-pack build blocks/<slug>/web --target web --release
-> --out-dir pkg`), `cargo install --path cli`, `cargo run --manifest-path tools/generator/Cargo.toml
-> -- .`, verify all applicable surfaces (CLI `gizza tool <slug>`; page Playwright `cd tests &&
-> xvfb-run npx playwright test tool-page-<slug>.spec.ts`). (2b) Apply the /improve-tool usability
-> standards to the page: model every fixed-choice param as `Param::enumv` (renders a <select>); write
-> the FAQ as `<details>`/`<summary>` accordions with a BLANK LINE inside each (so the answer markdown
-> renders + wraps in <p> — plain `## FAQ` markdown is a hard-fail); and SYNC `manifest.json`
-> `tool.parameters` to the descriptor schema — the page form reads the MANIFEST, not the live
-> descriptor, so a stub/`{input:string}` manifest renders EVERY field as a plain text box. Then run
-> `python3 scripts/check-tool-hygiene.py <slug>` and fix any violation (same gate CI enforces). (3)
-> Write `docs/checks/<TODAY>-improve-<slug>-competitor-analysis.md` (use today's actual date). (4) If it's a
-> semantic dup of an existing block, instead append `<slug>  # reason` to `docs/tool-skiplist.txt`,
-> commit that, and re-pick. (5) Honesty gate: if it can't be built+verified in ≤3 fix attempts,
-> `git clean -fd blocks/<slug>`, skiplist or report, do NOT commit broken. (6) Clean per-block target
-> dirs (`for d in blocks/*/target; do find "$d" -mindepth 1 -maxdepth 1 ! -name block.wasm -exec rm
-> -rf {} + ; done`), NEVER delete web/pkg. (7) `git add -A && git commit && git push origin
-> feat/tool-creating-2`. Return ONE line only: `<slug>: built+pushed <short-sha>` OR `skiplisted
-> <slug>: <reason>` OR `FAILED <slug>: <reason>`.
+> 1. **Pick:** `python3 scripts/pick-next-tool.py 2>/dev/null | grep -v '^skip' | head -1` →
+>    `slug/name/description/type_hint`. On `BACKLOG_COMPLETE`/`NO_BUILDABLE_REMAINING`, report and stop.
+> 2. **Dup check:** `ls blocks/ | grep -i <topic>`. A semantic dup of an existing block → append
+>    `<slug>  # duplicate of blocks/<other>` to `docs/tool-skiplist.txt`, commit that, and return
+>    `skiplisted <slug>: <reason>` (grep the named block's core/src/lib.rs to confirm first).
+> 3. **Read the recipes:** `.claude/skills/create-next-tool/SKILL.md` plus its `references/` files
+>    (wasm-safe crates, page patterns, ops gotchas) — they encode every dead end already hit.
+> 4. **Competitor scan (BEFORE implementing):** one WebSearch for the tool's function; skim the top
+>    3 real competitor tools. List the table-stakes params, defaults, and worked examples ours must
+>    match, tag each in-model/out-of-model, and design the descriptor to include the in-model ones
+>    from the start. Record the scan + decisions in
+>    `docs/checks/<TODAY>-improve-<slug>-competitor-analysis.md` (paraphrase only — NEVER copy
+>    competitor copy, branding, or trademarks; out-of-model items are listed, not built).
+> 5. **Build:** classify type → `scripts/scaffold-tool.sh <slug> <type>` → implement core (≥1 happy
+>    + ≥1 error unit test), descriptor (every param has `.describe()`; every fixed-choice param is
+>    `Param::enumv`; drift-guard schema test), web export, page (`meta.toml` placeholders on every
+>    text/number field; `content.md` with ≥1 worked example, ≥3 real `<details>` FAQs with a blank
+>    line inside each, and stated limits/edge cases). Fill EVERY scaffold TODO.
+> 6. **Verify (all foreground):** `cargo test --workspace` (in blocks/<slug>/) → `wafer build` (in
+>    blocks/<slug>/) → `wasm-pack build blocks/<slug>/web --target web --release --out-dir pkg` →
+>    `cargo install --path cli` → `python3 scripts/sync-tool-manifest.py <slug>` (generates
+>    manifest.json tool.* from the live descriptor — never hand-edit those) → `cargo run
+>    --manifest-path tools/generator/Cargo.toml -- .` → CLI (`gizza tool <slug> …`, incl. one
+>    exact-output case) → Playwright (`cd tests && xvfb-run npx playwright test
+>    tool-page-<slug>.spec.ts`). The page spec MUST assert real output — exact text for pure tools;
+>    for media decode the result and assert dimensions/pixels (new-tool/reference.md §media
+>    correctness) — plus one `?param=` deep-link case.
+> 7. **Hygiene gate:** `python3 scripts/check-tool-hygiene.py <slug>` must exit 0 (per-slug strict
+>    mode also enforces placeholders, FAQ count, and meta description length).
+> 8. **Honesty gate:** can't build+verify in ≤3 fix attempts → `git clean -fd blocks/<slug>`,
+>    skiplist or report FAILED. NEVER commit broken.
+> 9. **Cleanup:** `for d in blocks/*/target; do find "$d" -mindepth 1 -maxdepth 1 ! -name
+>    block.wasm -exec rm -rf {} + ; done`. NEVER delete any web/pkg.
+> 10. **Ship:** `git add -A && git commit && git push origin <BRANCH>`.
+>
+> Return ONE line only: `<slug>: built+pushed <short-sha>` OR `skiplisted <slug>: <reason>` OR
+> `FAILED <slug>: <reason>`.
 
-Replace `<TODAY>` with the current date each iteration (the loop runs across midnight).
+Replace `<REPO>`, `<BRANCH>`, `<TODAY>` at every dispatch (the loop runs across midnight and
+across machines/branches — stale substitutions have pushed to wrong branches before).
 
 ## Self-update — keep this skill improving
 
 When you resolve a NOVEL dispatcher/operational issue (a new failure mode, a better pacing trick, a
 cleanup gotcha), append a dated bullet to the **Operational findings log** below by Editing this
-file. Build-level findings (a new wasm-safe crate, a page pattern, a dup) go in
-`create-next-tool/SKILL.md` instead, not here. Keep entries terse and actionable.
+file. Build-level findings (a new wasm-safe crate, a page pattern, a dup) go in the matching
+`create-next-tool/references/*.md` file instead, not here. Keep entries terse and actionable.
 
 ## Operational findings log (dispatcher layer)
 
@@ -126,7 +150,7 @@ one legit build took ~58 min; don't mistake slow for stalled.
 **Handling FAILED / 529 Overloaded (2026-06-22).** A 529 is a transient server overload; the
 builder dies mid-build. The partial scaffold is uncommitted — clean it before retrying:
 ```bash
-cd /root/gizza-ai/gizza-ai
+cd <REPO>
 git clean -fd blocks/<slug>; rm -rf blocks/<slug> tests/tool-page-<slug>.spec.ts
 git status -sb   # confirm working tree clean + branch in sync
 ```
@@ -134,13 +158,14 @@ Then back off with a longer `ScheduleWakeup` (1800–3600s) and re-dispatch; the
 same un-built slug, so it's retried, not skipped.
 
 **Task-leak cleanup (only if the count climbs) (2026-06-22).** Stale records are on-disk
-`.output` files under the session tasks dir (`/tmp/claude-0/-root/<session>/tasks/`): `a*.output`
+`.output` files under the session tasks dir (`/tmp/claude-<uid>/<sanitized-cwd>/<session>/tasks/`
+— path varies per machine/session): `a*.output`
 = agent transcripts (KEEP — back resume/notifications), `b*.output` = background-bash command
 output. `TaskList` shows the live structured registry (usually empty here) and `TaskStop` returns
 "not found" for these finished records — they're inert (no live process), just UI clutter. To trim
 safely, delete only OLD background-bash files, protecting the active builder's recent ones:
 ```bash
-TD=/tmp/claude-0/-root/<session-id>/tasks
+TD=<session-tasks-dir>   # see path shape above
 find "$TD" -name 'b*.output' -mmin +15 -delete   # never a*.output, never <15min files
 ```
 With the foreground-build fix this should rarely be needed. If live orphan processes ever exist

--- a/.claude/skills/improve-tool/SKILL.md
+++ b/.claude/skills/improve-tool/SKILL.md
@@ -59,17 +59,32 @@ Follow these phases in order:
    - **Copy/SEO:** `page/content.md` + `page/meta.toml` — original copy, examples, FAQ, tags,
      title/description.
    - **UX/layout:** the page's input/output presentation (grouping, presets, preview), in sync
-     with the web export params. **MANDATORY Usability Standards**:
-     1. **Smart Defaults**: Any date, time, or datetime input MUST default to the user's current local date/time (e.g. via JavaScript formatting) if empty.
-     2. **Context Detection**: Always detect user context (e.g. local timezone via `Intl.DateTimeFormat().resolvedOptions().timeZone`) to pre-fill inputs like source timezone.
-     3. **Searchable Autocomplete/Dropdowns**: Fields with standard sets of values (e.g. timezones, country codes, formats, currencies) MUST NOT be raw text inputs. Use a searchable dropdown (e.g. HTML5 `<datalist>` or `<select>`) to prevent manual text entry.
-     4. **Native Date/Time Selectors**: Avoid raw text fields for dates, times, or datetimes. Swap them dynamically to native picker types (like `<input type="datetime-local">`, `date`, or `time`) to give users native calendars/time picker popovers.
-     5. **Tag-Pill UI for Comma-Separated Lists**: If a field accepts a list of items (e.g. comma-separated target zones), do not make the user type it. Build a tag-pill list UI displaying selected values as badges with "x" close buttons, paired with a search input to select and add new tags.
-     6. **Layout Stability (No Resizing Bounces)**: Do not dynamically shrink or bounce the container's width on errors, empty inputs, or keypress transitions. Ensure input boxes do not jump or resize under the user's typing cursor.
-     7. **Clear Reset Button**: Provide a visible, styled "Reset to Defaults" button or link to let users clear input fields or restore initial values with one click.
-     8. **FAQ Accordion Elements**: Convert FAQ sections into interactive, collapsible `<details>` and `<summary>` accordions featuring premium styling (hover effects, smooth transitions, custom plus/minus indicator icons). The content inside `<details>` MUST be wrapped in a `<p>` or `<div>` tag to ensure proper background, border-top, and padding styles apply.
-     9. **Sleek Custom Scrollbars**: Any container with scrollable overflow (especially dark code blocks like terminal CLI instructions) MUST be styled with custom scrollbar properties (`scrollbar-width: thin; scrollbar-color: ...` and corresponding webkit-scrollbar elements) that match the background theme, preventing default browser scrollbars from clipping bottom rounded corners.
-     10. **Grouped Developer/CLI Blocks**: Group developer-facing CLI terminal instructions and URL deep-links under a single `.tool-dev-group` card section styled as a multi-column grid on desktop screens. Set explicit bottom margins (e.g. `8px`) on `h2` headers for consistent typography layout hierarchy.
+     with the web export params. **Usability Standards** — the page must feel like a
+     purpose-built tool, not a generated form:
+     1. **Right control for the data.** Fixed choices are `Param::enumv` (renders a `<select>`);
+        booleans are checkboxes; dates/times get native pickers; large standard vocabularies
+        (timezones, currencies, country codes) get searchable autocomplete; list-valued fields
+        get an add/remove UI, not a comma-separated text box.
+     2. **Platform over per-tool hacks.** When a control kind or layout the tool needs doesn't
+        exist yet, add it DECLARATIVELY to the shared generator
+        (`tools/generator/src/{control,template}.rs` + `site/tool.js`) so every tool can use it.
+        Never add another `cfg.slug === "…"` branch to the shared `site/tool.js` — that's the
+        workspace fix-at-root-cause rule, and slug branches are why 6 tools' UI can't be reused.
+     3. **Smart defaults + context detection.** Pre-fill what the browser already knows (today's
+        date, the user's timezone via `Intl.DateTimeFormat().resolvedOptions().timeZone`) so the
+        tool shows a result before the user types anything.
+     4. **Worked examples everywhere.** Placeholders show a REAL input; the page copy shows at
+        least one input→output pair a user can verify.
+     5. **Layout stability.** Never resize/bounce the widget on errors, empty input, or
+        keystrokes — nothing may jump under the user's cursor.
+     6. **One-click reset** wherever inputs hold state worth clearing (restores defaults, not
+        just blanks).
+     7. **FAQ accordions.** `<details>`/`<summary>` with a blank line inside each so the answer
+        renders as markdown and picks up the shared styling (hygiene-gated).
+     8. **State the limits.** Max sizes, supported formats, depth caps, and edge-case behavior
+        belong on the page — users shouldn't discover them via an error.
+     9. **Errors say what was expected.** "expected X, got Y at Z" — never a bare "error"/
+        "invalid input".
    - **Visual design:** page styling, consistent with the shared `gizza-chrome`. Original only.
    - **Drift-guard:** REGENERATE the `authored` schema literal in the block's drift-guard test
      to the new descriptor (do NOT keep the old). Record the before→after schema diff for the

--- a/.claude/skills/improve-tool/reference.md
+++ b/.claude/skills/improve-tool/reference.md
@@ -84,16 +84,12 @@ design** (page styling).
 - **Copy/SEO** — `page/content.md` (body, examples, FAQ) + `page/meta.toml`
   (title/description/tags/h1/hero). **Original copy only.**
 - **UX/layout** — page input/output presentation; keep `[[input]]` field names + order in sync
-  with the web export params. **MANDATORY Usability Guidelines**:
-  - *Smart Defaults*: Pre-fill dates, times, and other fields with sensible defaults (e.g., current local date/time) rather than leaving them empty.
-  - *Context Detection*: Automatically detect the user's local timezone (via `Intl.DateTimeFormat().resolvedOptions().timeZone`), language, or locale to initialize fields correctly.
-  - *Searchable Autocompletes*: Avoid raw text fields for timezones, country codes, currencies, formats, or other predefined values. Dynamically inject an HTML5 `<datalist>` or custom searchable select list to let the user search and autocomplete.
-  - *Native Date/Time Selectors*: Avoid text fields for dates/times. Set `input.type` to picker types (e.g., `datetime-local`, `date`, `time`). Normalize default and URL pre-fill formats to use a `T` separator for ISO format support.
-  - *Tag-Pill List UI*: If inputs are list-based (e.g. multi-timezone comma-separated targets), build a tag-pill container (`.tz-tags-list`) where added timezones render as badges with delete buttons (`&times;`), hiding the raw comma-separated text input.
-  - *Layout Stability*: Keep the `.tool-widget` width stable (e.g. a fixed `760px` for multi-column widgets). Avoid toggling sizes on keystrokes, empty states, or validation errors to prevent layouts from shifting under the user's cursor.
-  - *Actionable Reset Button*: Place an explicit, styled Reset button next to the input fields to clear filters, reset list targets to default (e.g., `["UTC"]`), and re-fill inputs with current local defaults.
-  - *FAQ Accordions*: Wrap FAQ copy in HTML `<details>` and `<summary>` tags inside `content.md`. Wrap the details content in `<p>...</p>` or `<div>...</div>` blocks to properly scope styling (padding, borders, transitions). Style details/summary blocks in CSS with transition indicators (like plus/minus content arrows on toggle).
-  - *Developer Access Layout & Header Spacing*: Group terminal execution and deep-link instruction card grids under a `.tool-dev-group` wrapper using `tools/generator/src/template.rs`. Ensure code blocks (`.tool-cli-code`) configure custom styled scrollbars to match track/thumb colors (`scrollbar-width: thin; scrollbar-color: #334155 #0f172a` plus matching webkit styles) to avoid clipping bottom rounded corners. Set explicit bottom margins (e.g., `8px`) on `h2` headings for correct visual spacing.
+  with the web export params. Apply the **Usability Standards** in SKILL.md Phase 4 (right
+  control for the data; platform over per-tool hacks — extend `tools/generator` declaratively,
+  NEVER add a `cfg.slug === "…"` branch to `site/tool.js`; smart defaults + context detection;
+  worked examples; layout stability; one-click reset; FAQ accordions; state the limits;
+  actionable errors). Shared chrome (dev-group cards, CLI copy buttons, scrollbar styling) lives
+  in `tools/generator/src/template.rs` + `site/tool.css` — improve it THERE so all tools get it.
 - **Visual design** — page styling consistent with `gizza-chrome`. Original; no competitor assets.
 
 ### param types across surfaces (GOTCHA — bit me on url-encode)
@@ -133,7 +129,9 @@ The block has a unit test pinning `derived == authored` (e.g. url-encode's
    (add the new property/enum/default exactly as `to_schema_json()` emits it —
    `additionalProperties: false`, property order as inserted).
 3. Re-run → PASS. Capture the **before→after schema diff** (old literal vs new) for the PR.
-4. Update `manifest.json` `tool.description`/`tool.parameters` to match the new descriptor.
+4. Regenerate the manifest: `cargo install --path cli --force` then
+   `python3 scripts/sync-tool-manifest.py <slug>` (writes `tool.description`/`tool.parameters`
+   from the live descriptor + syncs summaries — do not hand-edit).
 
 Do NOT delete the drift-guard test — it stays as the migration guard for the NEXT change.
 
@@ -159,9 +157,11 @@ Do NOT delete the drift-guard test — it stays as the migration guard for the N
   `/tools/<slug>/`, AND a `?<param>=<value>` deep-link assertion. Add a case per new capability.
 - **CLI** `cargo install --path cli --force` then `gizza tool <slug> "<args>"` — incl. a new
   case per new capability. (gpu tools: assert `unsupported_in_cli` + exit 3.)
-- **Hygiene gate** `python3 scripts/check-tool-hygiene.py <slug>` — MUST exit 0. Enforces the two
-  standards that silently regressed before: enum params synced into `manifest.json` (§Phase 4 select
-  rendering) and FAQ as `<details>` accordions (Usability Standard #8). CI runs it repo-wide.
+- **Hygiene gate** `python3 scripts/check-tool-hygiene.py <slug>` — MUST exit 0. Enforces the
+  standards that silently regressed before: enum params synced into `manifest.json` (run
+  `scripts/sync-tool-manifest.py <slug>` after any descriptor change — never hand-sync), FAQ as
+  `<details>` accordions, no scaffold TODOs, summary consistency; per-slug strict mode also gates
+  placeholders, FAQ count, and meta description length. CI runs it repo-wide.
 - Hard gates: pre-existing behavior tests GREEN; every new capability has a test; API/CLI/query
   pass; hygiene gate exits 0. ≤3 fix attempts per failure, else escalate.
 

--- a/.claude/skills/new-tool/SKILL.md
+++ b/.claude/skills/new-tool/SKILL.md
@@ -35,7 +35,9 @@ the build/test/PR commands. Follow these steps in order:
      scaffold already delegates: `run_skill` (pure/no-page) or `resolve_source` →
      `dispatch_ffmpeg` → `build_media_envelope` (ffmpeg). Param API:
      `Param::string|integer|number|enumv|boolean|string_map(...)` +
-     `.required()/.default(v)/.min(n)/.max(n)/.describe(s)`; `Input::None` for
+     `.required()/.default(v)/.min(n)/.max(n)/.describe(s)` — give EVERY param a
+     `.describe()` that tells an LLM/CLI user what to pass (values, units, default,
+     an example); `Input::None` for
      pure/param-only, `Input::Image|Video|Document|File` for a `url`⊕`ref` media input,
      `source_list` for an array of sources. Exemplars: `blocks/url-encode` (pure),
      `blocks/image-resize` (ffmpeg page), `blocks/web-fetch` (no-page, flat output).
@@ -48,30 +50,40 @@ the build/test/PR commands. Follow these steps in order:
      markdown renders and wraps in `<p>` (see `blocks/age-calculator`). Plain-markdown FAQ is
      a hard-fail in the hygiene gate.
    - `manifest.json` — the scaffold generates it (build.rs needs it; `wafer build` does
-     NOT). Update `summary` + the `tool.description`/`tool.parameters` to match your
-     `src/lib.rs` skill() schema. **`tool.parameters` is LOAD-BEARING for the page**, not
-     just informational: the page form (`tools/generator/src/control.rs`) reads the
-     MANIFEST (not the live descriptor) to pick each field's control — a param renders as a
-     `<select>` only if its manifest property carries the `enum`, as a checkbox/number for
-     `boolean`/`integer`, else a text box. Leave `tool.parameters` as the scaffold stub and
-     EVERY field renders as plain text. Keep it byte-for-byte in sync with `schema_json()`.
-     **Summaries:** write ONE clean one-line summary and use it in all three places — the
-     `#[wafer_block(summary = "…")]` macro (what chat/the runtime shows), `wafer.toml`
-     `summary`, and `manifest.json` `summary`. Fill every scaffold `TODO` (title, h1, hero,
-     descriptions, summaries); do NOT leave the vestigial `"… skill"` suffix the old
-     scaffold seeded. The gate fails on any leftover `TODO`.
-7. **Build:** `wafer build` (from `blocks/<slug>/`); `cargo test --workspace` (from
-   `blocks/<slug>/`); `wasm-pack build blocks/<slug>/web --target web --release --out-dir pkg`;
-   `cargo run --manifest-path tools/generator/Cargo.toml -- .`; `solobase build`; and
-   `python3 scripts/check-tool-hygiene.py <slug>` (the hard gate CI enforces — fails on a
-   drifted manifest or a plain-markdown FAQ). Fix
+     NOT). **`tool.parameters` is LOAD-BEARING for the page**: the page form
+     (`tools/generator/src/control.rs`) reads the MANIFEST (not the live descriptor) to pick
+     each field's control — a param renders as a `<select>` only if its manifest property
+     carries the `enum`, as a checkbox/number for `boolean`/`integer`, else a text box.
+     **Do NOT hand-write `tool.*`** — it is generated: after `cargo install --path cli`
+     (step 7), `python3 scripts/sync-tool-manifest.py <slug>` regenerates
+     `tool.parameters`/`tool.description` from the live descriptor and propagates the
+     `#[wafer_block(summary = "…")]` macro summary into `manifest.json` + `wafer.toml`.
+     **Summaries:** write ONE clean one-line summary in the macro (no vestigial `"… skill"`
+     suffix) — the sync script owns the other two copies. Fill every scaffold `TODO` (title,
+     h1, hero, descriptions); the gate fails on any leftover `TODO`.
+7. **Build (in this order):** `wafer build` (from `blocks/<slug>/`); `cargo test --workspace`
+   (from `blocks/<slug>/`); `wasm-pack build blocks/<slug>/web --target web --release --out-dir pkg`;
+   `cargo install --path cli --force`; `python3 scripts/sync-tool-manifest.py <slug>` (regenerates
+   manifest `tool.*` + summaries from the live descriptor — required BEFORE the generator, which
+   reads the manifest); `cargo run --manifest-path tools/generator/Cargo.toml -- .`;
+   `solobase build`; and `python3 scripts/check-tool-hygiene.py <slug>` (the hard gate CI
+   enforces — per-slug mode is strict: drifted manifest, plain-markdown FAQ, scaffold TODOs,
+   summary drift, missing placeholders, <3 FAQs, bad meta description length). Fix
    compile/test failures (≤3 attempts) before escalating. (No SKILL.md to regenerate —
    the root SKILL.md is static and points agents at `gizza list`/`gizza describe`.)
 8. **Test (type-aware)** — see reference.md:
    - unit (always) + wafer fixtures (always);
-   - **Playwright** the page (pure + ffmpeg): add a spec in `tests/` driving `/tools/<slug>/`;
-   - **CLI** (pure/ffmpeg/network): `cargo install --path cli --force` then `gizza tool <slug> …`;
+   - **Playwright** the page (pure + ffmpeg): add a spec in `tests/` driving `/tools/<slug>/`.
+     The spec MUST assert real output correctness — exact text for pure tools; for media,
+     decode the result and assert dimensions/pixels (reference.md §media correctness) — plus
+     one `?param=` deep-link case;
+   - **CLI** (pure/ffmpeg/network): `gizza tool <slug> …` incl. one exact-output case;
      gpu: assert `unsupported_in_cli` + exit 3.
+8b. **User-QA rubric (before ship)** — load `/tools/<slug>/` once more and check as a USER:
+   every text/number field has a meaningful placeholder; the page copy shows ≥1 worked example
+   (input AND output); the FAQ answers ≥3 real questions; known limits (max sizes, formats,
+   depth caps) are stated on the page, not only in code; error messages say what was expected;
+   every descriptor param has a `.describe()` an LLM could act on. Fix gaps before committing.
 9. **Ship:** commit, `git push -u origin feat/tool-<slug>`, `gh pr create` with a body that
    states: the tool type, the derived assumptions, what was tested + results, and any
    limitation (e.g. "gpu: no page, no headless verification"; "ffmpeg: chat path is

--- a/.claude/skills/new-tool/reference.md
+++ b/.claude/skills/new-tool/reference.md
@@ -7,9 +7,15 @@
 - `cargo run --manifest-path tools/generator/Cargo.toml -- .` — renders pkg/tools/<slug>/
 - `solobase build` — rebuild app + all blocks into pkg/
 - `cargo install --path cli --force` then `gizza tool <slug> <args>` — CLI test
+- `python3 scripts/sync-tool-manifest.py <slug>` — AFTER the CLI install: regenerates
+  `manifest.json` `tool.parameters`/`tool.description` from the installed CLI's live descriptor
+  and propagates the wafer_block macro summary into `manifest.json` + `wafer.toml`. Never
+  hand-edit those fields; run this before the generator (which reads the manifest).
 - `python3 scripts/check-tool-hygiene.py <slug>` — hard gate (CI runs it repo-wide): fails on a
-  manifest whose `tool.parameters` drifted from the descriptor (page renders text not `<select>`) or a
-  `page/content.md` FAQ written as plain markdown instead of `<details>` accordions.
+  manifest whose `tool.parameters` drifted from the descriptor (page renders text not `<select>`), a
+  `page/content.md` FAQ written as plain markdown instead of `<details>` accordions, scaffold TODOs,
+  or summary drift. Per-slug mode is STRICT and additionally fails on missing field placeholders,
+  fewer than 3 FAQ entries, and a meta description outside 50–160 chars.
 
 ## Per-type file checklist (fill the scaffold's TODO/stub files)
 
@@ -19,7 +25,7 @@
 - `web/src/lib.rs`: `#[wasm_bindgen] pub fn <export>(...) -> Result<T, JsValue>` — the `<export>` name MUST match `page/meta.toml`'s `export`.
 - `page/meta.toml`: real slug/title/description/tags/h1/hero_subtitle; `format` = "number"|"text"; one `[[input]] source="field"` per arg — input NAMES + ORDER must equal the web fn's params.
 - `page/content.md`: real SEO copy. FAQ as `<details>`/`<summary>` accordions (blank line inside each), never plain `## FAQ` markdown.
-- `manifest.json` + `wafer.toml`: scaffold-generated. Update the `summary` in both, and `manifest.json`'s `tool.description`/`tool.parameters` to match your `src/lib.rs` skill() schema. **`tool.parameters` drives the page form** — `control.rs` reads it (not the descriptor) to render `<select>`/checkbox/number/text, so leaving it as the scaffold stub makes every field a text box. Keep it in sync with `schema_json()`.
+- `manifest.json` + `wafer.toml`: scaffold-generated. **`tool.parameters` drives the page form** — `control.rs` reads it (not the descriptor) to render `<select>`/checkbox/number/text, so a scaffold stub makes every field a text box. Do NOT hand-sync: run `python3 scripts/sync-tool-manifest.py <slug>` after the CLI install (it writes `tool.parameters`/`tool.description` from the live descriptor and propagates the macro summary into both files).
 - `tests/*.json`: wafer fixtures (recipe below).
 
 ### ffmpeg (reference: blocks/image-resize)
@@ -31,6 +37,10 @@
 
 ## Playwright spec template (`tests/tool-page-<slug>.spec.ts` — import from './fixtures'; the config serves ../pkg)
 
+Every spec asserts REAL output (an exact value a user would see), never just "something
+rendered" — a tool whose transform silently no-ops must FAIL its spec. Always include one
+`?param=` deep-link case (the page pre-fills from the query string and auto-runs).
+
 ### pure
 ```ts
 import { test, expect } from './fixtures';
@@ -39,9 +49,17 @@ test('<slug> page', async ({ page }) => {
   await page.fill('#in-<field>', '<input>');
   await expect(page.locator('#tool-output')).toHaveText('<expected>', { timeout: 15000 });
 });
+test('<slug> deep-link', async ({ page }) => {
+  await page.goto('/tools/<slug>/?<field>=<url-encoded-input>');
+  await expect(page.locator('#tool-output')).toHaveText('<expected>', { timeout: 15000 });
+});
 ```
 
-### ffmpeg (needs @ffmpeg CDN network)
+### ffmpeg (needs @ffmpeg CDN network) — §media correctness
+A `data:image/` prefix only proves *something* rendered. Decode the output and assert the
+transform actually happened: dimensions for resize/crop/rotate/thumbnail, pixel values for
+color transforms (grayscale/invert/tint), format for converters (`data:image/webp` etc.).
+`fixtures/red-2x2.png` is a known input — pure red, 2×2 — so expected values are exact.
 ```ts
 import { test, expect } from './fixtures';
 import * as path from 'path';
@@ -50,9 +68,26 @@ test('<slug> page', async ({ page }) => {
   await page.setInputFiles('#in-file', path.resolve(__dirname, 'fixtures/red-2x2.png'));
   const media = page.locator('#tool-output-media');
   await expect(media).toBeVisible({ timeout: 90000 });
-  expect(await media.getAttribute('src')).toMatch(/^data:image\//);
+  const src = await media.getAttribute('src');
+  expect(src).toMatch(/^data:image\//);
+  // Decode + verify the transform (adapt the assertion to the tool):
+  const px = await page.evaluate(async (dataUrl) => {
+    const img = new Image();
+    await new Promise((res, rej) => { img.onload = res; img.onerror = rej; img.src = dataUrl; });
+    const c = document.createElement('canvas');
+    c.width = img.naturalWidth; c.height = img.naturalHeight;
+    const ctx = c.getContext('2d');
+    ctx.drawImage(img, 0, 0);
+    const d = ctx.getImageData(0, 0, 1, 1).data;
+    return { w: img.naturalWidth, h: img.naturalHeight, r: d[0], g: d[1], b: d[2] };
+  }, src);
+  // resize 2x2 → 1x1:            expect(px.w).toBe(1);
+  // grayscale of pure red:       expect(px.r).toBe(px.g); expect(px.g).toBe(px.b);
+  // invert of pure red:          expect(px.r).toBeLessThan(30); expect(px.g).toBeGreaterThan(225);
 });
 ```
+Video/audio outputs: assert the mime prefix (`data:video/`, `data:audio/`) AND check duration or
+size via the element (`media.duration > 0`) after `loadedmetadata` — not just visibility.
 
 ## wafer fixture recipe (`tests/*.json`)
 `python3 -c "import json;print(list(json.dumps({'input':'...'}).encode()))"` → the byte list goes in `{"kind":"invoke","data":[...],"meta":[]}`.

--- a/blocks/image-resize/manifest.json
+++ b/blocks/image-resize/manifest.json
@@ -5,16 +5,50 @@
   "summary": "Resize an image fetched by URL.",
   "role": "skill",
   "tool": {
-    "description": "Resize an image at the given URL. Provide width and/or height in pixels. Use this when the user asks to make an image smaller or larger, or to fit it to specific dimensions.",
+    "description": "Resize an image. Provide either url (HTTP/HTTPS) or ref (id from a prior image tool call).",
     "parameters": {
-      "type": "object",
-      "required": ["url"],
+      "oneOf": [
+        {
+          "required": [
+            "url"
+          ]
+        },
+        {
+          "required": [
+            "ref"
+          ]
+        }
+      ],
       "properties": {
-        "url":    { "type": "string",  "description": "Absolute http(s) URL to an image (PNG, JPEG, or WebP)." },
-        "width":  { "type": "integer", "description": "Output width in pixels. Optional if height is given." },
-        "height": { "type": "integer", "description": "Output height in pixels. Optional if width is given." },
-        "fit":    { "type": "string",  "enum": ["contain", "cover", "stretch"], "description": "How to fit the image into the requested box. Default: contain (preserve aspect ratio, fit inside)." }
-      }
+        "fit": {
+          "description": "Resize mode (default: contain).",
+          "enum": [
+            "contain",
+            "cover",
+            "stretch"
+          ],
+          "type": "string"
+        },
+        "height": {
+          "description": "Target height in pixels.",
+          "minimum": 1,
+          "type": "integer"
+        },
+        "ref": {
+          "description": "Reference id from a prior image tool call (e.g. \"call_42\"). Use either url or ref.",
+          "type": "string"
+        },
+        "url": {
+          "description": "Image URL (HTTP/HTTPS).",
+          "type": "string"
+        },
+        "width": {
+          "description": "Target width in pixels.",
+          "minimum": 1,
+          "type": "integer"
+        }
+      },
+      "type": "object"
     }
   }
 }

--- a/scripts/check-tool-hygiene.py
+++ b/scripts/check-tool-hygiene.py
@@ -30,9 +30,22 @@ Prose usability standards (see `.claude/skills/improve-tool/SKILL.md`) were bein
 skipped silently because nothing failed the build. This turns the mechanically
 checkable ones into a gate.
 
+STRICT checks (5-7) — hard-fail ONLY in per-slug mode (how the build/improve skills
+run it, so every NEW/improved tool meets them); repo-wide they are printed as an
+aggregated advisory so CI stays green until the corpus is backfilled:
+
+  5. Placeholders. Every page/meta.toml `[[input]]` that renders as a text/number
+     field (i.e. not an enum <select> or boolean checkbox per the manifest) must
+     have a non-empty `placeholder` — the placeholder is the page's worked example.
+
+  6. FAQ depth. A tool page must answer ≥3 real questions as `<details>` accordions.
+
+  7. Meta description length. page/meta.toml `description` is the SERP snippet —
+     require 50-170 chars (truncation starts ~160; shorter than 50 wastes the slot).
+
 Usage:
-  scripts/check-tool-hygiene.py                 # check every blocks/<slug>/
-  scripts/check-tool-hygiene.py <slug> [<slug>] # check only these tools
+  scripts/check-tool-hygiene.py                 # repo-wide: checks 1-4 gate, 5-7 advisory
+  scripts/check-tool-hygiene.py <slug> [<slug>] # per-slug STRICT: checks 1-7 all gate
 
 Exit code 0 = clean, 1 = violations found (prints each), 2 = usage error.
 """
@@ -41,6 +54,7 @@ from __future__ import annotations
 import json
 import re
 import sys
+import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -210,6 +224,58 @@ def check_block(slug_dir: Path) -> list[str]:
     return problems
 
 
+def strict_checks(slug_dir: Path) -> list[tuple[str, str]]:
+    """Checks 5-7 (placeholders / FAQ depth / description length) as
+    (category, message) pairs. Gate per-slug; advisory repo-wide — see header."""
+    slug = slug_dir.name
+    out: list[tuple[str, str]] = []
+
+    meta_path = slug_dir / "page" / "meta.toml"
+    meta = None
+    if meta_path.is_file():
+        try:
+            meta = tomllib.loads(meta_path.read_text(encoding="utf-8", errors="replace"))
+        except tomllib.TOMLDecodeError as e:
+            out.append(("meta", f"{slug}: page/meta.toml does not parse as TOML: {e}"))
+
+    if meta is not None:
+        desc = str(meta.get("description", ""))
+        if not 50 <= len(desc) <= 170:
+            out.append((
+                "description",
+                f"{slug}: page/meta.toml description is {len(desc)} chars — keep it 50-170 "
+                f"(it is the SERP snippet; ~160 is where truncation starts).",
+            ))
+        props = manifest_props(slug_dir / "manifest.json") or {}
+        for inp in meta.get("input", []):
+            if inp.get("source") != "field":
+                continue
+            name = str(inp.get("name", "?"))
+            prop = props.get(name)
+            if isinstance(prop, dict) and (prop.get("enum") or prop.get("type") == "boolean"):
+                continue  # renders as a <select>/checkbox — no placeholder slot
+            if not str(inp.get("placeholder", "")).strip():
+                out.append((
+                    "placeholder",
+                    f"{slug}: page/meta.toml [[input]] \"{name}\" renders as a text/number field "
+                    f"but has NO placeholder — the placeholder is the page's worked example.",
+                ))
+
+    content = slug_dir / "page" / "content.md"
+    if content.is_file():
+        text = content.read_text(encoding="utf-8", errors="replace")
+        m = FAQ_HEADING_RE.search(text)
+        n = faq_section(text, m).count("<details") if m else text.count("<details")
+        if n < 3:
+            out.append((
+                "faq",
+                f"{slug}: page FAQ has {n} <details> entries — answer ≥3 real user questions "
+                f"(predictable confusion points, limits, privacy).",
+            ))
+
+    return out
+
+
 def main(argv: list[str]) -> int:
     if argv:
         dirs = []
@@ -221,10 +287,31 @@ def main(argv: list[str]) -> int:
             dirs.append(d)
     else:
         dirs = sorted(p for p in BLOCKS.iterdir() if p.is_dir())
+    per_slug = bool(argv)
 
     all_problems: list[str] = []
+    advisory: list[tuple[str, str]] = []
     for d in dirs:
         all_problems.extend(check_block(d))
+        strict = strict_checks(d)
+        if per_slug:
+            all_problems.extend(msg for _, msg in strict)
+        else:
+            advisory.extend(strict)
+
+    if advisory:
+        by_cat: dict[str, list[str]] = {}
+        for cat, msg in advisory:
+            by_cat.setdefault(cat, []).append(msg)
+        counts = ", ".join(f"{cat}: {len(msgs)}" for cat, msgs in sorted(by_cat.items()))
+        print(f"tool-hygiene: {len(advisory)} ADVISORY finding(s) repo-wide ({counts}) — these")
+        print("gate per-slug runs (new/improved tools) but not the repo-wide sweep. Samples:")
+        for cat, msgs in sorted(by_cat.items()):
+            for msg in msgs[:3]:
+                print(f"  ⚠ {msg}")
+            if len(msgs) > 3:
+                print(f"  ⚠ … and {len(msgs) - 3} more \"{cat}\" findings")
+        print()
 
     if all_problems:
         print(f"tool-hygiene: {len(all_problems)} violation(s) across {len(dirs)} tool(s):\n")

--- a/scripts/check-tool-hygiene.test.sh
+++ b/scripts/check-tool-hygiene.test.sh
@@ -46,18 +46,38 @@ grep -q 'FAQ section written as plain markdown' <<<"$out" || { echo "FAIL: missi
 grep -q "scaffold 'TODO' placeholder" <<<"$out" || { echo "FAIL: missing TODO violation" >&2; exit 1; }
 grep -q "wafer_block summary is still the scaffold placeholder" <<<"$out" || { echo "FAIL: missing macro-summary violation" >&2; exit 1; }
 
-# FIX all and expect a clean pass.
+# FIX all and expect a clean pass (per-slug mode is STRICT: checks 5-7 gate too,
+# so the compliant fixture needs a meta.toml with placeholders + an in-range
+# description, and >=3 FAQ accordions).
 cat > "$dir/src/lib.rs" <<'EOF'
 #[wafer_block(summary = "Encode or decode data.")]
 fn descriptor() {
     let _ = Param::enumv("mode", ["encode", "decode"]).default("encode");
 }
 EOF
-# manifest summary matches the macro summary (consistency check #4).
+# manifest summary matches the macro summary (consistency check #4). `text` has no
+# enum/boolean type -> renders as a text field -> needs a placeholder (check #5).
 cat > "$dir/manifest.json" <<'EOF'
 { "summary": "Encode or decode data.", "tool": { "parameters": { "properties": {
-  "mode": { "type": "string", "enum": ["encode", "decode"], "default": "encode" }
+  "mode": { "type": "string", "enum": ["encode", "decode"], "default": "encode" },
+  "text": { "type": "string" }
 } } } }
+EOF
+cat > "$dir/page/meta.toml" <<'EOF'
+slug        = "zzhygiene-scratch"
+description = "Encode or decode data instantly in your browser — free, private, and offline-capable."
+
+[[input]]
+name        = "text"
+label       = "Text"
+source      = "field"
+placeholder = "hello world"
+
+[[input]]
+name        = "mode"
+label       = "Mode"
+source      = "field"
+placeholder = ""
 EOF
 cat > "$dir/page/content.md" <<'EOF'
 ## About
@@ -67,12 +87,91 @@ Prose.
 
 <details>
 <summary>Is it free?</summary>
-<p>Yes.</p>
+
+Yes.
+
+</details>
+
+<details>
+<summary>Does my data leave the browser?</summary>
+
+No.
+
+</details>
+
+<details>
+<summary>Is there a size limit?</summary>
+
+Inputs over 10 MB may be slow.
+
 </details>
 EOF
 
 python3 "$root/scripts/check-tool-hygiene.py" "$slug" >/dev/null 2>&1 || {
-  echo "FAIL: gate rejected a compliant block" >&2; exit 1; }
+  echo "FAIL: gate rejected a compliant block" >&2
+  python3 "$root/scripts/check-tool-hygiene.py" "$slug" >&2 || true
+  exit 1; }
+
+# Repo-wide mode must NOT gate on the strict checks (advisory only): break a
+# strict rule and confirm per-slug fails while the same block passes repo-wide
+# scanning. (Repo-wide still gates checks 1-4.)
+sed -i 's/placeholder = "hello world"/placeholder = ""/' "$dir/page/meta.toml"
+out3="$(python3 "$root/scripts/check-tool-hygiene.py" "$slug" 2>&1 || true)"
+grep -q 'NO placeholder' <<<"$out3" || { echo "FAIL: strict mode missed a missing placeholder" >&2; exit 1; }
+sed -i 's/placeholder = ""$/placeholder = "hello world"/' "$dir/page/meta.toml"
+# ^ also gives `mode` a placeholder — harmless, it renders as a <select> (enum)
+
+# Too-short SERP description fails strict.
+sed -i 's/^description = .*/description = "Too short."/' "$dir/page/meta.toml"
+out4="$(python3 "$root/scripts/check-tool-hygiene.py" "$slug" 2>&1 || true)"
+grep -q 'SERP snippet' <<<"$out4" || { echo "FAIL: strict mode missed a bad description length" >&2; exit 1; }
+sed -i 's/^description = .*/description = "Encode or decode data instantly in your browser — free, private, and offline-capable."/' "$dir/page/meta.toml"
+
+# Fewer than 3 FAQ accordions fails strict.
+cat > "$dir/page/content.md" <<'EOF'
+## About
+Prose.
+
+## FAQ
+
+<details>
+<summary>Is it free?</summary>
+
+Yes.
+
+</details>
+EOF
+out5="$(python3 "$root/scripts/check-tool-hygiene.py" "$slug" 2>&1 || true)"
+grep -q 'answer ≥3 real user questions' <<<"$out5" || { echo "FAIL: strict mode missed a thin FAQ" >&2; exit 1; }
+cat > "$dir/page/content.md" <<'EOF'
+## About
+Prose.
+
+## FAQ
+
+<details>
+<summary>Is it free?</summary>
+
+Yes.
+
+</details>
+
+<details>
+<summary>Does my data leave the browser?</summary>
+
+No.
+
+</details>
+
+<details>
+<summary>Is there a size limit?</summary>
+
+Inputs over 10 MB may be slow.
+
+</details>
+EOF
+python3 "$root/scripts/check-tool-hygiene.py" "$slug" >/dev/null 2>&1 || {
+  echo "FAIL: gate rejected the re-fixed block" >&2; exit 1; }
 
 # A summary that disagrees with the macro must fail (check #4).
 cat > "$dir/manifest.json" <<'EOF'

--- a/scripts/sync-tool-manifest.py
+++ b/scripts/sync-tool-manifest.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Generate a block's manifest.json `tool.*` + summaries from the LIVE descriptor.
+
+Why: the page form (`tools/generator/src/control.rs`) reads `manifest.json` →
+`tool.parameters`, NOT the descriptor inside the wasm — historically that section was
+hand-synced, and it drifted (enums lost → text boxes instead of <select>s; stale
+param descriptions). This script makes the manifest a GENERATED artifact:
+
+  tool.parameters  ←  `gizza describe <name> --json-out`   (the descriptor's schema_json())
+  tool.description ←  `gizza describe <name>` Description   (the skill() description)
+  summary          ←  `#[wafer_block(summary = "…")]` in src/lib.rs, propagated to
+                      manifest.json `summary` AND wafer.toml `summary`
+
+Prereq: the tool must be in the INSTALLED CLI — run `cargo install --path cli --force`
+after `wafer build` and BEFORE this script. Run this BEFORE the page generator (which
+reads the manifest). `scripts/check-tool-hygiene.py` stays as the CI backstop.
+
+Usage:
+  scripts/sync-tool-manifest.py <slug> [<slug>...]   # rewrite the manifest(s)
+  scripts/sync-tool-manifest.py --check <slug> ...   # exit 1 if out of sync, write nothing
+
+Exit code 0 = synced/clean, 1 = --check found drift or a tool failed, 2 = usage error.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BLOCKS = ROOT / "blocks"
+
+# Same source-parsing rules as scripts/check-tool-hygiene.py (kept in sync by
+# check-tool-hygiene.test.sh): the macro summary is what chat/the runtime shows.
+MACRO_SUMMARY_RE = re.compile(r'wafer_block\((?:.|\n)*?\bsummary\s*=\s*"((?:\\.|[^"\\])*)"')
+WAFER_SUMMARY_RE = re.compile(r'^(\s*summary\s*=\s*)"(?:\\.|[^"\\])*"', re.MULTILINE)
+DESCRIBE_DESC_RE = re.compile(r"^Description:\s*(.*?)\n(?:Parameters|Name):", re.MULTILINE | re.DOTALL)
+
+_RUST_ESCAPES = {"\\": "\\", '"': '"', "'": "'", "n": "\n", "t": "\t", "r": "\r", "0": "\0"}
+
+
+def unescape_rust(s: str) -> str:
+    out: list[str] = []
+    i = 0
+    while i < len(s):
+        if s[i] == "\\" and i + 1 < len(s) and s[i + 1] in _RUST_ESCAPES:
+            out.append(_RUST_ESCAPES[s[i + 1]])
+            i += 2
+        else:
+            out.append(s[i])
+            i += 1
+    return "".join(out)
+
+
+def gizza(args: list[str]) -> str:
+    try:
+        r = subprocess.run(["gizza", *args], capture_output=True, text=True, timeout=60)
+    except FileNotFoundError:
+        sys.exit("error: `gizza` not on PATH — run `cargo install --path cli --force` first")
+    if r.returncode != 0:
+        raise RuntimeError(
+            f"`gizza {' '.join(args)}` failed (exit {r.returncode}): {r.stderr.strip() or r.stdout.strip()}\n"
+            f"  (is the block built + the CLI reinstalled? `wafer build` then `cargo install --path cli --force`)"
+        )
+    return r.stdout
+
+
+def sync_block(slug: str, check_only: bool) -> tuple[bool, list[str]]:
+    """Returns (changed, messages). Raises RuntimeError on a hard failure."""
+    slug_dir = BLOCKS / slug
+    manifest_path = slug_dir / "manifest.json"
+    if not manifest_path.is_file():
+        raise RuntimeError(f"blocks/{slug}/manifest.json not found")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    if "tool" not in manifest:
+        return False, [f"{slug}: no `tool` section in manifest.json — nothing to sync (non-tool block)"]
+
+    name = manifest.get("name", f"gizza-ai/{slug}")
+    short = name.split("/")[-1]
+    msgs: list[str] = []
+    changed = False
+
+    # tool.parameters ← live schema_json()
+    params = json.loads(gizza(["describe", short, "--json-out"]))
+    if manifest["tool"].get("parameters") != params:
+        changed = True
+        msgs.append(f"{slug}: tool.parameters ← live descriptor schema")
+        manifest["tool"]["parameters"] = params
+
+    # tool.description ← the skill() description from `gizza describe`
+    human = gizza(["describe", short])
+    m = DESCRIBE_DESC_RE.search(human)
+    if m:
+        desc = m.group(1).strip()
+        if desc and manifest["tool"].get("description") != desc:
+            changed = True
+            msgs.append(f"{slug}: tool.description ← live descriptor description")
+            manifest["tool"]["description"] = desc
+    else:
+        msgs.append(f"{slug}: WARN could not parse Description from `gizza describe {short}` — left as-is")
+
+    # summary ← wafer_block macro, propagated to manifest.json + wafer.toml
+    src_lib = slug_dir / "src" / "lib.rs"
+    summary = None
+    if src_lib.is_file():
+        sm = MACRO_SUMMARY_RE.search(src_lib.read_text(encoding="utf-8", errors="replace"))
+        if sm:
+            summary = unescape_rust(sm.group(1))
+    if summary:
+        if manifest.get("summary") != summary:
+            changed = True
+            msgs.append(f"{slug}: manifest summary ← macro summary")
+            manifest["summary"] = summary
+        wafer_path = slug_dir / "wafer.toml"
+        if wafer_path.is_file():
+            wafer_text = wafer_path.read_text(encoding="utf-8")
+            new_text, n = WAFER_SUMMARY_RE.subn(
+                lambda mm: mm.group(1) + json.dumps(summary, ensure_ascii=False), wafer_text, count=1
+            )
+            if n and new_text != wafer_text:
+                changed = True
+                msgs.append(f"{slug}: wafer.toml summary ← macro summary")
+                if not check_only:
+                    wafer_path.write_text(new_text, encoding="utf-8")
+    else:
+        msgs.append(f"{slug}: WARN no wafer_block macro summary found in src/lib.rs — summaries not synced")
+
+    if changed and not check_only:
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+    return changed, msgs
+
+
+def main(argv: list[str]) -> int:
+    check_only = "--check" in argv
+    slugs = [a for a in argv if not a.startswith("-")]
+    if not slugs:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    any_drift = False
+    failed = False
+    for slug in slugs:
+        try:
+            changed, msgs = sync_block(slug, check_only)
+        except (RuntimeError, json.JSONDecodeError) as e:
+            print(f"  ✗ {slug}: {e}", file=sys.stderr)
+            failed = True
+            continue
+        for msg in msgs:
+            print(f"  {'~' if changed else '='} {msg}")
+        if changed:
+            any_drift = True
+            print(f"  {'DRIFT (not written, --check)' if check_only else 'synced'}: blocks/{slug}/")
+        else:
+            print(f"  ok: blocks/{slug}/ already in sync")
+
+    if failed:
+        return 1
+    return 1 if (check_only and any_drift) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Why

An analysis of the tool-building pipeline (create-tool-loop / create-next-tool / new-tool / improve-tool) found the quality ceiling is set by a few root causes rather than prompt wording:

1. `manifest.json tool.*` was **hand-synced** to the descriptor — the page form reads the manifest, so drift silently downgraded selects to text boxes (the #151 backfill fixed 77+ tools after the fact, and `image-resize` had drifted again — fixed here as a demonstration).
2. The BUILDER PROMPT existed in **two copies that drifted**: the `create-next-tool` copy still told builders to run heavy builds in background + poll, which the loop banned on 2026-06-22 for leaking orphan tasks by the hundreds.
3. The loop skill **hardcoded environment facts** (`/root/gizza-ai/gizza-ai`, `git push origin feat/tool-creating-2`, 2-CPU box) that are wrong on any other machine/branch.
4. Loop-mode competitor research was vestigial (the prompt only said "write the analysis file"), media Playwright specs asserted only that *a* `data:` URL appeared, and nothing gated placeholders / FAQ depth / SERP description length.

## What

**Scripts**
- **`scripts/sync-tool-manifest.py`** (new): generates `tool.parameters`/`tool.description` from the installed CLI's live descriptor (`gizza describe`) and propagates the `wafer_block` macro summary to `manifest.json` + `wafer.toml`. `--check` mode for CI/verification. The manifest is now a generated artifact; `check-tool-hygiene.py` stays as the backstop.
- **`scripts/check-tool-hygiene.py`**: new strict checks — field placeholders (the page's worked example), ≥3 FAQ `<details>`, 50–170 char meta description. **Strict (gating) per-slug** — how the skills run it for new/improved tools — and **advisory (aggregated, non-gating) repo-wide** so CI stays green until the corpus is backfilled (current advisory counts: 166 description / 243 faq / 16 placeholder).
- `scripts/check-tool-hygiene.test.sh` extended to cover strict-mode pass/fail for all three new checks.

**Skills**
- `create-tool-loop`: single canonical BUILDER PROMPT (numbered checklist) with a pre-implementation competitor scan, the manifest-sync step, media-correctness test requirement, and the strict hygiene gate; `<REPO>`/`<BRANCH>`/`<TODAY>` substituted at dispatch time (stop-if-main guard).
- `create-next-tool`: drifted duplicate prompt removed (points at the canonical); 200-line findings log split into `references/{wasm-crates,page-patterns,ops}.md` with an index.
- `new-tool`: `.describe()` required on every param; build order includes `sync-tool-manifest.py` before the generator; Playwright templates now assert real output (decode media + dimension/pixel checks, deep-link case); new user-QA rubric step before ship.
- `improve-tool`: the 10 overfit usability standards (fixed 760px widths, scrollbar hex colors) replaced with 9 principles, including **platform over per-tool hacks** — extend `tools/generator` declaratively instead of adding `cfg.slug === …` branches to shared `site/tool.js` (6 tools already did this; a follow-up PR adds the declarative controls).

## Tested

- `bash scripts/check-tool-hygiene.test.sh` → OK (covers all strict checks pass+fail)
- `python3 scripts/check-tool-hygiene.py` repo-wide → exit 0 (advisory summary, no hard violations)
- `python3 scripts/sync-tool-manifest.py image-resize` → synced, idempotent (`--check` clean after), hygiene-clean; `url-encode` verified as a no-op on an already-clean block

## Follow-up (separate PR)

Declarative generator controls (date/time pickers, datalist vocabularies, example chips, copy-output/reset chrome) + migrating the 6 slug-branched tools out of `site/tool.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)