### PR TITLE
Generator: declarative page controls — date pickers, datalists, example chips, reset/copy chrome

### DIFF
--- a/blocks/age-calculator/page/meta.toml
+++ b/blocks/age-calculator/page/meta.toml
@@ -9,15 +9,27 @@ export        = "run"
 live          = false
 output_label  = "Age (JSON)"
 format        = "text"
+wide          = true
 
 [[input]]
 name        = "birthdate"
 label       = "Date of birth"
 placeholder = "2000-06-22"
 source      = "field"
+kind        = "date"
 
 [[input]]
 name        = "as_of"
 label       = "As of date (optional — defaults to today)"
 placeholder = "2026-06-22"
 source      = "field"
+kind        = "date"
+default     = "today"
+
+[[example]]
+label  = "Born 15 Apr 1990"
+params = { birthdate = "1990-04-15" }
+
+[[example]]
+label  = "Millennium baby"
+params = { birthdate = "2000-01-01" }

--- a/site/tool.css
+++ b/site/tool.css
@@ -1455,3 +1455,22 @@ body { margin: 0; font-family: system-ui, -apple-system, "Segoe UI", Roboto, san
 
 
 
+
+/* Declarative widget chrome (generator-rendered on every page — see
+   tools/generator/src/template.rs): example chips, Reset / Copy-result
+   actions, and the wide-widget class that replaces per-tool JS width hacks. */
+.tool-widget--wide { max-width: 760px; }
+.tool-examples { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin: 2px 0 12px; }
+.tool-examples-label { font-size: .8rem; text-transform: uppercase; letter-spacing: .04em; color: #94a3b8; }
+.tool-example-chip { border: 1px solid #cbd5e1; background: #fff; color: var(--tool-ink, #0f172a);
+  font-size: .85rem; padding: 4px 12px; border-radius: 999px; cursor: pointer;
+  transition: border-color .15s, box-shadow .15s; }
+.tool-example-chip:hover, .tool-example-chip:focus-visible { border-color: var(--tool-accent, #4f46e5);
+  box-shadow: 0 2px 8px rgba(15, 23, 42, .08); }
+.tool-widget-actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 12px; }
+.tool-widget-btn { border: 1px solid #cbd5e1; background: #fff; color: var(--tool-muted, #6b7280);
+  font-size: .85rem; padding: 6px 14px; border-radius: 8px; cursor: pointer;
+  transition: border-color .15s, color .15s; }
+.tool-widget-btn:hover, .tool-widget-btn:focus-visible { border-color: var(--tool-accent, #4f46e5);
+  color: var(--tool-ink, #0f172a); }
+.tool-widget-btn.copied { border-color: #16a34a; color: #16a34a; }

--- a/site/tool.js
+++ b/site/tool.js
@@ -41,11 +41,9 @@ function showResult(value) {
 }
 
 function showError(message) {
-  const widget = document.querySelector(".tool-widget");
-  if (widget && cfg.slug !== "timezone-convert" && cfg.slug !== "age-calculator" && cfg.slug !== "jwt-decode" && cfg.slug !== "list-converter") {
-    widget.style.maxWidth = "380px";
-  }
-
+  // Layout stability: never resize the widget on errors/keystrokes — nothing
+  // may jump under the user's cursor. Wide layouts are the tool-widget--wide
+  // class (meta.toml `wide = true`), not a JS width override.
   if (cfg.slug === "list-converter") {
     const inInput = document.getElementById("in-input");
     const outputTextarea = document.getElementById("list-conv-output-area");
@@ -245,6 +243,113 @@ function applyField(el, value) {
   }
 }
 
+// ---- Declarative widget behaviors (defaults / example chips / reset / copy) ----
+// Driven by window.GIZZA_TOOL, which the generator bakes from page/meta.toml —
+// every page gets these with ZERO per-tool JS. Do not add cfg.slug branches here;
+// extend the meta/generator instead (workspace fix-at-root-cause rule).
+
+// Resolve a meta `default` spec: "today"/"now" → the user's local date(-time),
+// "local-timezone" → their IANA zone, anything else literal.
+function resolveDefault(spec) {
+  const pad = (n) => String(n).padStart(2, "0");
+  const now = new Date();
+  if (spec === "today") {
+    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+  }
+  if (spec === "now") {
+    return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}`;
+  }
+  if (spec === "local-timezone") {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+    } catch (e) {
+      return "UTC";
+    }
+  }
+  return spec;
+}
+
+// Apply meta-declared defaults to empty fields. URL-prefilled or already-filled
+// fields are left alone unless `force` (the Reset path).
+function applyMetaDefaults(force = false) {
+  const params = new URLSearchParams(location.search);
+  for (const inp of cfg.inputs) {
+    if (inp.source !== "field" || !inp.default) continue;
+    const el = document.getElementById(inp.elementId);
+    if (!el) continue;
+    if (!force && (params.has(inp.name) || el.value)) continue;
+    applyField(el, resolveDefault(inp.default));
+  }
+}
+
+// Wire the example chips + Reset + Copy-result chrome the template renders.
+// `rerun` recomputes after programmatic input changes (compute for pure tools;
+// for ffmpeg tools it is the run fn, a no-op until a file is chosen).
+function wireWidgetChrome(rerun) {
+  for (const btn of document.querySelectorAll(".tool-example-chip")) {
+    btn.addEventListener("click", () => {
+      const ex = (cfg.examples || [])[Number(btn.dataset.example)];
+      if (!ex) return;
+      for (const [name, value] of Object.entries(ex.params || {})) {
+        const inp = cfg.inputs.find((i) => i.name === name);
+        if (inp) applyField(document.getElementById(inp.elementId), value);
+      }
+      rerun();
+    });
+  }
+
+  const reset = document.getElementById("tool-reset");
+  if (reset) {
+    reset.addEventListener("click", () => {
+      for (const inp of cfg.inputs) {
+        const el = document.getElementById(inp.elementId);
+        if (!el) continue;
+        if (inp.source === "file") {
+          el.value = "";
+          continue;
+        }
+        if (inp.source !== "field") continue;
+        // defaultValue/defaultChecked restore the server-rendered state (the
+        // select's default option, the checkbox default, a number's default).
+        if (el.type === "checkbox") {
+          el.checked = el.defaultChecked;
+        } else if (el.tagName === "SELECT") {
+          for (const o of el.options) o.selected = o.defaultSelected;
+        } else {
+          el.value = el.defaultValue;
+        }
+      }
+      applyMetaDefaults(true);
+      const media = document.getElementById("tool-output-media");
+      const dl = document.getElementById("tool-output-download");
+      if (media) media.hidden = true;
+      if (dl) dl.hidden = true;
+      history.replaceState({}, document.title, location.pathname);
+      rerun();
+    });
+  }
+
+  const copy = document.getElementById("tool-copy-output");
+  if (copy) {
+    copy.addEventListener("click", async () => {
+      const text = (out.textContent || "").trim();
+      if (!text) return;
+      try {
+        await navigator.clipboard.writeText(text);
+        copy.classList.add("copied");
+        const prev = copy.textContent;
+        copy.textContent = "Copied!";
+        setTimeout(() => {
+          copy.classList.remove("copied");
+          copy.textContent = prev;
+        }, 1500);
+      } catch (e) {
+        // Clipboard unavailable (e.g. non-secure context) — button is best-effort.
+      }
+    });
+  }
+}
+
 // Collect call args in declared order. "field" → input value; "clock" → now (s).
 function gatherArgs() {
   return cfg.inputs.map((inp) => {
@@ -323,6 +428,8 @@ async function main() {
     for (const f of qpFields) {
       applyField(document.getElementById(f.elementId), f.value);
     }
+    applyMetaDefaults();
+    wireWidgetChrome(run);
     async function loadUrlIntoFile(url) {
       try {
         const resp = await fetch(url);
@@ -369,8 +476,6 @@ async function main() {
 
   if (cfg.slug === "timezone-convert") {
     setupTimezoneConvertDefaults();
-  } else if (cfg.slug === "age-calculator") {
-    setupAgeCalculatorDefaults();
   } else if (cfg.slug === "jwt-decode") {
     setupJwtDecodeDefaults();
   }
@@ -387,10 +492,6 @@ async function main() {
       const hasField = cfg.inputs.some((i) => i.source === "field");
       const empty = hasField && gatherArgs().every((a) => a === "" || a == null);
       if (empty) {
-        const widget = document.querySelector(".tool-widget");
-        if (widget && cfg.slug !== "timezone-convert" && cfg.slug !== "age-calculator" && cfg.slug !== "jwt-decode") {
-          widget.style.maxWidth = "380px";
-        }
         out.classList.remove("error");
         out.textContent = "";
       } else {
@@ -404,6 +505,8 @@ async function main() {
   for (const f of queryPrefill(cfg.inputs, location.search).fields) {
     applyField(document.getElementById(f.elementId), f.value);
   }
+  applyMetaDefaults();
+  wireWidgetChrome(compute);
 
   // Wire field inputs to live recompute.
   for (const inp of cfg.inputs) {
@@ -425,6 +528,11 @@ async function main() {
 }
 
 function setupTimezoneConvertDefaults() {
+  // Legacy custom UI: it ships its own Reset, and its dashboard output makes the
+  // generic Copy-result copy a text soup — drop the generic chrome until this
+  // tool is migrated to the declarative meta.toml controls.
+  document.getElementById("tool-reset")?.remove();
+  document.getElementById("tool-copy-output")?.remove();
   const widget = document.querySelector(".tool-widget");
   if (widget) {
     widget.style.maxWidth = "760px";
@@ -684,78 +792,6 @@ function setupTimezoneConvertDefaults() {
   }
 }
 
-function setupAgeCalculatorDefaults() {
-  const widget = document.querySelector(".tool-widget");
-  if (widget) {
-    widget.style.maxWidth = "760px";
-  }
-
-  const birthInput = document.getElementById("in-birthdate");
-  const asOfInput = document.getElementById("in-as_of");
-
-  const birthLabel = document.querySelector('label[for="in-birthdate"]');
-  const asOfLabel = document.querySelector('label[for="in-as_of"]');
-
-  if (birthInput) {
-    birthInput.type = "date";
-  }
-  if (asOfInput) {
-    asOfInput.type = "date";
-  }
-
-  // Format current local date: YYYY-MM-DD
-  const now = new Date();
-  const pad = (n) => String(n).padStart(2, '0');
-  const localDateStr = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
-
-  const params = new URLSearchParams(location.search);
-  if (asOfInput && !asOfInput.value && !params.has("as_of")) {
-    asOfInput.value = localDateStr;
-  }
-
-  if (widget && birthInput && asOfInput) {
-    const wrapper = document.createElement("div");
-    wrapper.className = "age-inputs-wrapper";
-
-    const col1 = document.createElement("div");
-    col1.className = "age-inputs-col";
-    if (birthLabel) col1.appendChild(birthLabel);
-    col1.appendChild(birthInput);
-
-    const col2 = document.createElement("div");
-    col2.className = "age-inputs-col";
-    if (asOfLabel) col2.appendChild(asOfLabel);
-    col2.appendChild(asOfInput);
-
-    const col3 = document.createElement("div");
-    col3.className = "age-inputs-col";
-    
-    const resetBtn = document.createElement("button");
-    resetBtn.type = "button";
-    resetBtn.className = "age-reset-btn";
-    resetBtn.innerHTML = `<svg viewBox="0 0 24 24" width="14" height="14" stroke="currentColor" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M21.5 2v6h-6M21.34 15.57a10 10 0 1 1-.57-8.38l5.67-5.67"/></svg> Reset`;
-    col3.appendChild(resetBtn);
-
-    wrapper.appendChild(col1);
-    wrapper.appendChild(col2);
-    wrapper.appendChild(col3);
-
-    widget.insertBefore(wrapper, widget.firstChild);
-
-    resetBtn.addEventListener("click", () => {
-      birthInput.value = "";
-      asOfInput.value = localDateStr;
-      
-      // Clear URL params on reset
-      const newUrl = window.location.pathname;
-      window.history.replaceState({}, document.title, newUrl);
-
-      birthInput.dispatchEvent(new Event("input"));
-      asOfInput.dispatchEvent(new Event("input"));
-    });
-  }
-}
-
 function renderAgeCalculator(data) {
   out.innerHTML = "";
   out.className = "age-active-container";
@@ -890,6 +926,10 @@ function renderAgeCalculator(data) {
 }
 
 function renderKrutidevUnicode(mod) {
+  // Legacy dual-pane UI with its own copy/clear buttons — drop the generic
+  // chrome until this tool is migrated to the declarative controls.
+  document.getElementById("tool-reset")?.remove();
+  document.getElementById("tool-copy-output")?.remove();
   const widget = document.querySelector(".tool-widget");
   if (widget) {
     widget.style.maxWidth = "960px";
@@ -1570,6 +1610,10 @@ function countListItems(text, sepType, customSep) {
 }
 
 function setupJwtDecodeDefaults() {
+  // Legacy custom dashboard output — the generic Copy-result would copy its
+  // concatenated labels; drop it until this tool is migrated. Reset stays (the
+  // token field is a normal input).
+  document.getElementById("tool-copy-output")?.remove();
   const widget = document.querySelector(".tool-widget");
   if (widget) {
     widget.style.maxWidth = "880px";

--- a/tests/tool-page-widget-chrome.spec.ts
+++ b/tests/tool-page-widget-chrome.spec.ts
@@ -1,0 +1,44 @@
+// Declarative widget chrome (tools/generator + site/tool.js): example chips,
+// meta-declared defaults, Reset, and Copy-result — rendered on every page from
+// meta.toml with zero per-tool JS. age-calculator is the first migrated tool
+// (kind="date" pickers replace its old slug-specific setup in tool.js).
+import { test, expect } from './fixtures';
+
+const localToday = () => {
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+};
+
+test('example chip prefills its params and runs', async ({ page }) => {
+  await page.goto('/tools/age-calculator/');
+  await page.click('.tool-example-chip:has-text("Born 15 Apr 1990")');
+  await expect(page.locator('#in-birthdate')).toHaveValue('1990-04-15');
+  await expect(page.locator('#tool-output .age-result-hero-text')).toContainText('old', { timeout: 15000 });
+});
+
+test('kind="date" renders native pickers and default="today" prefills', async ({ page }) => {
+  await page.goto('/tools/age-calculator/');
+  await expect(page.locator('#in-birthdate')).toHaveAttribute('type', 'date');
+  await expect(page.locator('#in-as_of')).toHaveValue(localToday());
+});
+
+test('reset restores server defaults and meta defaults', async ({ page }) => {
+  await page.goto('/tools/age-calculator/');
+  await page.fill('#in-birthdate', '1990-01-15');
+  await page.fill('#in-as_of', '2026-06-22');
+  await page.click('#tool-reset');
+  await expect(page.locator('#in-birthdate')).toHaveValue('');
+  await expect(page.locator('#in-as_of')).toHaveValue(localToday());
+});
+
+test('copy-result copies the output text', async ({ page, context }) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  await page.goto('/tools/url-encode/');
+  await page.fill('#in-text', 'a b');
+  await expect(page.locator('#tool-output')).toHaveText('a%20b', { timeout: 15000 });
+  await page.click('#tool-copy-output');
+  await expect(page.locator('#tool-copy-output')).toHaveClass(/copied/);
+  const clip = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clip).toBe('a%20b');
+});

--- a/tools/generator/src/control.rs
+++ b/tools/generator/src/control.rs
@@ -4,8 +4,14 @@
 //!
 //! A `source="field"` input renders as: `<select>` (param has an `enum`),
 //! checkbox (`boolean`), number input (`integer`/`number`), or text/textarea
-//! (`string` or — defensively — any param missing from the schema).
+//! (`string` or — defensively — any param missing from the schema). The meta can
+//! override a string param with a native picker (`kind = "date" | "time" |
+//! "datetime-local"`) or a named `<datalist>` vocabulary (`options = "timezones"`)
+//! — the descriptor only knows "string", so these page-level refinements live in
+//! `page/meta.toml`.
 
+use crate::meta::Input;
+use crate::vocab;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -35,6 +41,14 @@ pub enum Control {
     },
     Checkbox {
         default: bool,
+    },
+    /// A native picker: `<input type="date|time|datetime-local">` (meta `kind`).
+    Picker {
+        input_type: String,
+    },
+    /// A text input backed by a `<datalist>` of a named vocabulary (meta `options`).
+    Datalist {
+        options: Vec<String>,
     },
 }
 
@@ -67,8 +81,41 @@ impl ParamSchema {
         ParamSchema(props)
     }
 
-    /// Resolve the control for field `name`. `multiline` only matters for a
-    /// string/unknown param (textarea vs single-line text).
+    /// Resolve the control for a `source="field"` input: meta-level overrides
+    /// (`kind`, `options`) win over the schema-derived control, because the
+    /// schema only knows JSON types ("string") while the meta knows the page
+    /// affordance (a date picker, a timezone autocomplete).
+    pub fn control_for_input(&self, input: &Input) -> Control {
+        match input.kind.as_str() {
+            "" => {}
+            k @ ("date" | "time" | "datetime-local") => {
+                return Control::Picker { input_type: k.to_string() };
+            }
+            other => {
+                eprintln!(
+                    "warning: [[input]] \"{}\" has unknown kind \"{other}\" (want date|time|datetime-local) — falling back to the schema control",
+                    input.name
+                );
+            }
+        }
+        if !input.options.is_empty() {
+            match vocab::options(&input.options) {
+                Some(opts) => {
+                    return Control::Datalist {
+                        options: opts.iter().map(|s| s.to_string()).collect(),
+                    };
+                }
+                None => eprintln!(
+                    "warning: [[input]] \"{}\" names unknown options vocabulary \"{}\" (see tools/generator/src/vocab.rs) — falling back to the schema control",
+                    input.name, input.options
+                ),
+            }
+        }
+        self.control_for(&input.name, input.multiline)
+    }
+
+    /// Resolve the schema-derived control for field `name`. `multiline` only
+    /// matters for a string/unknown param (textarea vs single-line text).
     pub fn control_for(&self, name: &str, multiline: bool) -> Control {
         let text_or_area = || {
             if multiline {
@@ -166,5 +213,60 @@ mod tests {
         let s = ParamSchema::empty();
         assert_eq!(s.control_for("whatever", false), Control::Text);
         assert_eq!(s.control_for("whatever", true), Control::Textarea);
+    }
+
+    fn field(name: &str, kind: &str, options: &str) -> Input {
+        Input {
+            name: name.into(),
+            source: "field".into(),
+            label: String::new(),
+            placeholder: String::new(),
+            accept: String::new(),
+            multiline: false,
+            kind: kind.into(),
+            options: options.into(),
+            default: String::new(),
+        }
+    }
+
+    #[test]
+    fn meta_kind_overrides_schema_with_a_native_picker() {
+        let s = schema(json!({ "birthdate": { "type": "string" } }));
+        assert_eq!(
+            s.control_for_input(&field("birthdate", "date", "")),
+            Control::Picker { input_type: "date".into() }
+        );
+        assert_eq!(
+            s.control_for_input(&field("at", "datetime-local", "")),
+            Control::Picker { input_type: "datetime-local".into() }
+        );
+    }
+
+    #[test]
+    fn named_options_render_a_datalist() {
+        let s = schema(json!({ "from": { "type": "string" } }));
+        match s.control_for_input(&field("from", "", "timezones")) {
+            Control::Datalist { options } => {
+                assert!(options.iter().any(|o| o == "UTC"));
+                assert!(options.iter().any(|o| o == "Europe/Amsterdam"));
+            }
+            other => panic!("expected Datalist, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_kind_and_vocab_fall_back_to_schema_control() {
+        let s = schema(json!({ "x": { "type": "string" } }));
+        assert_eq!(s.control_for_input(&field("x", "color", "")), Control::Text);
+        assert_eq!(s.control_for_input(&field("x", "", "nope")), Control::Text);
+    }
+
+    #[test]
+    fn without_overrides_meta_input_uses_schema_control() {
+        let s = schema(json!({ "mode": { "type": "string", "enum": ["a", "b"] } }));
+        match s.control_for_input(&field("mode", "", "")) {
+            Control::Select { options, .. } => assert_eq!(options, vec!["a", "b"]),
+            other => panic!("expected Select, got {other:?}"),
+        }
     }
 }

--- a/tools/generator/src/main.rs
+++ b/tools/generator/src/main.rs
@@ -10,6 +10,7 @@ mod index;
 mod markdown;
 mod meta;
 mod template;
+mod vocab;
 
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/tools/generator/src/markdown.rs
+++ b/tools/generator/src/markdown.rs
@@ -92,7 +92,7 @@ pub(crate) fn example_deeplink(meta: &ToolMeta, schema: &ParamSchema) -> String 
         if i.source == "file" {
             pairs.push("url=https://example.com/input".to_string());
         } else if i.source == "field" {
-            let sample = sample_value(&schema.control_for(&i.name, i.multiline), &i.placeholder);
+            let sample = sample_value(&schema.control_for_input(i), &i.placeholder);
             pairs.push(format!("{}={}", i.name, urlencode(&sample)));
         }
     }
@@ -112,6 +112,17 @@ fn sample_value(control: &Control, placeholder: &str) -> String {
             .or_else(|| default.map(fmt_num))
             .or_else(|| min.map(fmt_num))
             .unwrap_or_else(|| "1".to_string()),
+        Control::Picker { input_type } => ph.unwrap_or_else(|| {
+            match input_type.as_str() {
+                "time" => "09:30",
+                "datetime-local" => "2000-01-31T09:30",
+                _ => "2000-01-31", // "date"
+            }
+            .to_string()
+        }),
+        Control::Datalist { options } => ph
+            .or_else(|| options.first().cloned())
+            .unwrap_or_else(|| "value".to_string()),
         Control::Text | Control::Textarea => ph.unwrap_or_else(|| "value".to_string()),
     }
 }

--- a/tools/generator/src/meta.rs
+++ b/tools/generator/src/meta.rs
@@ -20,6 +20,30 @@ pub struct Input {
     /// single-line `<input>` (e.g. for batch/per-line input). Default false.
     #[serde(default)]
     pub multiline: bool,
+    /// For source="field": force a native picker control — "date", "time", or
+    /// "datetime-local". Overrides the schema-derived control (the descriptor
+    /// only knows "string"). Empty = derive from the schema.
+    #[serde(default)]
+    pub kind: String,
+    /// For source="field": the NAME of an option vocabulary (see `vocab.rs`,
+    /// e.g. "timezones") rendered as a `<datalist>` for searchable autocomplete.
+    #[serde(default)]
+    pub options: String,
+    /// For source="field": client-side default applied on load when the field is
+    /// empty and not pre-filled from the URL. "today" → local YYYY-MM-DD, "now" →
+    /// local YYYY-MM-DDTHH:MM, "local-timezone" → the user's IANA zone; anything
+    /// else is used literally. Also what the Reset button restores.
+    #[serde(default)]
+    pub default: String,
+}
+
+/// A one-click example: a chip under the inputs that pre-fills `params` and runs.
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub struct Example {
+    pub label: String,
+    /// param name → value, applied via the same path as URL query pre-fill.
+    #[serde(default)]
+    pub params: std::collections::BTreeMap<String, String>,
 }
 
 /// Full metadata for a single tool page.
@@ -49,6 +73,13 @@ pub struct ToolMeta {
     pub runtime: String,
     #[serde(default, rename = "input")]
     pub inputs: Vec<Input>,
+    /// One-click example chips rendered under the inputs.
+    #[serde(default, rename = "example")]
+    pub examples: Vec<Example>,
+    /// Widen the widget (multi-column result layouts). Renders as the
+    /// `tool-widget--wide` class instead of a per-tool JS width hack.
+    #[serde(default)]
+    pub wide: bool,
 }
 
 fn default_runtime() -> String {
@@ -72,8 +103,14 @@ impl ToolMeta {
                     "source": i.source,
                     "elementId": format!("in-{}", i.name),
                     "accept": i.accept,
+                    "default": i.default,
                 })
             })
+            .collect();
+        let examples: Vec<serde_json::Value> = self
+            .examples
+            .iter()
+            .map(|e| serde_json::json!({ "label": e.label, "params": e.params }))
             .collect();
         serde_json::json!({
             "slug": self.slug,
@@ -82,6 +119,7 @@ impl ToolMeta {
             "live": self.live,
             "intervalMs": self.interval_ms,
             "inputs": inputs,
+            "examples": examples,
             "output": { "label": self.output_label, "elementId": "tool-output" },
             "format": self.format,
             "runtime": self.runtime,

--- a/tools/generator/src/template.rs
+++ b/tools/generator/src/template.rs
@@ -82,12 +82,13 @@ pub fn render_page(meta: &ToolMeta, content_html: &str, schema: &ParamSchema) ->
                     section class="tool-hero" {
                         h1 { (meta.h1) }
                         p class="tool-hero-sub" { (meta.hero_subtitle) }
-                        div class="tool-widget" {
+                        @let widget_class = if meta.wide { "tool-widget tool-widget--wide" } else { "tool-widget" };
+                        div class=(widget_class) {
                             @for input in &meta.inputs {
                                 @if input.source == "field" {
                                     @let id = format!("in-{}", input.name);
                                     label class="tool-field-label" for=(id) { (input.label) }
-                                    @match schema.control_for(&input.name, input.multiline) {
+                                    @match schema.control_for_input(input) {
                                         Control::Select { options, default } => {
                                             select id=(id) class="tool-input tool-select" {
                                                 @for opt in &options {
@@ -107,6 +108,19 @@ pub fn render_page(meta: &ToolMeta, content_html: &str, schema: &ParamSchema) ->
                                                   min=[min_s.as_deref()] max=[max_s.as_deref()] value=[val_s.as_deref()]
                                                   autocomplete="off" autocapitalize="off" spellcheck="false";
                                         }
+                                        Control::Picker { input_type } => {
+                                            input id=(id) class="tool-input" type=(input_type)
+                                                  placeholder=(input.placeholder) autocomplete="off";
+                                        }
+                                        Control::Datalist { options } => {
+                                            @let list_id = format!("dl-{}", input.name);
+                                            input id=(id) class="tool-input" type="text" list=(list_id)
+                                                  placeholder=(input.placeholder)
+                                                  autocomplete="off" autocapitalize="off" spellcheck="false";
+                                            datalist id=(list_id) {
+                                                @for opt in &options { option value=(opt) {} }
+                                            }
+                                        }
                                         Control::Textarea => {
                                             textarea id=(id) class="tool-input" rows="4"
                                                   placeholder=(input.placeholder)
@@ -124,6 +138,14 @@ pub fn render_page(meta: &ToolMeta, content_html: &str, schema: &ParamSchema) ->
                                           type="file" accept=(input.accept);
                                 }
                             }
+                            @if !meta.examples.is_empty() {
+                                div class="tool-examples" {
+                                    span class="tool-examples-label" { "Try:" }
+                                    @for (i, ex) in meta.examples.iter().enumerate() {
+                                        button type="button" class="tool-example-chip" data-example=(i) { (ex.label) }
+                                    }
+                                }
+                            }
                             div class="tool-output-label" { (meta.output_label) }
                             @if meta.format == "image" || meta.format == "video" || meta.format == "audio" {
                                 @if meta.format == "image" {
@@ -137,6 +159,20 @@ pub fn render_page(meta: &ToolMeta, content_html: &str, schema: &ParamSchema) ->
                                 output id="tool-output" class="tool-output" { "" }
                             } @else {
                                 output id="tool-output" class="tool-output" { "" }
+                            }
+                            @let has_fields = meta.inputs.iter().any(|i| i.source == "field");
+                            @let is_media = meta.format == "image" || meta.format == "video" || meta.format == "audio";
+                            @if has_fields || !is_media {
+                                div class="tool-widget-actions" {
+                                    @if has_fields {
+                                        button id="tool-reset" class="tool-widget-btn" type="button"
+                                               title="Restore the default inputs" { "Reset" }
+                                    }
+                                    @if !is_media {
+                                        button id="tool-copy-output" class="tool-widget-btn" type="button"
+                                               title="Copy the result to the clipboard" { "Copy result" }
+                                    }
+                                }
                             }
                         }
                     }
@@ -494,6 +530,77 @@ placeholder = "640"
 "#,
         )
         .unwrap()
+    }
+
+    fn declarative_sample() -> ToolMeta {
+        ToolMeta::from_toml(
+            r#"
+slug          = "age-calculator"
+title         = "Age Calculator — gizza.ai"
+description   = "d"
+h1            = "Age Calculator"
+hero_subtitle = "s"
+wasm          = "gizza_ai_age_calculator_web"
+export        = "run"
+output_label  = "Age"
+format        = "text"
+wide          = true
+
+[[input]]
+name        = "birthdate"
+label       = "Date of birth"
+source      = "field"
+kind        = "date"
+
+[[input]]
+name        = "as_of"
+label       = "As of"
+source      = "field"
+kind        = "date"
+default     = "today"
+
+[[input]]
+name        = "from"
+label       = "From zone"
+source      = "field"
+options     = "timezones"
+
+[[example]]
+label  = "Born 1990-04-15"
+params = { birthdate = "1990-04-15" }
+"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn renders_declarative_controls_examples_and_widget_chrome() {
+        let html = render_page(&declarative_sample(), "<h2>About</h2>", &ParamSchema::empty());
+        // meta kind="date" → native picker, no per-tool JS type-swapping
+        assert!(html.contains(r#"id="in-birthdate" class="tool-input" type="date""#), "date picker rendered");
+        // meta options="timezones" → datalist autocomplete
+        assert!(html.contains(r#"list="dl-from""#), "input references its datalist");
+        assert!(html.contains(r#"<datalist id="dl-from">"#), "datalist rendered");
+        assert!(html.contains(r#"<option value="Europe/Amsterdam">"#), "vocab options present");
+        // [[example]] → one-click chip wired by data-example index
+        assert!(html.contains("tool-example-chip"), "example chip rendered");
+        assert!(html.contains(r#"data-example="0""#), "chip carries its example index");
+        assert!(html.contains("Born 1990-04-15"), "chip shows the example label");
+        // wide widgets are a class, not a JS style override
+        assert!(html.contains("tool-widget tool-widget--wide"), "wide widget class");
+        // standard chrome: reset + copy-result on every field/text tool
+        assert!(html.contains(r#"id="tool-reset""#), "reset button rendered");
+        assert!(html.contains(r#"id="tool-copy-output""#), "copy-result button rendered");
+        // client config carries the declarative default + examples for tool.js
+        assert!(html.contains(r#""default":"today""#), "input default in client config");
+        assert!(html.contains(r#""examples":[{"label":"Born 1990-04-15""#), "examples in client config");
+    }
+
+    #[test]
+    fn media_tools_get_reset_but_not_copy_result() {
+        let html = render_page(&ffmpeg_sample(), "<h2>About</h2>", &ParamSchema::empty());
+        assert!(html.contains(r#"id="tool-reset""#), "reset present (has fields)");
+        assert!(!html.contains(r#"id="tool-copy-output""#), "no copy-result on media output");
     }
 
     #[test]

--- a/tools/generator/src/vocab.rs
+++ b/tools/generator/src/vocab.rs
@@ -1,0 +1,54 @@
+//! Named option vocabularies for `[[input]] options = "<name>"` — rendered as a
+//! `<datalist>` so large standard value sets (timezones, …) get searchable
+//! autocomplete instead of a raw text box. Declarative: a tool opts in from its
+//! `page/meta.toml`; no per-tool JS.
+
+/// IANA timezone names, matching the set the timezone tools accept. Kept short on
+/// purpose (major zones per region) — a datalist is autocomplete, not validation;
+/// the core still accepts any valid IANA name typed in full.
+pub const TIMEZONES: &[&str] = &[
+    "UTC", "GMT",
+    "Africa/Cairo", "Africa/Johannesburg", "Africa/Lagos", "Africa/Nairobi",
+    "America/Anchorage", "America/Argentina/Buenos_Aires", "America/Bogota",
+    "America/Chicago", "America/Denver", "America/Halifax", "America/Los_Angeles",
+    "America/Mexico_City", "America/New_York", "America/Phoenix", "America/Santiago",
+    "America/Sao_Paulo", "America/St_Johns", "America/Toronto", "America/Vancouver",
+    "Asia/Bangkok", "Asia/Dubai", "Asia/Hong_Kong", "Asia/Jakarta", "Asia/Jerusalem",
+    "Asia/Kabul", "Asia/Kolkata", "Asia/Kathmandu", "Asia/Manila", "Asia/Riyadh",
+    "Asia/Seoul", "Asia/Shanghai", "Asia/Singapore", "Asia/Taipei", "Asia/Tashkent",
+    "Asia/Tehran", "Asia/Tokyo", "Atlantic/Azores",
+    "Australia/Adelaide", "Australia/Brisbane", "Australia/Darwin", "Australia/Hobart",
+    "Australia/Melbourne", "Australia/Perth", "Australia/Sydney",
+    "Europe/Amsterdam", "Europe/Athens", "Europe/Belgrade", "Europe/Berlin",
+    "Europe/Brussels", "Europe/Budapest", "Europe/Copenhagen", "Europe/Dublin",
+    "Europe/Helsinki", "Europe/Istanbul", "Europe/Lisbon", "Europe/London",
+    "Europe/Madrid", "Europe/Moscow", "Europe/Oslo", "Europe/Paris", "Europe/Prague",
+    "Europe/Rome", "Europe/Stockholm", "Europe/Vienna", "Europe/Warsaw", "Europe/Zurich",
+    "Pacific/Auckland", "Pacific/Chatham", "Pacific/Fiji", "Pacific/Honolulu",
+];
+
+/// Look up a named vocabulary. Unknown names return `None` and the field falls
+/// back to a plain text input (the generator warns, it does not abort).
+pub fn options(name: &str) -> Option<&'static [&'static str]> {
+    match name {
+        "timezones" => Some(TIMEZONES),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timezones_vocab_resolves() {
+        let tz = options("timezones").expect("timezones vocab exists");
+        assert!(tz.contains(&"UTC"));
+        assert!(tz.contains(&"Europe/Amsterdam"));
+    }
+
+    #[test]
+    fn unknown_vocab_is_none() {
+        assert_eq!(options("nope"), None);
+    }
+}


### PR DESCRIPTION
## Why

The improve-tool usability standards (native date pickers, searchable timezone autocomplete, smart defaults, reset buttons, stable layout) had no platform support — the generator only knew Text/Textarea/Number/Select/Checkbox. So each "premium" tool implemented them as `cfg.slug === "…"` branches inside the **shared** `site/tool.js` (2,151 lines; 6 tools branched), which no other tool can reuse and which violates the workspace fix-at-root-cause rule.

## What

Page affordances are now **declared in `page/meta.toml`** and rendered by the generator for every tool:

| meta.toml | renders as |
|---|---|
| `[[input]] kind = "date" \| "time" \| "datetime-local"` | native picker (overrides the schema's `string`) |
| `[[input]] options = "timezones"` | `<datalist>` autocomplete from a named vocabulary (`vocab.rs`; unknown names warn + fall back) |
| `[[input]] default = "today" \| "now" \| "local-timezone" \| literal` | client-side smart default (skipped when URL-prefilled; what Reset restores) |
| `[[example]] label / params` | one-click "Try:" chips that prefill and run |
| `wide = true` | `tool-widget--wide` class (replaces JS width overrides) |
| — | standard **Reset** + **Copy result** buttons on every field/text tool |

`site/tool.js` gains one generic wiring layer (`applyMetaDefaults` / `wireWidgetChrome`) with an explicit "do not add cfg.slug branches here" header, and **loses**:
- the error-state width bounce (`maxWidth = "380px"` on error/empty — the layout-instability the standards ban), and
- the whole `setupAgeCalculatorDefaults` slug branch — **age-calculator is the first migrated tool** (date pickers + today default + example chips, meta.toml only).

Remaining legacy custom UIs (timezone-convert, jwt-decode, krutidev, list-converter) explicitly drop the generic chrome inside their existing setup functions until each is migrated (follow-ups).

## Tested

- `cargo test` (tools/generator): 33 passed, incl. new control/vocab/template tests
- Generator run repo-wide: 308 pages rendered
- Playwright: 30 specs green — age-calculator (3), url-encode (5), timezone-convert (5), jwt-decode, list-converter, krutidev, percentage-calculator, image-crop, image-resize, plus a new `tool-page-widget-chrome.spec.ts` (chip prefill+run, native picker + today default, reset restore, clipboard copy)

## Follow-ups

- Migrate timezone-convert (needs a `tag-list` control kind + declarative dashboard renderer), jwt-decode, krutidev, list-converter off their slug branches
- Builder skills already instruct new tools to use these declarative features (see #152)

🤖 Generated with [Claude Code](https://claude.com/claude-code)