### PR TITLE
Builder-feedback fixes: raw multi-line CLI output, scaffold __SLUG__, fresh-checkout docs

### DIFF
--- a/.claude/skills/create-next-tool/references/ops.md
+++ b/.claude/skills/create-next-tool/references/ops.md
@@ -31,3 +31,14 @@ builder per tool keeps the dispatcher's context tiny so the loop runs indefinite
 `~/.claude/.credentials.json` holds only OAuth tokens (token expiry, not the usage window). The quota
 + reset are enforced server-side and only surfaced on a rate-limit error response — the loop can't
 pre-read remaining budget from disk; it must react to a limit error (back off / stop) when it hits one.
+
+**Fresh checkout / worktree gotchas (2026-07-02, from the first isolated builder run):**
+- `tests/package-lock.json` is deliberately gitignored — use `npm install` in `tests/` (what CI
+  does), NOT `npm ci` (which hard-requires a lockfile and fails).
+- `cargo install --path cli` embeds only the blocks whose `target/block.wasm` exists. A fresh
+  checkout has just the ~33 COMMITTED wasm fixtures, so the install produces (and globally
+  overwrites `~/.cargo/bin/gizza` with) a CLI missing most tools. Either run the baseline
+  `solobase build` first, or reinstall from the full checkout when done.
+- The page generator prints a "web/pkg not found (skipping WASM copy)" warning per block whose
+  wasm-pack output is missing — in a fresh checkout that's ~300 warnings. Harmless for the tool
+  you're building (its own page still renders); noisy but expected without the baseline build.

--- a/.claude/skills/new-tool/SKILL.md
+++ b/.claude/skills/new-tool/SKILL.md
@@ -66,7 +66,9 @@ the build/test/PR commands. Follow these steps in order:
    `cargo install --path cli --force`; `python3 scripts/sync-tool-manifest.py <slug>` (regenerates
    manifest `tool.*` + summaries from the live descriptor — required BEFORE the generator, which
    reads the manifest); `cargo run --manifest-path tools/generator/Cargo.toml -- .`;
-   `solobase build`; and `python3 scripts/check-tool-hygiene.py <slug>` (the hard gate CI
+   `solobase build` (may be SKIPPED per the create-next-tool throughput rule — `wafer build`
+   already validated this block's wasm and CI runs the full build on deploy; say so in the PR
+   if skipped); and `python3 scripts/check-tool-hygiene.py <slug>` (the hard gate CI
    enforces — per-slug mode is strict: drifted manifest, plain-markdown FAQ, scaffold TODOs,
    summary drift, missing placeholders, <3 FAQs, bad meta description length). Fix
    compile/test failures (≤3 attempts) before escalating. (No SKILL.md to regenerate —

--- a/.claude/skills/new-tool/reference.md
+++ b/.claude/skills/new-tool/reference.md
@@ -63,6 +63,9 @@ shared `site/tool.js` for these:
 Every spec asserts REAL output (an exact value a user would see), never just "something
 rendered" — a tool whose transform silently no-ops must FAIL its spec. Always include one
 `?param=` deep-link case (the page pre-fills from the query string and auto-runs).
+GOTCHA: `toHaveText` normalizes whitespace, so it can't assert MULTI-LINE output exactly —
+compare `await page.locator('#tool-output').textContent()` against the expected string with
+real newlines instead (single-line outputs are fine with `toHaveText`).
 
 ### pure
 ```ts

--- a/cli/src/render.rs
+++ b/cli/src/render.rs
@@ -107,6 +107,12 @@ fn trim_number(v: &Value) -> String {
         }
         return format!("{f}");
     }
+    // A string result prints as its raw text — Value::to_string would JSON-encode
+    // it (surrounding quotes + \n escapes), which turned every multi-line text
+    // tool's output into one escaped line (`"operation: …\nbinary   : …"`).
+    if let Some(s) = v.as_str() {
+        return s.to_string();
+    }
     v.to_string()
 }
 
@@ -139,6 +145,20 @@ mod tests {
     fn envelope_for_llm() {
         let r = render(br#"{"_for_llm":"resized cat to 64x64","_for_ui":{}}"#, false);
         assert_eq!(r.stdout, "resized cat to 64x64");
+    }
+
+    #[test]
+    fn multiline_string_result_prints_raw_text() {
+        // NOT the JSON encoding ("line one\nline two") — real newlines, no quotes.
+        let r = render(br#"{"result":"line one\nline two"}"#, false);
+        assert_eq!(r.stdout, "line one\nline two");
+        assert_eq!(r.exit_code, 0);
+    }
+
+    #[test]
+    fn non_string_result_still_renders_as_json() {
+        let r = render(br#"{"result":{"items":[1,2]}}"#, false);
+        assert_eq!(r.stdout, r#"{"items":[1,2]}"#);
     }
 
     #[test]

--- a/scripts/scaffold-tool.sh
+++ b/scripts/scaffold-tool.sh
@@ -337,4 +337,8 @@ label  = "File"
 EOF
 fi
 
+# The quoted ('EOF') heredocs above can't expand $slug, so their templates use a
+# literal __SLUG__ token — substitute it everywhere in one pass here.
+grep -rl '__SLUG__' "$dir" | while read -r f; do sed -i "s/__SLUG__/${slug}/g" "$f"; done
+
 echo "scaffolded blocks/$slug ($type). Next: implement core/src/lib.rs, src/lib.rs (skill schema), web/src/lib.rs, page/meta.toml, page/content.md."


### PR DESCRIPTION
## What

The follow-ups from the first fully isolated /new-tool builder run (#156's skill-fidelity report):

- **CLI human output**: `{"result": "<string>"}` now prints the raw text — previously `Value::to_string()` JSON-encoded it, so every multi-line text tool printed one escaped line (`"operation: …\nbinary   : …"`, quotes included). Verified live: asn1-parser and bitwise-calculator now render real lines. Two new render tests (raw multi-line string; non-string results still render as JSON).
- **scaffold-tool.sh**: the quoted (`'EOF'`) heredocs left a literal `__SLUG__` in core doc comments — one substitution pass at the end fixes all files (verified by scaffolding + grepping a scratch tool).
- **ops.md**: fresh-checkout/worktree gotchas — `npm install` not `npm ci` (`tests/package-lock.json` is deliberately gitignored, matching CI), `cargo install --path cli` from a fresh checkout embeds only the ~33 committed `block.wasm` fixtures (and globally overwrites `gizza`), and the generator's ~300 `web/pkg not found` warnings are expected without a baseline build.
- **new-tool docs**: `toHaveText` whitespace-normalization gotcha for multi-line assertions; step 7 now states the sanctioned `solobase build` skip inline.

## Tested
- `cargo test` in `cli/`: 13/13 incl. the two new render tests
- Scaffolded a scratch tool → zero `__SLUG__` occurrences → removed
- Reinstalled the CLI from the full checkout: 387 tools embedded, `url-encode` restored, `bitwise-calculator a=87 op=and b=101 bits=8` prints its 6-line result as real lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)