### PR TITLE
test-infra: no-store static server for the Playwright webServer

### DIFF
--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -16,7 +16,10 @@ export default defineConfig({
     // The pkg/ bundle is browser-WASM + SW-based.
   },
   webServer: {
-    command: 'python3 -m http.server --directory ../pkg 8001',
+    // serve_pkg.py sends Cache-Control: no-store — the persistent chromium
+    // profile otherwise disk-caches unhashed tool.js/tool-audio.js and tests
+    // run stale JS after a page regen.
+    command: 'python3 serve_pkg.py ../pkg 8001',
     port: 8001,
     timeout: 60_000,
     reuseExistingServer: true,

--- a/tests/serve_pkg.py
+++ b/tests/serve_pkg.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Static file server for tests that disables browser caching.
+
+`python3 -m http.server` sends no Cache-Control header, so the persistent
+chromium profile (tests/fixtures.ts) disk-caches unhashed assets like
+tool.js/tool-audio.js across runs — regenerated pages then execute stale
+JS. This wrapper serves the same directory with `Cache-Control: no-store`
+so every request hits the current build.
+
+Usage: serve_pkg.py <directory> <port>
+"""
+
+import contextlib
+import socket
+import sys
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+
+
+class NoStoreHandler(SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header("Cache-Control", "no-store")
+        super().end_headers()
+
+
+class DualStackServer(ThreadingHTTPServer):
+    # Same dual-stack bind as `python3 -m http.server`, so localhost works
+    # whether it resolves to 127.0.0.1 or ::1.
+    address_family = socket.AF_INET6
+
+    def server_bind(self):
+        with contextlib.suppress(OSError):
+            self.socket.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+        return super().server_bind()
+
+
+def main() -> None:
+    directory, port = sys.argv[1], int(sys.argv[2])
+    handler = partial(NoStoreHandler, directory=directory)
+    DualStackServer(("::", port), handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
One item from the audio-tools deferred backlog (PR #161 body): the Playwright persistent chromium profile disk-caches the unhashed `tool.js`/`tool-audio.js` because `python3 -m http.server` sends no `Cache-Control` header — after regenerating pages, tests silently run stale JS (false green/red signals during dev).

## Change

- `tests/serve_pkg.py` — 20-line stdlib wrapper around `SimpleHTTPRequestHandler` that adds `Cache-Control: no-store` to every response. Same MIME map and dual-stack bind as `python3 -m http.server`, so behavior is otherwise identical.
- `tests/playwright.config.ts` — webServer command switched to it.

## Verified

- `no-store` present on 200s and 404s; `application/wasm` / `text/html` / JS MIME types unchanged; served over both 127.0.0.1 and ::1.
- `tool-page-trim-audio.spec.ts` green through the new webServer; the request log shows `tool.js`/`tool-audio.js` re-fetched on every page load instead of served from disk cache.

## Migration note

A profile that already holds entries cached under the old server can serve them heuristically once more (the stored responses predate the header). One final manual clear is needed per existing profile: `rm -rf tests/.cache/chromium-profile/Default/{Cache,"Code Cache"}`. Anything fetched through the new server is never disk-cached again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)