### PR TITLE
fix(tool.js): run-sequence guard for overlapping ffmpeg runs + FIFO ffmpegExec

### DIFF
--- a/js/ffmpeg.js
+++ b/js/ffmpeg.js
@@ -89,12 +89,25 @@ function uint8ToB64(arr) {
 /**
  * Run ffmpeg with the given CLI args.
  *
+ * Calls are serialized FIFO: they share one FFmpeg instance and its virtual
+ * FS, and tools reuse fixed in/out filenames — interleaved
+ * writeFile/exec/readFile from overlapping calls would cross-wire inputs and
+ * outputs (e.g. an earlier call reading back a later call's output).
+ *
  * @param {string} argsJson    JSON-encoded array of strings, e.g. '["-i","in","out"]'
  * @param {string} inputsJson  JSON-encoded array of {name, bytes_b64}
  * @param {string} outputName  Filename to read back from ffmpeg's virtual FS
  * @returns {Promise<{exit_code:number, output_b64:string, log:string}>}
  */
-export async function ffmpegExec(argsJson, inputsJson, outputName) {
+let execChain = Promise.resolve();
+
+export function ffmpegExec(argsJson, inputsJson, outputName) {
+    const run = execChain.then(() => execOnce(argsJson, inputsJson, outputName));
+    execChain = run.then(() => {}, () => {});
+    return run;
+}
+
+async function execOnce(argsJson, inputsJson, outputName) {
     const args = JSON.parse(argsJson);
     const inputs = JSON.parse(inputsJson);
     const ffmpeg = await ensureFfmpeg();

--- a/site/tool.js
+++ b/site/tool.js
@@ -416,7 +416,15 @@ async function main() {
       }
     }
 
+    // Overlapping runs race: ffmpeg run times vary, so a stale slow run can
+    // resolve after a newer one and overwrite its media.src and output
+    // waveform — or repaint output that Reset just cleared. Every run() call
+    // takes a ticket (including the no-file early return, so Reset's rerun
+    // invalidates an in-flight run); only the newest ticket may touch the DOM.
+    let runSeq = 0;
+
     async function run() {
+      const seq = ++runSeq;
       const file = fileInput && fileInput.files && fileInput.files[0];
       if (!file) return;
       out.textContent = "Processing…";
@@ -433,6 +441,7 @@ async function main() {
         return v !== "" && !isNaN(Number(v)) ? Number(v) : v;
       });
       const r = await runFfmpeg(cfg, mod, ffmpegExec, file, fieldArgs);
+      if (seq !== runSeq) return; // superseded while ffmpeg ran — drop the result
       if (r.ok) {
         out.textContent = "";
         media.src = r.dataUrl;
@@ -446,9 +455,9 @@ async function main() {
         if (outputWf && String(r.dataUrl).startsWith("data:audio/")) {
           try {
             const blob = await (await fetch(r.dataUrl)).blob();
-            await outputWf.load(blob);
+            if (seq === runSeq) await outputWf.load(blob);
           } catch (e) {
-            outputWf.clear(); // fallback: native player alone, as today
+            if (seq === runSeq) outputWf.clear(); // fallback: native player alone, as today
           }
         }
       } else {

--- a/tests/tool-page-run-sequence.spec.ts
+++ b/tests/tool-page-run-sequence.spec.ts
@@ -1,0 +1,91 @@
+// Run-sequence guard (site/tool.js run()): overlapping ffmpeg runs must not
+// let a stale slow run overwrite a newer result (or repaint after Reset).
+// Driven on trim-audio, but the behavior under test is generic tool.js.
+//
+// ffmpeg.js is stubbed via route interception, so completion order is
+// controlled causally (the stale run only resolves after the newer run's
+// result has been consumed) — no real ffmpeg, no CDN, no timing guesses.
+import { test, expect } from './fixtures';
+import path from 'node:path';
+
+const FIXTURE = path.resolve(__dirname, 'fixtures/tone-3s.mp3');
+
+// Base64 payloads distinguish which run's output landed in media.src.
+const STALE_B64 = 'U1RBTEU='; // "STALE"
+const FRESH_B64 = 'RlJFU0g='; // "FRESH"
+
+// Stub for the stale-slow-run test. Runs with end=1.5 in their argv are the
+// "stale" run and block until a "fresh" run (end=2) has completed AND the
+// page has had a macrotask to consume its result; then the stale run
+// resolves and, unguarded, would overwrite the fresh output.
+const STALE_RUN_STUB = `
+let release;
+const released = new Promise((r) => { release = r; });
+window.__staleResolved = false;
+export async function ffmpegExec(argsJson, inputsJson, outputName) {
+  if (argsJson.includes('1.5')) {
+    await released;
+    window.__staleResolved = true;
+    return { exit_code: 0, output_b64: '${STALE_B64}', log: '' };
+  }
+  setTimeout(release, 0); // let the fresh result's microtask chain flush first
+  return { exit_code: 0, output_b64: '${FRESH_B64}', log: '' };
+}
+`;
+
+// Stub for the Reset test: every call blocks until the test releases it.
+const GATED_STUB = `
+window.__gateResolved = false;
+const gate = new Promise((r) => { window.__releaseFfmpeg = () => { r(); }; });
+export async function ffmpegExec(argsJson, inputsJson, outputName) {
+  await gate;
+  window.__gateResolved = true;
+  return { exit_code: 0, output_b64: '${STALE_B64}', log: '' };
+}
+`;
+
+test('a stale slow run must not overwrite a newer result', async ({ page }) => {
+  await page.route('**/tools/trim-audio/ffmpeg.js', (route) =>
+    route.fulfill({ contentType: 'text/javascript', body: STALE_RUN_STUB })
+  );
+  await page.goto('/tools/trim-audio/');
+  await page.waitForSelector('#in-audio');
+  await page.fill('#in-start', '0.5');
+  await page.fill('#in-end', '1.5');
+  await page.setInputFiles('#in-audio', FIXTURE); // run 1 (stale, gated)
+  await page.fill('#in-end', '2'); // run 2 (fresh, completes first)
+
+  const media = page.locator('#tool-output-media');
+  await expect(media).toHaveAttribute('src', `data:audio/mpeg;base64,${FRESH_B64}`, {
+    timeout: 15_000,
+  });
+  // Let the stale run resolve and (if unguarded) do its damage.
+  await page.waitForFunction(() => (window as any).__staleResolved === true);
+  await page.waitForTimeout(300);
+  await expect(media).toHaveAttribute('src', `data:audio/mpeg;base64,${FRESH_B64}`);
+  const dl = page.locator('#tool-output-download');
+  await expect(dl).toHaveAttribute('href', `data:audio/mpeg;base64,${FRESH_B64}`);
+});
+
+test('a run resolving after Reset must not repaint the cleared output', async ({ page }) => {
+  await page.route('**/tools/trim-audio/ffmpeg.js', (route) =>
+    route.fulfill({ contentType: 'text/javascript', body: GATED_STUB })
+  );
+  await page.goto('/tools/trim-audio/');
+  await page.waitForSelector('#in-audio');
+  await page.fill('#in-start', '0.5');
+  await page.fill('#in-end', '1.5');
+  await page.setInputFiles('#in-audio', FIXTURE); // run in flight, gated
+  const out = page.locator('#tool-output');
+  await expect(out).toHaveText('Processing…');
+
+  await page.click('#tool-reset'); // clears file + output while run in flight
+  await page.evaluate(() => (window as any).__releaseFfmpeg());
+  await page.waitForFunction(() => (window as any).__gateResolved === true);
+  await page.waitForTimeout(300);
+
+  const media = page.locator('#tool-output-media');
+  await expect(media).toBeHidden();
+  await expect(page.locator('#tool-output-download')).toBeHidden();
+  await expect(out).toHaveText('');
+});


### PR DESCRIPTION
Deferred item from the audio-tools backlog (PR #161 body): overlapping ffmpeg runs raced last-write-wins — drag commits on the waveform make rapid re-runs likely.

## The race, two layers

**Display (site/tool.js `run()`)**: a stale slow run resolving after a newer one overwrote the newer result's `media.src`, download link, and output waveform. Worse, a run resolving after **Reset** repainted the output Reset had just cleared. Fixed with a generation ticket: every `run()` call bumps `runSeq` (including the no-file early return, so Reset's rerun invalidates in-flight runs); completions holding a stale ticket return without touching the DOM — including the async output-waveform tail after the media swap.

**Virtual FS (js/ffmpeg.js `ffmpegExec()`)**: overlapping calls share one FFmpeg instance and virtual FS while tools reuse fixed in/out filenames (`in.mp3`, `out.wav`), so interleaved `writeFile`/`exec`/`readFile` could cross-wire runs — an earlier call reading back a later call's output. Calls are now serialized FIFO via a promise chain; the exported signature and result shape are unchanged (also used by the chat bridge path).

## Test

`tests/tool-page-run-sequence.spec.ts` reproduces both bugs deterministically (red before the fix, green after) by stubbing `ffmpeg.js` with route interception — the stale run's completion is *causally* gated on the fresh result (or Reset) having landed first, so there are no timing guesses and no CDN/ffmpeg dependency.

## Verified

- New spec: 2/2 green (was 2/2 red pre-fix, failing with the stale payload visible in `media.src`).
- Regressions: trim-audio, audio-fade, audio-loop, audio-normalize, audio-silence-remove, video-mute, widget-chrome — 17 passed.
- Pages regenerated via `tools/generator`; `site/tool.js` and `js/ffmpeg.js` copies verified byte-identical in `pkg/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)