### PR TITLE
fix(tests): unroute stubbed ffmpeg.js after each run-sequence test

### DIFF
--- a/tests/tool-page-run-sequence.spec.ts
+++ b/tests/tool-page-run-sequence.spec.ts
@@ -10,6 +10,16 @@ import path from 'node:path';
 
 const FIXTURE = path.resolve(__dirname, 'fixtures/tone-3s.mp3');
 
+// The fixture page is shared across every test in the worker (fixtures.ts
+// reuses one persistent-context page), and page.route registrations OUTLIVE
+// the test that added them. Without this cleanup, alphabetically-later specs
+// (e.g. tool-page-trim-audio) load the gated stub instead of the real
+// ffmpeg.js — whose release gate belongs to a dead document — and hang at
+// "Processing…" until their 90 s expect timeout.
+test.afterEach(async ({ page }) => {
+  await page.unrouteAll({ behavior: 'ignoreErrors' });
+});
+
 // Base64 payloads distinguish which run's output landed in media.src.
 const STALE_B64 = 'U1RBTEU='; // "STALE"
 const FRESH_B64 = 'RlJFU0g='; // "FRESH"


### PR DESCRIPTION
Follow-up to #165, caught by the post-merge combined run of all seven audio suites: `page.route` registrations outlive the test on the shared persistent-context page (`fixtures.ts` reuses one page per worker), so alphabetically-later specs loaded the run-sequence spec's **gated ffmpeg stub** instead of the real `ffmpeg.js`. The stub's release gate belongs to the dead document that registered it, so `tool-page-trim-audio`'s first test hung at 'Processing…' for its full 90 s expect timeout.

Fix: `test.afterEach → page.unrouteAll({ behavior: 'ignoreErrors' })` in the run-sequence spec.

Verified: the exact failing pair (run-sequence → trim-audio, one worker) passes, and the full combined suite (run-sequence, waveform, trim-audio, audio-convert, audio-fade, video-mute, widget-chrome) is 21/21 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)