### PR TITLE
improve-tool: audio-pitch-shift — slider control, preset chips, transposition copy

### DIFF
--- a/blocks/audio-pitch-shift/page/content.md
+++ b/blocks/audio-pitch-shift/page/content.md
@@ -4,8 +4,10 @@ Pick an audio file and how many semitones to move it: positive values raise
 the pitch, negative values lower it, and the speed stays exactly the same. Use
 it to transpose a backing track into a singable key, deepen a voice recording,
 or make the classic chipmunk / slowed-and-deep effects without touching the
-tempo. The shift runs entirely in your browser with ffmpeg compiled to
-WebAssembly, so your audio is never uploaded to a server.
+tempo. Drag the slider for whole semitones, type a decimal for cent-level
+fine-tuning, or hit one of the preset chips. The shift runs entirely in your
+browser with ffmpeg compiled to WebAssembly, so your audio is never uploaded
+to a server.
 
 ### Worked example
 
@@ -16,17 +18,32 @@ the new key at the original tempo and downloads as the original name with a
 
 - `12` — one octave up (a 440 Hz A becomes an 880 Hz A).
 - `-12` — one octave down.
-- `-3` — lower a song three semitones into a more comfortable vocal range.
-- `0.5` — a quarter-tone nudge (50 cents) for tuning mismatches, e.g. matching
-  an A=432 Hz recording to A=440 Hz is about `0.32` semitones.
+- `-3` — lower a song three semitones into a more comfortable vocal range
+  (a common karaoke trick when the original is too high).
+- `1` — raise a recording made in E♭ tuning back to standard pitch, so you
+  can play along without retuning your guitar. `-1` does the reverse.
+- `0.5` — a quarter-tone nudge (50 cents) for tuning mismatches; one cent is
+  `0.01`, so tuning an A=432 Hz recording up to A=440 Hz is about `0.32`
+  semitones (and `-0.32` converts 440 Hz music down to 432 Hz).
+
+### Semitone cheat sheet
+
+Count piano keys, black keys included — each key is one semitone. Moving from
+C to D is `2`, C to E is `4`, down a perfect fourth is `-5`, and any octave is
+`12`. So a song in G that you want in E goes down `-3`; a song in C that you
+want in D goes up `2`. Producers use the same counting to layer harmonies: a
+copy of a vocal shifted `3`, `4`, `5`, or `7` semitones lands on the classic
+harmony intervals.
 
 ### How it works
 
 The tool uses the classic resample method, fully offline: the audio is
 resampled to a new rate (which shifts pitch and speed together, like changing
 tape speed), then time-stretched back to the original duration with ffmpeg's
-`atempo` filter. Pitch accuracy is within a fraction of a cent, and the output
-duration matches the input.
+`atempo` filter. Each semitone is a frequency change of about 5.95% (the
+twelfth root of 2), and fractional shifts are computed with the same formula.
+Pitch accuracy is within a fraction of a cent, and the output duration
+matches the input.
 
 ### Formats
 
@@ -64,12 +81,32 @@ with the pitch preserved), use the change-speed tool instead.
 </details>
 
 <details>
+<summary>Is a pitch changer the same as a pitch shifter?</summary>
+
+Yes — "pitch changer", "pitch shifter", "key changer", and "transpose tool"
+all describe the same operation: moving every note in a recording up or down
+by a fixed interval while keeping the speed unchanged. This page does exactly
+that, measured in semitones.
+
+</details>
+
+<details>
 <summary>How many semitones do I need to change key?</summary>
 
 Count the steps between the keys: each semitone is one step on a piano
 (including black keys). C to D is `2`, C to E is `4`, down a fourth is `-5`.
 An octave is `12`. Fractional values work too — `0.5` is a quarter tone, and
 one cent is `0.01`, so you can fix small tuning offsets precisely.
+
+</details>
+
+<details>
+<summary>Can I play along with a song recorded in E♭ (half-step-down) tuning?</summary>
+
+Yes — shift the recording up `1` semitone and it lands in standard tuning, so
+you can play along without retuning your instrument. The reverse works too:
+shift a standard-tuning song down `-1` to match a guitar already tuned to
+E♭, or down `-2` for D (whole-step-down) tunings.
 
 </details>
 

--- a/blocks/audio-pitch-shift/page/meta.toml
+++ b/blocks/audio-pitch-shift/page/meta.toml
@@ -1,7 +1,7 @@
 slug          = "audio-pitch-shift"
 title         = "Change Audio Pitch Online — gizza.ai"
-description   = "Shift the pitch of any audio file up or down by semitones without changing its speed — transpose songs or voices free, right in your browser."
-tags          = ["audio", "pitch", "semitones", "transpose", "key", "shift", "voice", "chipmunk"]
+description   = "Free online pitch changer — shift any audio up or down by semitones without changing its speed. Transpose songs, fix tuning, deepen voices in your browser."
+tags          = ["audio", "pitch", "semitones", "transpose", "key", "shift", "changer", "voice", "chipmunk", "432 hz", "karaoke", "cents"]
 h1            = "Change Audio Pitch"
 hero_subtitle = "Pick an audio file and a semitone shift — the key changes, the speed doesn't, and nothing leaves your browser."
 wasm          = "gizza_ai_audio_pitch_shift_web"
@@ -21,8 +21,30 @@ name        = "semitones"
 source      = "field"
 label       = "Semitones (-24 to 24)"
 placeholder = "3"
+kind        = "slider"
+step        = "1"
 
 [[input]]
 name   = "format"
 source = "field"
 label  = "Format"
+
+[[example]]
+label  = "Octave up (+12)"
+params = { semitones = "12" }
+
+[[example]]
+label  = "Octave down (−12)"
+params = { semitones = "-12" }
+
+[[example]]
+label  = "Half step up (+1)"
+params = { semitones = "1" }
+
+[[example]]
+label  = "Half step down (−1)"
+params = { semitones = "-1" }
+
+[[example]]
+label  = "440 → 432 Hz (−0.32)"
+params = { semitones = "-0.32" }

--- a/docs/checks/2026-07-03-improve-audio-pitch-shift-competitor-analysis.md
+++ b/docs/checks/2026-07-03-improve-audio-pitch-shift-competitor-analysis.md
@@ -1,5 +1,110 @@
 # audio-pitch-shift — competitor analysis (2026-07-03)
 
+Two passes, same day:
+
+1. **Build-time scan** (kept below) — one WebSearch, 3-6 tools skimmed, table-stakes
+   decisions for the initial build.
+2. **Improve-pass deep dive** (this section) — top 5 real competitor tools, one
+   read-only researcher each, full params/defaults/formats/UX/SEO profiles.
+   All paraphrased; no competitor copy, branding, or assets reused.
+
+## Improve pass — the 5 profiles (paraphrased)
+
+### 1. SoundTools pitch shifter (soundtools.io/pitch-shifter)
+- **Params:** semitone slider, −12…+12 (whole steps); preset buttons ±1 semitone +
+  a "custom" mode. No cents control, no tempo toggle (a separate speed tool exists).
+- **Formats:** in mp3/wav/flac/aac/ogg; out = same container as input, no picker,
+  no bitrate options.
+- **UX:** live re-adjustable preview while playing, spacebar shortcut, plain
+  file-picker (no drag-drop), no waveform, no reset.
+- **SEO:** targets both "pitch shifter" and "pitch changer"; music-theory education
+  (semitone = adjacent piano keys); worked key transpositions (C major +2 → D major,
+  G major −3 → E major); karaoke (−2…−3 for vocal range), guitar drop-tuning
+  emulation, harmony layering (±3/4/5/7); FAQ on why big shifts sound robotic.
+- **Notes:** processing location ambiguous ("in your browser" copy, no
+  files-never-leave claim); no stated size limits.
+
+### 2. Audioalter pitch shifter (audioalter.com/pitch-shifter)
+- **Params:** single slider −24…+24 semitones (widest range seen); fractional values
+  accepted by the backend (their 440→432 Hz preset is −0.3177 st); no number box.
+- **Formats:** in mp3/wav/flac/ogg; no output format/quality options documented.
+- **UX:** drag-drop upload, submit-then-wait job, before/after audio samples embedded
+  as worked examples; no preview of the user's own file, no waveform, no reset, no FAQ.
+- **SEO:** "12 semitones = 1 octave" framing; a dedicated 432 Hz-converter landing
+  page as a preset variant; numbered how-to steps.
+- **Notes:** server-side (upload + 50 MB cap) — our browser-local story is a
+  differentiator.
+
+### 3. vocalremover.org pitcher (vocalremover.org/pitch)
+- **Params:** pitch slider −6.00…+6.00 st at 0.01-st (1-cent) resolution, with a
+  "snap to semitones" toggle (off by default); independent speed slider 0.5×–1.5×.
+- **Formats:** in ~any audio; out mp3 (default) or wav; no bitrate options.
+- **UX:** auto-detects key/scale/BPM on load; live target-key readout as the slider
+  moves; waveform player with seek/loop/level meters; whole-page drag-drop; output
+  auto-named with resulting key + bpm; confirm dialog before discarding a track;
+  no reset button, no FAQ, minimal page copy.
+- **SEO:** transpose-music language, key/BPM detection headline, serverless/privacy
+  claim ("files never leave your device").
+- **Notes:** genuinely browser-local; narrow ±6 range; behind Cloudflare (researched
+  by driving the app in a browser).
+
+### 4. pitchchanger.io (pitchchanger.io/audio-pitch-changer)
+- **Params:** pitch slider −12…+12 st, step 1, signed live readout; speed slider
+  0.5×–1.5× step 0.05; process button disabled at neutral settings with a hint.
+- **Formats:** in mp3/wav/flac/m4a/aac (250 MB cap shown inline); out WAV (framed
+  as the high-quality choice) or MP3; no bitrate knobs.
+- **UX:** drag-drop zone with format badges; waveform strip with click-to-seek;
+  file-info cards (duration original vs current, BPM during playback, key detection
+  "coming soon"); progress % + success banner; "upload different file" instead of
+  reset; separate long-form SEO article page cross-linking the tool; ~24 locales.
+- **SEO:** stacks "pitch changer / song key changer / transpose music online";
+  worked examples (+2 = C→D, −3 = C→A, +12 = octave); quality guidance (stay within
+  ~6 st overall, ~4 for vocals); phase-vocoder/granular explainer; a
+  history-of-pitch-shifting timeline as authority content; persona list (singers,
+  karaoke, theater auditions, guitarists avoiding capos, Bb/Eb horn players, ear
+  training, DJ harmonic mixing, teachers, transcribers).
+- **Notes:** ffmpeg-wasm + SoundTouch, genuinely local (verified via network log);
+  marketing says phase vocoder while telemetry says SoundTouch (WSOLA).
+
+### 5. OnlineToneGenerator pitch shifter (onlinetonegenerator.com/pitch-shifter.html)
+- **Params:** slider + paired number box (semitones); "maintain tempo" checkbox
+  (default on — off couples pitch to speed); "save output" checkbox that records
+  playback to an mp3.
+- **Formats:** in mp3/wav only; out mp3 (real-time capture — must play the whole
+  file to record it).
+- **UX:** live playback preview; percent-of-original readout; recordings list;
+  no waveform, no presets, no drag-drop, no reset.
+- **SEO:** singer backing-track transposition; guitarist angle (shift a half-step-
+  down recording up 1 st to play along in standard tuning); "one semitone ≈ 5.946%
+  frequency change" educational hook.
+- **Notes:** Web Audio, fully local; the record-in-real-time download path is weak —
+  our offline ffmpeg render is strictly better.
+
+## Gap list (ours vs the 5) and decisions
+
+| # | Gap (≥1 competitor has it) | Dimension | Fit | Decision |
+|---|---|---|---|---|
+| 1 | Slider control for the shift (all 5 use one) | UX | in-model | **Built** — declarative `kind = "slider"` in the shared generator (range + number pair, one run per drag-release); no slug branches |
+| 2 | One-click presets (SoundTools ±1; Audioalter 432 Hz page) | UX | in-model | **Built** — 5 `[[example]]` chips: ±12, ±1, 440→432 Hz (−0.32) |
+| 3 | Fractional input without browser step-mismatch nags | UX | in-model | **Built** — number-typed params now render `step="any"` (platform-wide) |
+| 4 | Copy-paste-runnable CLI example (our page card omitted required `semitones`) | copy | in-model | **Built** — page + markdown CLI examples now include schema-derived samples for every field (platform-wide) |
+| 5 | Key-transposition worked examples, karaoke/guitar/harmony personas (SoundTools, pitchchanger, OTG) | copy/SEO | in-model | **Built** — semitone cheat-sheet section, E♭-tuning FAQ + example, harmony intervals, "pitch changer" synonym FAQ, ~5.95%/semitone fact |
+| 6 | "Pitch changer" keyword targeting (SoundTools, pitchchanger) | copy/SEO | in-model | **Built** — meta description/tags + FAQ equivalence entry |
+| 7 | Live preview while dragging (SoundTools, vocalremover, OTG, pitchchanger) | capability | out-of-model | page framework is run-per-change (no live audio graph); slider commits one run per release |
+| 8 | Key/scale/BPM detection + target-key readout (vocalremover; pitchchanger "soon") | capability | out-of-model | needs audio analysis outside the argv-builder model; FAQ teaches counting semitones |
+| 9 | Formant-preserving voice mode (pro shifters) | capability | out-of-model | no librubberband in either ffmpeg build; FAQ states the ±4 st natural range honestly |
+| 10 | Combined speed+pitch controls on one page (vocalremover, pitchchanger, OTG toggle) | capability | out-of-model here | deliberate split — change-speed owns tempo; page copy cross-links |
+| 11 | Bigger input caps (50–250 MB server tools) | capability | out-of-model here | 10 MiB is the family-wide envelope cap; revisit family-wide, not per-tool |
+| 12 | Output auto-named with detected key/bpm (vocalremover) | UX | out-of-model | depends on gap 8; family keeps the deterministic `-pitch-shifted.<ext>` suffix |
+
+Engine capabilities (range ±24, 1-cent precision, tempo-exact chain, 5 output
+formats, any-decodable input) were already at or ahead of best-in-class — no
+core/descriptor change; the chat schema is unchanged in this pass.
+
+---
+
+# Build-time scan (original, kept for the record)
+
 One WebSearch ("online pitch shifter change audio pitch semitones without changing tempo
 tool"); skimmed the top real tools: Audioalter pitch-shifter, SoundTools pitch-shifter,
 vocalremover.org pitch, Tembrica pitch, AudioSpeedChanger, x-minus.pro transpose.
@@ -40,3 +145,13 @@ vocalremover.org pitch, Tembrica pitch, AudioSpeedChanger, x-minus.pro transpose
 - Playwright on the 440 Hz sine fixture: +12 → measured ~880 Hz still ~3 s; deep link
   `?semitones=-12&format=wav` → ~220 Hz still ~3 s; bare upload → guiding no-op error.
   Bounds pre-measured with local ffmpeg (880.0 / 220.0 Hz on the same chain).
+
+## Improve-pass verification (2026-07-03, all run, all green)
+
+- Phase 1 baseline: 14 unit tests (incl. drift guard) green; CLI +12/0/30 against the
+  public beep (duration 1.254 s preserved; both guiding errors exact); Playwright 3/3.
+- Post-improve: generator 43 unit tests (slider/step-any/CLI-example cases added);
+  Playwright 5/5 incl. new slider-commit (+12 → ~880 Hz) and preset-chip-after-error
+  (−12 → ~220 Hz) cases; sibling regression suites (trim-audio, audio-eq, calculator,
+  age-calculator) 9/9; per-slug hygiene gate exit 0; `wafer build` OK (548.5 KiB);
+  CLI smoke of the page's copy-paste example verbatim.

--- a/site/tool.css
+++ b/site/tool.css
@@ -31,6 +31,11 @@ body { margin: 0; font-family: system-ui, -apple-system, "Segoe UI", Roboto, san
   background-repeat: no-repeat; background-position: right 12px center; }
 .tool-checkbox { width: 18px; height: 18px; margin: 6px 0 14px; accent-color: var(--tool-accent);
   vertical-align: middle; cursor: pointer; display: block; }
+/* kind="slider": range + number pair (the number box keeps the canonical id). */
+.tool-slider-row { display: flex; align-items: center; gap: 12px; }
+.tool-slider-row .tool-input { width: 92px; flex: 0 0 auto; }
+.tool-slider { flex: 1 1 auto; min-width: 0; margin: 6px 0 12px;
+  accent-color: var(--tool-accent); cursor: pointer; }
 /* pre-wrap: multi-line text results (bitwise-calculator, asn1-parser, …) render
    as real lines instead of collapsing into one wrapped paragraph; single-line
    results are unaffected. */

--- a/site/tool.js
+++ b/site/tool.js
@@ -12,9 +12,9 @@ const out = document.getElementById(cfg.output.elementId);
 //   setup(ctx)                → one-time setup; return true to TAKE OVER wiring
 //   renderResult(value, ctx)  → return true if the result was rendered
 //   renderError(message, ctx) → return true if the error was rendered
-// Prefer the declarative meta.toml controls (kind/options/default/[[example]]/
-// wide); custom.js is only for layouts/renderers those can't express. Do NOT
-// add per-tool slug branches to this file.
+// Prefer the declarative meta.toml controls (kind incl. slider/options/default/
+// [[example]]/wide); custom.js is only for layouts/renderers those can't
+// express. Do NOT add per-tool slug branches to this file.
 let custom = {};
 let customCtx = null;
 
@@ -120,6 +120,7 @@ function wireWidgetChrome(rerun) {
         if (inp) applyField(document.getElementById(inp.elementId), value);
       }
       refreshTagLists();
+      refreshSliders();
       rerun();
     });
   }
@@ -147,6 +148,7 @@ function wireWidgetChrome(rerun) {
       }
       applyMetaDefaults(true);
       refreshTagLists();
+      refreshSliders();
       const media = document.getElementById("tool-output-media");
       const dl = document.getElementById("tool-output-download");
       if (media) media.hidden = true;
@@ -179,6 +181,52 @@ function wireWidgetChrome(rerun) {
       }
     });
   }
+}
+
+// ---- Generic slider mirror (meta kind="slider") ----
+// A range input (id "in-<name>-slider", data-for="in-<name>") mirrors the
+// canonical number box two-way. Dragging updates the number live WITHOUT
+// firing events; releasing dispatches ONE change on the number input — one
+// run per drag, the same commit discipline as the waveform selection. Pure
+// (non-ffmpeg) tools also recompute live during the drag, which is cheap.
+
+// Where the thumb rests when its number box is empty: the rendered value
+// attribute (the schema default) or the numeric midpoint (the range
+// element's own no-value default).
+function sliderRestValue(slider) {
+  if (slider.defaultValue !== "") return slider.defaultValue;
+  const min = Number(slider.min);
+  const max = Number(slider.max);
+  return String(min + (max - min) / 2);
+}
+
+// Re-sync every slider from its number box (after programmatic value writes:
+// meta defaults, example chips, reset, deep-links).
+function refreshSliders() {
+  for (const s of document.querySelectorAll(".tool-slider")) {
+    const el = document.getElementById(s.dataset.for);
+    if (!el) continue;
+    s.value = el.value !== "" ? el.value : sliderRestValue(s);
+  }
+}
+
+function wireSliders() {
+  for (const s of document.querySelectorAll(".tool-slider")) {
+    const el = document.getElementById(s.dataset.for);
+    if (!el) continue;
+    s.addEventListener("input", () => {
+      el.value = s.value; // live mirror — programmatic writes fire no events
+      if (cfg.runtime !== "ffmpeg") el.dispatchEvent(new Event("input"));
+    });
+    s.addEventListener("change", () => {
+      el.value = s.value;
+      el.dispatchEvent(new Event("change")); // exactly one run per drag-release
+    });
+    el.addEventListener("input", () => {
+      if (el.value !== "") s.value = el.value;
+    });
+  }
+  refreshSliders();
 }
 
 // ---- Generic tag-list widget (meta kind="tag-list") ----
@@ -473,6 +521,7 @@ async function main() {
     }
     applyMetaDefaults();
     wireTagLists();
+    wireSliders();
     wireWidgetChrome(run);
     if (custom.setup && custom.setup({ ...customCtx, run, fileInput, fieldInputs }) === true) {
       return; // custom module owns all wiring for this tool
@@ -542,6 +591,7 @@ async function main() {
   }
   applyMetaDefaults();
   wireTagLists();
+  wireSliders();
   wireWidgetChrome(compute);
   if (custom.setup && custom.setup({ ...customCtx, compute }) === true) {
     return; // custom module owns all wiring for this tool

--- a/tests/tool-page-audio-pitch-shift.spec.ts
+++ b/tests/tool-page-audio-pitch-shift.spec.ts
@@ -58,6 +58,7 @@ test('audio-pitch-shift deep link prefills and shifts down an octave to ~220 Hz 
   await page.goto('/tools/audio-pitch-shift/?semitones=-12&format=wav');
   await page.waitForSelector('#in-audio');
   await expect(page.locator('#in-semitones')).toHaveValue('-12', { timeout: 15_000 });
+  await expect(page.locator('#in-semitones-slider')).toHaveValue('-12'); // slider mirrors the prefill
   await expect(page.locator('#in-format')).toHaveValue('wav');
   await page.setInputFiles('#in-audio', FIXTURE);
   const media = page.locator('#tool-output-media');
@@ -78,4 +79,46 @@ test('audio-pitch-shift bare upload gets the guiding no-op error', async ({ page
   const out = page.locator('#tool-output');
   await expect(out).toContainText('leaves the pitch unchanged', { timeout: 90_000 });
   await expect(out).toContainText('octave up');
+});
+
+test('audio-pitch-shift slider commit fills the number box and runs (+12 → ~880 Hz)', async ({ page }) => {
+  await page.goto('/tools/audio-pitch-shift/');
+  await page.waitForSelector('#in-semitones-slider');
+  // Slider rests at the midpoint (0) and drag-commits through the shared
+  // tool.js mirror: input mirrors the value silently, change runs once.
+  const slider = page.locator('#in-semitones-slider');
+  await expect(slider).toHaveValue('0');
+  await slider.evaluate((el) => {
+    const s = el as HTMLInputElement;
+    s.value = '12';
+    s.dispatchEvent(new Event('input', { bubbles: true }));
+    s.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+  await expect(page.locator('#in-semitones')).toHaveValue('12');
+  await page.setInputFiles('#in-audio', FIXTURE);
+  const media = page.locator('#tool-output-media');
+  await expect(media).toBeVisible({ timeout: 90_000 });
+  const { freq, duration } = await freqAndDuration(page, (await media.getAttribute('src'))!);
+  expect(freq).toBeGreaterThan(850); // pre-measured 880.0 Hz with local ffmpeg
+  expect(freq).toBeLessThan(910);
+  expect(duration).toBeGreaterThan(2.7);
+  expect(duration).toBeLessThan(3.3);
+});
+
+test('audio-pitch-shift preset chip re-runs after an error (Octave down → ~220 Hz)', async ({ page }) => {
+  await page.goto('/tools/audio-pitch-shift/');
+  await page.waitForSelector('#in-audio');
+  await page.setInputFiles('#in-audio', FIXTURE); // empty semitones → guiding error
+  const out = page.locator('#tool-output');
+  await expect(out).toContainText('leaves the pitch unchanged', { timeout: 90_000 });
+  await page.getByRole('button', { name: 'Octave down (−12)' }).click();
+  await expect(page.locator('#in-semitones')).toHaveValue('-12');
+  await expect(page.locator('#in-semitones-slider')).toHaveValue('-12'); // chip re-syncs the slider
+  const media = page.locator('#tool-output-media');
+  await expect(media).toBeVisible({ timeout: 90_000 });
+  const { freq, duration } = await freqAndDuration(page, (await media.getAttribute('src'))!);
+  expect(freq).toBeGreaterThan(205); // pre-measured 220.0 Hz with local ffmpeg
+  expect(freq).toBeLessThan(235);
+  expect(duration).toBeGreaterThan(2.7);
+  expect(duration).toBeLessThan(3.3);
 });

--- a/tools/generator/src/control.rs
+++ b/tools/generator/src/control.rs
@@ -34,6 +34,22 @@ pub enum Control {
         min: Option<f64>,
         max: Option<f64>,
         default: Option<f64>,
+        /// True for JSON-schema `number` (fractional) params → `step="any"`,
+        /// so decimals like 0.5 don't trip the browser's step-mismatch
+        /// validation. Integer params keep the default whole-number stepper.
+        step_any: bool,
+    },
+    /// A range slider paired with the regular number box (meta `kind =
+    /// "slider"`), for bounded numeric params where dragging beats typing.
+    /// The number input keeps the canonical `in-<name>` id (deep-links, CLI
+    /// parity, reset all unchanged); the slider mirrors it via `site/tool.js`.
+    Slider {
+        min: f64,
+        max: f64,
+        default: Option<f64>,
+        /// Slider drag granularity (meta `step`, default 1). The paired
+        /// number box always accepts finer values (`step="any"`).
+        step: String,
     },
     Select {
         options: Vec<String>,
@@ -68,6 +84,13 @@ impl ParamSchema {
         ParamSchema(HashMap::new())
     }
 
+    /// Build a schema from a JSON `properties` object — test-only constructor
+    /// for sibling modules (the real path goes through `load`).
+    #[cfg(test)]
+    pub(crate) fn from_props_for_tests(props: serde_json::Value) -> Self {
+        ParamSchema(props.as_object().unwrap().clone().into_iter().collect())
+    }
+
     /// Read `<tool_dir>/manifest.json` and extract `tool.parameters.properties`.
     /// A missing or unparseable manifest yields an empty schema (no panic, no
     /// abort) so a tool with a stale manifest just keeps plain text inputs.
@@ -97,6 +120,23 @@ impl ParamSchema {
             k @ ("date" | "time" | "datetime-local") => {
                 return Control::Picker { input_type: k.to_string() };
             }
+            "slider" => {
+                // A slider needs real bounds; only a numeric param with both
+                // min and max in the schema qualifies. Anything else falls back
+                // to the schema control (with a warning) rather than rendering
+                // an unbounded range input.
+                if let Control::Number { min: Some(min), max: Some(max), default, .. } =
+                    self.control_for(&input.name, false)
+                {
+                    let step = if input.step.is_empty() { "1".to_string() } else { input.step.clone() };
+                    return Control::Slider { min, max, default, step };
+                }
+                eprintln!(
+                    "warning: [[input]] \"{}\" kind=\"slider\" needs a numeric schema param with min+max — falling back to the schema control",
+                    input.name
+                );
+                return self.control_for(&input.name, input.multiline);
+            }
             "tag-list" => {
                 let options: Vec<String> = vocab::options(&input.options)
                     .map(|opts| opts.iter().map(|s| s.to_string()).collect())
@@ -111,7 +151,7 @@ impl ParamSchema {
             }
             other => {
                 eprintln!(
-                    "warning: [[input]] \"{}\" has unknown kind \"{other}\" (want date|time|datetime-local|tag-list) — falling back to the schema control",
+                    "warning: [[input]] \"{}\" has unknown kind \"{other}\" (want date|time|datetime-local|tag-list|slider) — falling back to the schema control",
                     input.name
                 );
             }
@@ -162,10 +202,11 @@ impl ParamSchema {
             Some("boolean") => Control::Checkbox {
                 default: p.get("default").and_then(|d| d.as_bool()).unwrap_or(false),
             },
-            Some("integer") | Some("number") => Control::Number {
+            Some(t @ ("integer" | "number")) => Control::Number {
                 min: p.get("minimum").and_then(|m| m.as_f64()),
                 max: p.get("maximum").and_then(|m| m.as_f64()),
                 default: p.get("default").and_then(|d| d.as_f64()),
+                step_any: t == "number",
             },
             _ => text_or_area(),
         }
@@ -215,8 +256,66 @@ mod tests {
                 min: Some(1.0),
                 max: Some(16.0),
                 default: Some(1.0),
+                step_any: false,
             }
         );
+    }
+
+    #[test]
+    fn fractional_number_param_gets_step_any() {
+        let s = schema(json!({
+            "semitones": { "type": "number", "minimum": -24, "maximum": 24 }
+        }));
+        assert_eq!(
+            s.control_for("semitones", false),
+            Control::Number {
+                min: Some(-24.0),
+                max: Some(24.0),
+                default: None,
+                step_any: true,
+            }
+        );
+    }
+
+    #[test]
+    fn slider_kind_pairs_range_with_number_when_bounded() {
+        let s = schema(json!({
+            "semitones": { "type": "number", "minimum": -24, "maximum": 24 }
+        }));
+        let mut f = field("semitones", "slider", "");
+        assert_eq!(
+            s.control_for_input(&f),
+            Control::Slider {
+                min: -24.0,
+                max: 24.0,
+                default: None,
+                step: "1".into(),
+            }
+        );
+        f.step = "0.5".into();
+        assert_eq!(
+            s.control_for_input(&f),
+            Control::Slider {
+                min: -24.0,
+                max: 24.0,
+                default: None,
+                step: "0.5".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn slider_kind_without_bounds_falls_back_to_schema_control() {
+        // No min/max in the schema → an unbounded range input would be
+        // meaningless; fall back to the plain number box.
+        let s = schema(json!({ "gain": { "type": "number" } }));
+        assert_eq!(
+            s.control_for_input(&field("gain", "slider", "")),
+            Control::Number { min: None, max: None, default: None, step_any: true }
+        );
+        // Non-numeric param → schema control (text).
+        let s = schema(json!({ "mode": { "type": "string" } }));
+        assert_eq!(s.control_for_input(&field("mode", "slider", "")), Control::Text);
     }
 
     #[test]
@@ -243,6 +342,7 @@ mod tests {
             multiline: false,
             kind: kind.into(),
             options: options.into(),
+            step: String::new(),
             default: String::new(),
         }
     }

--- a/tools/generator/src/markdown.rs
+++ b/tools/generator/src/markdown.rs
@@ -16,7 +16,7 @@ pub fn tool_markdown(meta: &ToolMeta, content_md: &str, schema: &ParamSchema) ->
     s.push_str(&format!("{}\n\n", meta.description));
 
     s.push_str("## Run it\n\n");
-    s.push_str(&format!("- **CLI:** `{}`\n", cli_example(meta)));
+    s.push_str(&format!("- **CLI:** `{}`\n", cli_example(meta, schema)));
     s.push_str(&format!("- **Web:** {}/tools/{}/\n\n", SITE, meta.slug));
 
     s.push_str("## Inputs\n\n");
@@ -66,15 +66,25 @@ pub fn tool_markdown(meta: &ToolMeta, content_md: &str, schema: &ParamSchema) ->
     s
 }
 
-/// The example CLI invocation: field tools use the first field input's
-/// placeholder as the example arg; file tools take a path; auto-only tools
-/// (e.g. clock) take no args.
-fn cli_example(meta: &ToolMeta) -> String {
-    if let Some(field) = meta.inputs.iter().find(|i| i.source == "field") {
+/// The example CLI invocation, copy-paste-runnable. File tools take
+/// `url=…` plus a `key=value` sample for EVERY field input (derived from the
+/// same schema samples as the deep-link example — a file tool's fields are
+/// often required, so an example without them would just error). Pure field
+/// tools use the first field's placeholder as the bare positional (mapped to
+/// the first required scalar); auto-only tools (e.g. clock) take no args.
+/// `pub(crate)` so `template.rs` renders the identical example on the page.
+pub(crate) fn cli_example(meta: &ToolMeta, schema: &ParamSchema) -> String {
+    if meta.inputs.iter().any(|i| i.source == "file") {
+        let mut args = vec!["'url=https://example.com/input'".to_string()];
+        for i in meta.inputs.iter().filter(|i| i.source == "field") {
+            if let Some(sample) = sample_value(&schema.control_for_input(i), &i.placeholder) {
+                args.push(format!("'{}={}'", i.name, sample));
+            }
+        }
+        format!("gizza tool {} {}", meta.slug, args.join(" "))
+    } else if let Some(field) = meta.inputs.iter().find(|i| i.source == "field") {
         let arg = if field.placeholder.is_empty() { "..." } else { field.placeholder.as_str() };
         format!("gizza tool {} \"{}\"", meta.slug, arg)
-    } else if meta.inputs.iter().any(|i| i.source == "file") {
-        format!("gizza tool {} <path>", meta.slug)
     } else {
         format!("gizza tool {}", meta.slug)
     }
@@ -125,6 +135,19 @@ fn sample_value(control: &Control, placeholder: &str) -> Option<String> {
                     .or_else(|| default.map(fmt_num))
                     .or_else(|| min.map(fmt_num))
                     .unwrap_or_else(|| "1".to_string()),
+            )
+        }
+        Control::Slider { default, min, .. } => {
+            // Same numeric-sample rules as Number; a slider always has bounds,
+            // so min is the last-resort sample.
+            let numeric_ph = ph.as_ref().filter(|p| p.parse::<f64>().is_ok()).cloned();
+            if ph.is_some() && numeric_ph.is_none() {
+                return None;
+            }
+            Some(
+                numeric_ph
+                    .or_else(|| default.map(fmt_num))
+                    .unwrap_or_else(|| fmt_num(*min)),
             )
         }
         Control::Picker { input_type } => Some(ph.unwrap_or_else(|| {
@@ -191,7 +214,7 @@ source      = "field"
         // A non-numeric placeholder on a number control (trim-audio's end
         // "to end") signals that EMPTY is meaningful — the example must omit
         // the param rather than teach a bogus value.
-        let num = Control::Number { min: Some(0.0), max: None, default: None };
+        let num = Control::Number { min: Some(0.0), max: None, default: None, step_any: false };
         assert_eq!(sample_value(&num, "to end"), None);
         assert_eq!(sample_value(&num, "15"), Some("15".to_string()));
         assert_eq!(sample_value(&num, ""), Some("0".to_string())); // min fallback
@@ -256,10 +279,57 @@ source = "clock"
     }
 
     #[test]
-    fn file_tool_uses_path_example_and_accept() {
+    fn file_tool_uses_url_example_and_accept() {
         let md = tool_markdown(&file_tool(), "prose", &crate::control::ParamSchema::empty());
-        assert!(md.contains("`gizza tool image-grayscale <path>`"), "path CLI example");
+        assert!(
+            md.contains("`gizza tool image-grayscale 'url=https://example.com/input'`"),
+            "url= CLI example"
+        );
         assert!(md.contains("`file` — Image _(file; accept: image/*)_"), "accept shown");
+    }
+
+    #[test]
+    fn file_tool_cli_example_includes_field_samples() {
+        // A file tool's field params are often REQUIRED — a copy-pasted
+        // example without them would just error. Samples come from the same
+        // schema-derived values as the deep-link example.
+        let meta = ToolMeta::from_toml(
+            r#"
+slug          = "audio-pitch-shift"
+title         = "t"
+description   = "d"
+h1            = "h"
+hero_subtitle = "s"
+wasm          = "w"
+export        = "build_argv"
+output_label  = "o"
+format        = "audio"
+runtime       = "ffmpeg"
+
+[[input]]
+name   = "audio"
+source = "file"
+accept = "audio/*"
+
+[[input]]
+name        = "semitones"
+source      = "field"
+placeholder = "3"
+
+[[input]]
+name   = "format"
+source = "field"
+"#,
+        )
+        .unwrap();
+        let schema = ParamSchema::from_props_for_tests(serde_json::json!({
+            "semitones": { "type": "number", "minimum": -24, "maximum": 24 },
+            "format": { "type": "string", "enum": ["mp3", "wav"], "default": "mp3" }
+        }));
+        assert_eq!(
+            cli_example(&meta, &schema),
+            "gizza tool audio-pitch-shift 'url=https://example.com/input' 'semitones=3' 'format=mp3'"
+        );
     }
 
     #[test]

--- a/tools/generator/src/meta.rs
+++ b/tools/generator/src/meta.rs
@@ -29,6 +29,10 @@ pub struct Input {
     /// e.g. "timezones") rendered as a `<datalist>` for searchable autocomplete.
     #[serde(default)]
     pub options: String,
+    /// For kind="slider": the slider's drag granularity (e.g. "1", "0.5").
+    /// Empty = 1. The paired number box always accepts finer typed values.
+    #[serde(default)]
+    pub step: String,
     /// For source="field": client-side default applied on load when the field is
     /// empty and not pre-filled from the URL. "today" → local YYYY-MM-DD, "now" →
     /// local YYYY-MM-DDTHH:MM, "local-timezone" → the user's IANA zone; anything

--- a/tools/generator/src/template.rs
+++ b/tools/generator/src/template.rs
@@ -2,7 +2,7 @@
 //! with SEO `<head>` tags and JSON-LD.
 
 use crate::control::{fmt_num, Control, ParamSchema};
-use crate::markdown::example_deeplink;
+use crate::markdown::{cli_example as shared_cli_example, example_deeplink};
 use crate::meta::ToolMeta;
 use gizza_chrome::{header as chrome_header, footer as chrome_footer, Active};
 use maud::{html, PreEscaped, DOCTYPE};
@@ -41,17 +41,10 @@ pub fn render_page(
     .to_string()
     .replace("</", "<\\/");
 
-    // How to run THIS tool headlessly via the gizza CLI — derived from the
-    // tool's own inputs (first field's placeholder, or a url= for file tools).
-    let cli_example = match meta.inputs.first() {
-        Some(inp) if inp.source == "file" => {
-            format!("gizza tool {} 'url=https://example.com/input'", meta.slug)
-        }
-        Some(inp) if !inp.placeholder.is_empty() => {
-            format!("gizza tool {} '{}'", meta.slug, inp.placeholder)
-        }
-        _ => format!("gizza tool {}", meta.slug),
-    };
+    // How to run THIS tool headlessly via the gizza CLI — the same
+    // copy-paste-runnable example as the markdown twin (file tools include a
+    // sample for every field, since those are often required).
+    let cli_example = shared_cli_example(meta, schema);
 
     let markup = html! {
         (DOCTYPE)
@@ -113,14 +106,33 @@ pub fn render_page(
                                         Control::Checkbox { default } => {
                                             input id=(id) class="tool-checkbox" type="checkbox" checked[default];
                                         }
-                                        Control::Number { min, max, default } => {
+                                        Control::Number { min, max, default, step_any } => {
                                             @let min_s = min.map(fmt_num);
                                             @let max_s = max.map(fmt_num);
                                             @let val_s = default.map(fmt_num);
                                             input id=(id) class="tool-input" type="number"
                                                   placeholder=(input.placeholder)
                                                   min=[min_s.as_deref()] max=[max_s.as_deref()] value=[val_s.as_deref()]
+                                                  step=[step_any.then_some("any")]
                                                   autocomplete="off" autocapitalize="off" spellcheck="false";
+                                        }
+                                        Control::Slider { min, max, default, step } => {
+                                            // Range + number pair. The number input keeps the
+                                            // canonical in-<name> id so deep-links, reset, chips
+                                            // and gatherArgs are untouched; tool.js mirrors the
+                                            // slider generically via data-for (no slug branches).
+                                            @let min_s = fmt_num(min);
+                                            @let max_s = fmt_num(max);
+                                            @let val_s = default.map(fmt_num);
+                                            div class="tool-slider-row" {
+                                                input id=(format!("{id}-slider")) class="tool-slider" type="range"
+                                                      data-for=(id) min=(min_s) max=(max_s) step=(step)
+                                                      value=[val_s.as_deref()] aria-label=(input.label);
+                                                input id=(id) class="tool-input tool-slider-value" type="number"
+                                                      placeholder=(input.placeholder)
+                                                      min=(min_s) max=(max_s) value=[val_s.as_deref()] step="any"
+                                                      autocomplete="off" autocapitalize="off" spellcheck="false";
+                                            }
                                         }
                                         Control::Picker { input_type } => {
                                             input id=(id) class="tool-input" type=(input_type)
@@ -628,6 +640,64 @@ params = { birthdate = "1990-04-15" }
         // client config carries the declarative default + examples for tool.js
         assert!(html.contains(r#""default":"today""#), "input default in client config");
         assert!(html.contains(r#""examples":[{"label":"Born 1990-04-15""#), "examples in client config");
+    }
+
+    #[test]
+    fn renders_slider_kind_and_step_any_number() {
+        let meta = ToolMeta::from_toml(
+            r#"
+slug          = "audio-pitch-shift"
+title         = "t"
+description   = "d"
+h1            = "h"
+hero_subtitle = "s"
+wasm          = "w"
+export        = "build_argv"
+runtime       = "ffmpeg"
+output_label  = "o"
+format        = "audio"
+
+[[input]]
+name   = "audio"
+source = "file"
+accept = "audio/*"
+
+[[input]]
+name        = "semitones"
+source      = "field"
+label       = "Semitones"
+placeholder = "3"
+kind        = "slider"
+
+[[input]]
+name        = "gain"
+source      = "field"
+label       = "Gain"
+"#,
+        )
+        .unwrap();
+        let schema = ParamSchema::from_props_for_tests(serde_json::json!({
+            "semitones": { "type": "number", "minimum": -24, "maximum": 24 },
+            "gain": { "type": "number", "minimum": -60, "maximum": 60 }
+        }));
+        let html = render_page(&meta, "<h2>About</h2>", &schema, false, false);
+        // kind="slider" → a range input mirroring the canonical number box
+        assert!(html.contains(r#"id="in-semitones-slider""#), "slider rendered");
+        assert!(html.contains(r#"data-for="in-semitones""#), "slider targets its number box");
+        assert!(
+            html.contains(r#"min="-24" max="24" step="1""#),
+            "slider carries schema bounds and default step"
+        );
+        assert!(html.contains(r#"id="in-semitones""#), "canonical number input kept");
+        // number-typed params accept fractions without step-mismatch warnings
+        assert!(html.contains(r#"step="any""#), "fractional step on number inputs");
+        // the plain number field (no kind) has no slider
+        assert!(!html.contains(r#"id="in-gain-slider""#), "no slider without kind=slider");
+        // copy-paste-runnable CLI example includes the field samples
+        assert!(
+            html.contains("gizza tool audio-pitch-shift 'url=https://example.com/input' 'semitones=3'"),
+            "CLI example includes required field sample"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## improve-tool: audio-pitch-shift

### Competitor analysis (top 5)
| tool | does better | dimension |
| ---- | ----------- | --------- |
| SoundTools | ±1-semitone presets, key-transposition worked examples, karaoke/guitar/harmony personas, "pitch changer" synonym targeting | ux, copy |
| Audioalter | ±24 slider, 432 Hz preset niche, before/after examples | ux, copy |
| vocalremover.org | 1-cent slider resolution with semitone snap, key/BPM detection, waveform player | ux, capabilities |
| pitchchanger.io | slider with signed live readout, quality guidance (±6 st / ±4 vocals), deep persona SEO | ux, copy |
| OnlineToneGenerator | slider+number pair, "5.946% per semitone" education, guitarist E♭-tuning angle | ux, copy |

Full paraphrased profiles + the 12-row gap table: `docs/checks/2026-07-03-improve-audio-pitch-shift-competitor-analysis.md`.

### Schema diff (before → after)
None — the chat schema is unchanged. The engine (±24 st range, 1-cent fractional precision, 5 output formats, tempo-exact chain) was already at or ahead of every competitor, so no descriptor/core change; drift-guard and manifest untouched and still green.

### Changes by dimension
- **Capabilities:** none needed (see above). All 5 competitors' engine features are either matched, beaten, or out-of-model (list below).
- **Copy/SEO:** semitone cheat-sheet section (C→D = 2, G→E = −3, harmony intervals 3/4/5/7); karaoke and guitar E♭-tuning worked examples; ~5.95%-per-semitone fact; new FAQs "pitch changer vs pitch shifter" and "play along with half-step-down recordings"; meta description/tags now target "pitch changer", "432 hz", "karaoke", "cents".
- **UX/layout:** `semitones` renders as a range slider paired with the number box (every competitor uses a slider) — built as a **declarative generator control** (`kind = "slider"` + optional `step` in meta.toml), not a per-tool hack; 5 one-click preset chips (Octave ±12, Half step ±1, 440→432 Hz −0.32) via the existing `[[example]]` mechanism; number inputs for fractional params now emit `step="any"` so `0.5` doesn't trip browser validation.
- **Visual design:** slider styled with the shared `--tool-accent` in `site/tool.css`; no other changes — page stays on shared gizza-chrome.
- **Platform (shared, root-cause):** the page's "Run it from the terminal" example previously omitted required field params for every file tool (`gizza tool audio-pitch-shift 'url=…'` → "missing required arg `semitones`"). Page + markdown-twin CLI examples are now one shared, schema-derived, copy-paste-runnable builder (`'url=…' 'semitones=3' 'format=mp3'` — smoke-tested verbatim).

### Phase-1 fixes (pre-existing breakage)
- none — all green (14 unit tests incl. drift-guard; CLI happy path + both guiding errors vs the public beep, duration preserved at 1.254 s; Playwright 3/3 incl. deep-link).

### Out-of-model features considered, not built
- Live preview while dragging (4/5 competitors) — page framework is run-per-change; the slider commits exactly one ffmpeg run per drag-release instead.
- Key/scale/BPM detection + live target-key readout (vocalremover) — audio analysis outside the argv-builder model; FAQ teaches counting semitones.
- Formant-preserving voice mode — no librubberband in either ffmpeg build; FAQ states the honest ±4 st natural range.
- Combined speed+pitch on one page — deliberate family split; change-speed owns tempo and the copy cross-links.
- 50–250 MB caps / key-named output files — family-wide invariants (10 MiB envelope, deterministic `-pitch-shifted.<ext>` suffix); revisit family-wide if ever.

### Tested
- Generator: 43/43 unit tests (new: slider control, bounds fallback, step-any, CLI-example samples, template rendering).
- Block: `cargo test --workspace` 14/14 incl. `schema_json_matches_authored_chat_schema` (unchanged schema); `wafer build` OK (548.5 KiB, binary identical — not re-committed). `blocks/*/tests/` wafer fixtures: none exist for the audio family (ffmpeg tools; family norm).
- Playwright: 5/5 — octave-up, deep-link (`?semitones=-12&format=wav`, now also asserts the slider mirror), guiding no-op error, **slider-commit +12 → ~880 Hz**, **preset-chip-after-error −12 → ~220 Hz** (bounds pre-measured with local ffmpeg).
- Sibling regressions (shared tool.js touched): trim-audio (waveform-bound), audio-eq, calculator, age-calculator — 9/9.
- CLI: `gizza tool audio-pitch-shift 'url=…' 'semitones=3' 'format=mp3'` (the page's exact example) → OK.
- Hygiene: `scripts/check-tool-hygiene.py audio-pitch-shift` exit 0.
- Limitations: chat-ffmpeg is non-functional in the Service Worker runtime (family constraint — page + CLI are the live surfaces); `solobase build` skipped per run instructions (branch CI covers it); `wasm-pack` not re-run (web crate untouched).

> Original work only — no competitor copy, branding, or trademarks copied.
