### PR TITLE
improve-tool: waveform-image — gradient waves, peak sampling, per-channel colors, color-picker control

### DIFF
--- a/blocks/waveform-image/core/src/lib.rs
+++ b/blocks/waveform-image/core/src/lib.rs
@@ -49,7 +49,7 @@ pub const SCALES: [&str; 4] = ["lin", "sqrt", "cbrt", "log"];
 pub const SAMPLINGS: [&str; 2] = ["average", "peak"];
 
 /// Most channels a `color` list may address. ffmpeg itself defaults to a
-/// 9-color cycle; 8 coves 7.1 audio and keeps the filtergraph bounded.
+/// 9-color cycle; 8 covers 7.1 audio and keeps the filtergraph bounded.
 pub const MAX_COLORS: usize = 8;
 
 /// Validate a strict hex color (`#RGB`/`#RGBA`/`#RRGGBB`/`#RRGGBBAA`,

--- a/blocks/waveform-image/core/src/lib.rs
+++ b/blocks/waveform-image/core/src/lib.rs
@@ -14,9 +14,16 @@
 //! downmix is skipped and `split_channels=1` stacks one lane per channel.
 //!
 //! Color strings are interpolated into `-filter_complex`, so they are
-//! validated to strict `#RGB`/`#RRGGBB` hex — input hygiene that doubles as
-//! filtergraph hardening (a stray `,`/`;`/`:` in a color would rewrite the
-//! graph).
+//! validated to strict hex (`#RGB`/`#RGBA`/`#RRGGBB`/`#RRGGBBAA`) — input
+//! hygiene that doubles as filtergraph hardening (a stray `,`/`;`/`:` in a
+//! color would rewrite the graph). Short forms are EXPANDED to the 6/8-digit
+//! form before interpolation: ffmpeg's own color parser only understands
+//! `#RRGGBB[AA]`, and silently falls back to white on a 3-digit hex.
+//!
+//! `color2` turns the wave into a horizontal left→right gradient: the wave is
+//! drawn white, its alpha plane is extracted as a mask, and the mask is
+//! `alphamerge`d onto a `gradients` source (`color` → `color2` across the
+//! width). A background still wraps the result in the overlay recipe.
 
 /// Default output width in pixels — the 1200×300 social-banner shape the
 /// popular waveform generators standardized on.
@@ -36,20 +43,65 @@ pub const MAX_HEIGHT: u32 = 2048;
 /// sqrt/cbrt/log progressively boost quiet material so it stays visible.
 pub const SCALES: [&str; 4] = ["lin", "sqrt", "cbrt", "log"];
 
-/// Validate a strict hex color: `#RGB` or `#RRGGBB`, case-insensitive.
-/// Returns the trimmed value. Strictness doubles as filtergraph hardening.
-fn parse_hex_color<'a>(value: &'a str, field: &str) -> Result<&'a str, String> {
+/// Per-column sampling modes showwavespic accepts. `average` draws the mean
+/// amplitude; `peak` draws the loudest sample — a fuller wave that keeps
+/// short hits visible.
+pub const SAMPLINGS: [&str; 2] = ["average", "peak"];
+
+/// Most channels a `color` list may address. ffmpeg itself defaults to a
+/// 9-color cycle; 8 coves 7.1 audio and keeps the filtergraph bounded.
+pub const MAX_COLORS: usize = 8;
+
+/// Validate a strict hex color (`#RGB`/`#RGBA`/`#RRGGBB`/`#RRGGBBAA`,
+/// case-insensitive) and NORMALIZE it to the 6/8-digit form ffmpeg's color
+/// parser understands (a 3-digit hex is silently dropped → white wave).
+/// Strictness doubles as filtergraph hardening.
+fn parse_hex_color(value: &str, field: &str) -> Result<String, String> {
     let v = value.trim();
-    let ok = matches!(v.len(), 4 | 7)
-        && v.starts_with('#')
-        && v[1..].bytes().all(|b| b.is_ascii_hexdigit());
-    if ok {
-        Ok(v)
-    } else {
-        Err(format!(
-            "{field} must be a hex color like #4f46e5 or #f00, got {value:?}"
-        ))
+    let digits = v.strip_prefix('#').unwrap_or("");
+    let ok = matches!(digits.len(), 3 | 4 | 6 | 8)
+        && !digits.is_empty()
+        && digits.bytes().all(|b| b.is_ascii_hexdigit())
+        && v.starts_with('#');
+    if !ok {
+        return Err(format!(
+            "{field} must be a hex color like #4f46e5, #f00 or #00000080, got {value:?}"
+        ));
     }
+    if digits.len() <= 4 {
+        // #RGB(A) → #RRGGBB(AA): double each digit.
+        let mut out = String::with_capacity(1 + digits.len() * 2);
+        out.push('#');
+        for c in digits.chars() {
+            out.push(c);
+            out.push(c);
+        }
+        Ok(out)
+    } else {
+        Ok(v.to_string())
+    }
+}
+
+/// Parse a comma-separated list of hex colors (for per-channel coloring with
+/// `split_channels`) into showwavespic's pipe-joined `colors=` value. Empty →
+/// the default accent. Each entry is validated + normalized.
+fn parse_color_list(value: &str, field: &str) -> Result<String, String> {
+    let v = value.trim();
+    if v.is_empty() {
+        return Ok(DEFAULT_COLOR.to_string());
+    }
+    let parts: Vec<&str> = v.split(',').map(str::trim).collect();
+    if parts.len() > MAX_COLORS {
+        return Err(format!(
+            "{field} lists {} colors — at most {MAX_COLORS} (one per channel) are supported",
+            parts.len()
+        ));
+    }
+    let mut colors = Vec::with_capacity(parts.len());
+    for part in parts {
+        colors.push(parse_hex_color(part, field)?);
+    }
+    Ok(colors.join("|"))
 }
 
 /// Round + range-check a dimension. `0` (an empty page field) selects the
@@ -83,61 +135,124 @@ pub fn parse_scale(s: &str) -> Result<&'static str, String> {
         .ok_or_else(|| format!("scale {s:?} not supported (lin|sqrt|cbrt|log)"))
 }
 
-/// Build the `-filter_complex` graph string from validated parts.
+/// Parse the per-column sampling mode. Empty defaults to `average`.
+pub fn parse_sampling(s: &str) -> Result<&'static str, String> {
+    let v = s.trim().to_ascii_lowercase();
+    if v.is_empty() {
+        return Ok("average");
+    }
+    SAMPLINGS
+        .iter()
+        .find(|k| **k == v)
+        .copied()
+        .ok_or_else(|| format!("sampling {s:?} not supported (average|peak)"))
+}
+
+/// Build the `-filter_complex` graph string from validated parts. `colors` is
+/// the pipe-joined showwavespic value; `gradient` is `Some((from, to))` for a
+/// horizontal gradient-filled wave; `background` wraps everything in the
+/// color-source + overlay recipe.
 fn build_graph(
     width: u32,
     height: u32,
-    color: &str,
+    colors: &str,
+    gradient: Option<(&str, &str)>,
     background: Option<&str>,
     split_channels: bool,
     scale: &str,
+    sampling: &str,
 ) -> String {
+    // `filter=peak` only when asked, so default graphs stay byte-identical
+    // to the pre-sampling ones (argv stability across surfaces + tests).
+    let peak = if sampling == "peak" { ":filter=peak" } else { "" };
+    let wave_colors = if gradient.is_some() { "#ffffff" } else { colors };
     let wave = if split_channels {
         format!(
-            "[0:a]showwavespic=s={width}x{height}:colors={color}:scale={scale}:split_channels=1"
+            "[0:a]showwavespic=s={width}x{height}:colors={wave_colors}:scale={scale}{peak}:split_channels=1"
         )
     } else {
         format!(
-            "[0:a]aformat=channel_layouts=mono,showwavespic=s={width}x{height}:colors={color}:scale={scale}"
+            "[0:a]aformat=channel_layouts=mono,showwavespic=s={width}x{height}:colors={wave_colors}:scale={scale}{peak}"
         )
+    };
+    // Gradient fill: draw the wave white, lift its alpha plane out as a mask,
+    // and merge the mask onto a left→right two-color `gradients` source. The
+    // gradient axis is pinned to the horizontal midline so it is purely
+    // horizontal at any size.
+    let (wave, wave_label) = match gradient {
+        None => (wave, "[wave]"),
+        Some((from, to)) => {
+            let mid = height / 2;
+            (
+                format!(
+                    "gradients=s={width}x{height}:c0={from}:c1={to}:x0=0:y0={mid}:x1={width}:y1={mid}[grad];\
+                     {wave}[w];[w]alphaextract[mask];[grad][mask]alphamerge"
+                ),
+                "[gwave]",
+            )
+        }
     };
     match background {
         None => wave,
         Some(bg) => format!(
-            "color=c={bg}:s={width}x{height}[bg];{wave}[wave];[bg][wave]overlay=format=auto"
+            "color=c={bg}:s={width}x{height}[bg];{wave}{wave_label};[bg]{wave_label}overlay=format=auto"
         ),
     }
 }
 
 /// Validate params and return `(argv, out_name)` for an input file. Width and
 /// height arrive as f64 (the page sends 0 for an empty field → default);
-/// `color`/`background` are hex strings (empty color → default, empty
-/// background → transparent); `scale` is lin|sqrt|cbrt|log (empty → lin).
+/// `color` is one hex or a comma-separated per-channel list (empty → default);
+/// `color2` is an optional gradient end color (empty → solid); `background`
+/// is a hex (empty → transparent); `scale` is lin|sqrt|cbrt|log (empty → lin);
+/// `sampling` is average|peak (empty → average). All hex colors accept
+/// `#RGB`/`#RGBA`/`#RRGGBB`/`#RRGGBBAA` and are normalized for ffmpeg.
 /// Single source shared by the chat block (`src/lib.rs`) and the web page
 /// (`web/src/lib.rs`). The output is always `out.png`.
+#[allow(clippy::too_many_arguments)] // mirrors the page field order 1:1
 pub fn plan_waveform_image(
     in_name: &str,
     width: f64,
     height: f64,
     color: &str,
+    color2: &str,
     background: &str,
     split_channels: bool,
     scale: &str,
+    sampling: &str,
 ) -> Result<(Vec<String>, String), String> {
     let w = parse_dim(width, DEFAULT_WIDTH, MAX_WIDTH, "width")?;
     let h = parse_dim(height, DEFAULT_HEIGHT, MAX_HEIGHT, "height")?;
-    let color = if color.trim().is_empty() {
-        DEFAULT_COLOR
+    let colors = parse_color_list(color, "color")?;
+    let gradient_to = if color2.trim().is_empty() {
+        None
     } else {
-        parse_hex_color(color, "color")?
+        Some(parse_hex_color(color2, "color2")?)
     };
+    if gradient_to.is_some() && colors.contains('|') {
+        return Err(
+            "color2 draws a gradient from a single color — use one color, not a list, with color2"
+                .to_string(),
+        );
+    }
     let background = if background.trim().is_empty() {
         None
     } else {
         Some(parse_hex_color(background, "background")?)
     };
     let scale = parse_scale(scale)?;
-    let graph = build_graph(w, h, color, background, split_channels, scale);
+    let sampling = parse_sampling(sampling)?;
+    let gradient = gradient_to.as_deref().map(|to| (colors.as_str(), to));
+    let graph = build_graph(
+        w,
+        h,
+        &colors,
+        gradient,
+        background.as_deref(),
+        split_channels,
+        scale,
+        sampling,
+    );
     let out_name = "out.png".to_string();
     // showwavespic emits exactly one frame; -frames:v 1 stops after it and
     // -update 1 tells the image2 muxer this is a single image, not a sequence.
@@ -159,9 +274,33 @@ pub fn plan_waveform_image(
 mod tests {
     use super::*;
 
+    /// `plan_waveform_image` with the two new params defaulted — keeps the
+    /// pre-existing behavior tests readable.
+    fn plan(
+        in_name: &str,
+        width: f64,
+        height: f64,
+        color: &str,
+        background: &str,
+        split_channels: bool,
+        scale: &str,
+    ) -> Result<(Vec<String>, String), String> {
+        plan_waveform_image(
+            in_name,
+            width,
+            height,
+            color,
+            "",
+            background,
+            split_channels,
+            scale,
+            "",
+        )
+    }
+
     #[test]
     fn default_argv_is_mono_transparent_1200x300_accent() {
-        let (argv, out) = plan_waveform_image("in.mp3", 0.0, 0.0, "", "", false, "").unwrap();
+        let (argv, out) = plan("in.mp3", 0.0, 0.0, "", "", false, "").unwrap();
         assert_eq!(out, "out.png");
         assert_eq!(
             argv,
@@ -184,9 +323,7 @@ mod tests {
 
     #[test]
     fn background_wraps_wave_in_color_overlay_recipe() {
-        let (argv, _) =
-            plan_waveform_image("in.wav", 640.0, 200.0, "#FF0000", "#000000", false, "lin")
-                .unwrap();
+        let (argv, _) = plan("in.wav", 640.0, 200.0, "#FF0000", "#000000", false, "lin").unwrap();
         assert_eq!(
             argv[3],
             "color=c=#000000:s=640x200[bg];\
@@ -197,7 +334,7 @@ mod tests {
 
     #[test]
     fn split_channels_skips_downmix_and_sets_the_option() {
-        let (argv, _) = plan_waveform_image("in.mp3", 0.0, 0.0, "", "", true, "sqrt").unwrap();
+        let (argv, _) = plan("in.mp3", 0.0, 0.0, "", "", true, "sqrt").unwrap();
         assert_eq!(
             argv[3],
             "[0:a]showwavespic=s=1200x300:colors=#4f46e5:scale=sqrt:split_channels=1"
@@ -214,75 +351,194 @@ mod tests {
     }
 
     #[test]
-    fn short_hex_and_mixed_case_are_accepted() {
+    fn sampling_variants_accepted_and_defaulted() {
+        assert_eq!(parse_sampling("").unwrap(), "average");
+        assert_eq!(parse_sampling("PEAK").unwrap(), "peak");
+        assert_eq!(parse_sampling(" average ").unwrap(), "average");
+        assert!(parse_sampling("rms").is_err());
+    }
+
+    #[test]
+    fn sampling_peak_adds_the_filter_option_average_stays_bare() {
         let (argv, _) =
-            plan_waveform_image("a.mp3", 0.0, 0.0, "#F00", "#ABCdef", false, "").unwrap();
-        assert!(argv[3].contains("colors=#F00"), "{}", argv[3]);
-        assert!(argv[3].contains("color=c=#ABCdef"), "{}", argv[3]);
+            plan_waveform_image("a.mp3", 0.0, 0.0, "", "", "", false, "", "peak").unwrap();
+        assert_eq!(
+            argv[3],
+            "[0:a]aformat=channel_layouts=mono,showwavespic=s=1200x300:colors=#4f46e5:scale=lin:filter=peak"
+        );
+        // Explicit "average" keeps the graph byte-identical to the default.
+        let (avg, _) =
+            plan_waveform_image("a.mp3", 0.0, 0.0, "", "", "", false, "", "average").unwrap();
+        assert!(!avg[3].contains("filter="), "{}", avg[3]);
+    }
+
+    /// REGRESSION (found in the improve pass): ffmpeg's color parser only
+    /// understands `#RRGGBB[AA]` — a raw `#f00` was warned about and silently
+    /// replaced with WHITE. Short forms must be expanded before interpolation.
+    #[test]
+    fn three_and_four_digit_hex_expand_to_ffmpeg_form() {
+        let (argv, _) = plan("a.mp3", 0.0, 0.0, "#f00", "#ABC", false, "").unwrap();
+        assert!(argv[3].contains("colors=#ff0000"), "{}", argv[3]);
+        assert!(argv[3].contains("color=c=#AABBCC"), "{}", argv[3]);
+        let (argv, _) = plan("a.mp3", 0.0, 0.0, "#f008", "", false, "").unwrap();
+        assert!(argv[3].contains("colors=#ff000088"), "{}", argv[3]);
+    }
+
+    #[test]
+    fn alpha_hex_passes_through_for_translucent_scrims() {
+        let (argv, _) = plan("a.mp3", 0.0, 0.0, "#4f46e5", "#00000080", false, "").unwrap();
+        assert!(argv[3].contains("color=c=#00000080"), "{}", argv[3]);
+    }
+
+    #[test]
+    fn six_and_eight_digit_hex_keep_their_case_and_value() {
+        let (argv, _) = plan("a.mp3", 0.0, 0.0, "#ABCdef", "#0b1220", false, "").unwrap();
+        assert!(argv[3].contains("colors=#ABCdef"), "{}", argv[3]);
+        assert!(argv[3].contains("color=c=#0b1220"), "{}", argv[3]);
+    }
+
+    #[test]
+    fn color_list_joins_with_pipe_for_per_channel_lanes() {
+        let (argv, _) = plan("a.mp3", 0.0, 0.0, "#ff0000, #00f", "", true, "").unwrap();
+        assert_eq!(
+            argv[3],
+            "[0:a]showwavespic=s=1200x300:colors=#ff0000|#0000ff:scale=lin:split_channels=1"
+        );
+    }
+
+    #[test]
+    fn color_list_rejects_bad_entries_and_oversized_lists() {
+        let err = plan("a.mp3", 0.0, 0.0, "#ff0000,red", "", true, "").unwrap_err();
+        assert!(err.contains("color"), "{err}");
+        let nine = vec!["#ff0000"; 9].join(",");
+        let err = plan("a.mp3", 0.0, 0.0, &nine, "", true, "").unwrap_err();
+        assert!(err.contains("8"), "{err}");
+    }
+
+    #[test]
+    fn gradient_wave_uses_the_alphamerge_recipe() {
+        let (argv, _) =
+            plan_waveform_image("a.mp3", 320.0, 100.0, "#ff0000", "#0000ff", "", false, "", "")
+                .unwrap();
+        assert_eq!(
+            argv[3],
+            "gradients=s=320x100:c0=#ff0000:c1=#0000ff:x0=0:y0=50:x1=320:y1=50[grad];\
+             [0:a]aformat=channel_layouts=mono,showwavespic=s=320x100:colors=#ffffff:scale=lin[w];\
+             [w]alphaextract[mask];[grad][mask]alphamerge"
+        );
+    }
+
+    #[test]
+    fn gradient_with_background_overlays_the_merged_wave() {
+        let (argv, _) = plan_waveform_image(
+            "a.mp3", 320.0, 100.0, "#f00", "#00f", "#000000", false, "", "",
+        )
+        .unwrap();
+        assert_eq!(
+            argv[3],
+            "color=c=#000000:s=320x100[bg];\
+             gradients=s=320x100:c0=#ff0000:c1=#0000ff:x0=0:y0=50:x1=320:y1=50[grad];\
+             [0:a]aformat=channel_layouts=mono,showwavespic=s=320x100:colors=#ffffff:scale=lin[w];\
+             [w]alphaextract[mask];[grad][mask]alphamerge[gwave];\
+             [bg][gwave]overlay=format=auto"
+        );
+    }
+
+    #[test]
+    fn gradient_composes_with_split_channels_and_peak() {
+        let (argv, _) = plan_waveform_image(
+            "a.mp3", 0.0, 0.0, "#f00", "#00f", "", true, "sqrt", "peak",
+        )
+        .unwrap();
+        assert!(argv[3].contains("split_channels=1"), "{}", argv[3]);
+        assert!(argv[3].contains("filter=peak"), "{}", argv[3]);
+        assert!(argv[3].contains("alphamerge"), "{}", argv[3]);
+        assert!(argv[3].contains("colors=#ffffff"), "{}", argv[3]);
+    }
+
+    #[test]
+    fn gradient_rejects_a_color_list_start() {
+        let err = plan_waveform_image(
+            "a.mp3", 0.0, 0.0, "#f00,#0f0", "#00f", "", false, "", "",
+        )
+        .unwrap_err();
+        assert!(err.contains("single"), "{err}");
+        // …and a bad color2 names its field.
+        let err =
+            plan_waveform_image("a.mp3", 0.0, 0.0, "#f00", "blue", "", false, "", "").unwrap_err();
+        assert!(err.contains("color2"), "{err}");
     }
 
     #[test]
     fn rejects_bad_hex_colors_with_field_name() {
-        let err = plan_waveform_image("a.mp3", 0.0, 0.0, "red", "", false, "").unwrap_err();
+        let err = plan("a.mp3", 0.0, 0.0, "red", "", false, "").unwrap_err();
         assert!(err.contains("color"), "{err}");
         assert!(err.contains("#4f46e5"), "{err}");
-        let err = plan_waveform_image("a.mp3", 0.0, 0.0, "", "#12345", false, "").unwrap_err();
+        let err = plan("a.mp3", 0.0, 0.0, "", "#12345", false, "").unwrap_err();
         assert!(err.contains("background"), "{err}");
     }
 
     #[test]
     fn hex_validation_blocks_filtergraph_injection() {
-        // A crafted "color" must not be able to smuggle graph syntax through.
-        for evil in ["#fff,anullsink", "#fff;movie=x", "#fff:s=9x9", "white"] {
+        // A crafted color must not be able to smuggle graph syntax through —
+        // in any color-bearing field (color splits on ',', each part strict).
+        for evil in ["#fff;movie=x", "#fff:s=9x9", "white", "#fff|#000"] {
             assert!(
-                plan_waveform_image("a.mp3", 0.0, 0.0, evil, "", false, "").is_err(),
+                plan("a.mp3", 0.0, 0.0, evil, "", false, "").is_err(),
                 "{evil} should be rejected as color"
             );
             assert!(
-                plan_waveform_image("a.mp3", 0.0, 0.0, "", evil, false, "").is_err(),
+                plan("a.mp3", 0.0, 0.0, "", evil, false, "").is_err(),
                 "{evil} should be rejected as background"
             );
+            assert!(
+                plan_waveform_image("a.mp3", 0.0, 0.0, "#fff", evil, "", false, "", "").is_err(),
+                "{evil} should be rejected as color2"
+            );
         }
+        // The comma is a list separator for color, but strict hex elsewhere.
+        assert!(plan("a.mp3", 0.0, 0.0, "#fff,anullsink", "", false, "").is_err());
+        assert!(plan("a.mp3", 0.0, 0.0, "", "#fff,#000", false, "").is_err());
     }
 
     #[test]
     fn zero_or_empty_dimensions_take_the_defaults() {
-        let (argv, _) = plan_waveform_image("a.mp3", 0.0, 150.0, "", "", false, "").unwrap();
+        let (argv, _) = plan("a.mp3", 0.0, 150.0, "", "", false, "").unwrap();
         assert!(argv[3].contains("s=1200x150"), "{}", argv[3]);
-        let (argv, _) = plan_waveform_image("a.mp3", 800.0, 0.0, "", "", false, "").unwrap();
+        let (argv, _) = plan("a.mp3", 800.0, 0.0, "", "", false, "").unwrap();
         assert!(argv[3].contains("s=800x300"), "{}", argv[3]);
     }
 
     #[test]
     fn fractional_dimensions_are_rounded() {
-        let (argv, _) = plan_waveform_image("a.mp3", 799.6, 200.4, "", "", false, "").unwrap();
+        let (argv, _) = plan("a.mp3", 799.6, 200.4, "", "", false, "").unwrap();
         assert!(argv[3].contains("s=800x200"), "{}", argv[3]);
     }
 
     #[test]
     fn rejects_out_of_range_dimensions_with_bounds_in_message() {
-        let err = plan_waveform_image("a.mp3", 4097.0, 300.0, "", "", false, "").unwrap_err();
+        let err = plan("a.mp3", 4097.0, 300.0, "", "", false, "").unwrap_err();
         assert!(err.contains("width"), "{err}");
         assert!(err.contains("4096"), "{err}");
-        let err = plan_waveform_image("a.mp3", 1200.0, 2049.0, "", "", false, "").unwrap_err();
+        let err = plan("a.mp3", 1200.0, 2049.0, "", "", false, "").unwrap_err();
         assert!(err.contains("height"), "{err}");
         assert!(err.contains("2048"), "{err}");
-        let err = plan_waveform_image("a.mp3", 8.0, 300.0, "", "", false, "").unwrap_err();
+        let err = plan("a.mp3", 8.0, 300.0, "", "", false, "").unwrap_err();
         assert!(err.contains("16"), "{err}");
-        assert!(plan_waveform_image("a.mp3", f64::NAN, 0.0, "", "", false, "").is_err());
-        assert!(plan_waveform_image("a.mp3", -100.0, 0.0, "", "", false, "").is_err());
+        assert!(plan("a.mp3", f64::NAN, 0.0, "", "", false, "").is_err());
+        assert!(plan("a.mp3", -100.0, 0.0, "", "", false, "").is_err());
     }
 
     #[test]
     fn bounds_are_inclusive() {
-        assert!(plan_waveform_image("a.mp3", 16.0, 16.0, "", "", false, "").is_ok());
-        assert!(plan_waveform_image("a.mp3", 4096.0, 2048.0, "", "", false, "").is_ok());
+        assert!(plan("a.mp3", 16.0, 16.0, "", "", false, "").is_ok());
+        assert!(plan("a.mp3", 4096.0, 2048.0, "", "", false, "").is_ok());
     }
 
     #[test]
     fn out_name_is_always_png_regardless_of_input_ext() {
         for in_name in ["in.flac", "in.wav", "in.m4a"] {
-            let (_, out) = plan_waveform_image(in_name, 0.0, 0.0, "", "", false, "").unwrap();
+            let (_, out) = plan(in_name, 0.0, 0.0, "", "", false, "").unwrap();
             assert_eq!(out, "out.png");
         }
     }

--- a/blocks/waveform-image/manifest.json
+++ b/blocks/waveform-image/manifest.json
@@ -5,7 +5,7 @@
   "summary": "Render a static waveform PNG image from an audio file",
   "role": "skill",
   "tool": {
-    "description": "Render a static waveform PNG image from an audio file (any format ffmpeg decodes: mp3, wav, flac, ogg, m4a, opus, ...). Provide either url (HTTP/HTTPS) or ref (id from a prior tool call). width x height set the image size in pixels (default 1200x300); color is the wave's #RRGGBB hex (default #4f46e5); background is an optional #RRGGBB hex (empty = transparent PNG); split_channels draws one lane per channel instead of a single mono wave; scale (lin|sqrt|cbrt|log) boosts quiet audio's visibility. Output is always a PNG image.",
+    "description": "Render a static waveform PNG image from an audio file (any format ffmpeg decodes: mp3, wav, flac, ogg, m4a, opus, ...). Provide either url (HTTP/HTTPS) or ref (id from a prior tool call). width x height set the image size in pixels (default 1200x300); color is the wave's hex color (default #4f46e5; alpha via #RRGGBBAA; a comma-separated list colors split channels); color2 turns the wave into a horizontal color->color2 gradient; background is an optional hex (empty = transparent PNG); split_channels draws one lane per channel instead of a single mono wave; scale (lin|sqrt|cbrt|log) boosts quiet audio's visibility; sampling=peak draws the loudest sample per column for a fuller wave. Output is always a PNG image.",
     "parameters": {
       "additionalProperties": false,
       "oneOf": [
@@ -22,12 +22,16 @@
       ],
       "properties": {
         "background": {
-          "description": "Background color as #RGB or #RRGGBB hex, e.g. #000000. Empty or omitted keeps the background transparent (the PNG has an alpha channel).",
+          "description": "Background color as hex: #RGB, #RRGGBB or #RRGGBBAA — e.g. #000000, or #00000080 for a see-through scrim. Empty or omitted keeps the background transparent (the PNG has an alpha channel).",
           "type": "string"
         },
         "color": {
           "default": "#4f46e5",
-          "description": "Waveform color as #RGB or #RRGGBB hex, e.g. #4f46e5 or #f00. Default #4f46e5.",
+          "description": "Waveform color as hex: #RGB, #RRGGBB or #RRGGBBAA (alpha), e.g. #4f46e5 or #f00. With split_channels, a comma-separated list colors each channel (e.g. #ff0000,#0000ff). Default #4f46e5.",
+          "type": "string"
+        },
+        "color2": {
+          "description": "Optional gradient end color (same hex forms). When set, the wave is filled with a horizontal left-to-right gradient from color to color2; color must then be a single value. Empty = solid color.",
           "type": "string"
         },
         "height": {
@@ -39,6 +43,15 @@
         },
         "ref": {
           "description": "Reference id from a prior tool call. Use either url or ref.",
+          "type": "string"
+        },
+        "sampling": {
+          "default": "average",
+          "description": "Per-pixel-column sampling. average (default) draws the mean amplitude; peak draws the loudest sample — a fuller wave that keeps short hits visible. Default average.",
+          "enum": [
+            "average",
+            "peak"
+          ],
           "type": "string"
         },
         "scale": {

--- a/blocks/waveform-image/page/content.md
+++ b/blocks/waveform-image/page/content.md
@@ -2,11 +2,11 @@
 
 Upload an audio file and this tool renders its waveform as a PNG image —
 the classic soundwave graphic used for podcast covers, social banners,
-audio-post thumbnails and player artwork. Choose the image size, the wave
-color and an optional background color, or leave the background empty for a
-transparent PNG that drops onto any design. The render runs entirely in your
-browser with ffmpeg compiled to WebAssembly (its `showwavespic` filter), so
-your audio is never uploaded to a server.
+audio-post thumbnails and player artwork. Choose the image size, a solid or
+gradient wave color and an optional background color, or leave the background
+empty for a transparent PNG that drops onto any design. The render runs
+entirely in your browser with ffmpeg compiled to WebAssembly (its
+`showwavespic` filter), so your audio is never uploaded to a server.
 
 ### Worked example
 
@@ -14,32 +14,49 @@ Make a social banner for a podcast episode: upload the episode mp3, leave
 **Width** and **Height** empty (the default is a banner-shaped `1200×300`),
 set **Wave color** to `#4f46e5` and **Background** to `#0b1220`. The result is
 a 1200×300 PNG named like the original with a `-waveform.png` suffix — dark
-card, indigo wave. For a transparent overlay to place on top of your own
-artwork, leave **Background** empty instead: the PNG keeps its alpha channel,
-so only the wave itself is opaque. A quiet voice memo that renders as a thin
-line becomes clearly visible with **Amplitude scale** set to `sqrt` or `log`.
+card, indigo wave. Add `#ec4899` as the **Gradient end** and the wave fades
+indigo→pink left to right. For a transparent overlay to place on top of your
+own artwork, leave **Background** empty instead: the PNG keeps its alpha
+channel, so only the wave itself is opaque. A quiet voice memo that renders as
+a thin line becomes clearly visible with **Amplitude scale** set to `sqrt` or
+`log` — and **Sampling** set to `peak` keeps short hits visible. Or just tap
+one of the **Try** presets under the fields.
 
 ### Options
 
 - **Width / Height** — image size in pixels (16–4096 × 16–2048). Empty fields
   use the 1200×300 default.
-- **Wave color** — `#RGB` or `#RRGGBB` hex, e.g. `#4f46e5` or `#f00`.
-- **Background** — hex color, or empty for a transparent PNG.
+- **Wave color** — hex color: `#RGB`, `#RRGGBB` or `#RRGGBBAA` (the last two
+  digits are alpha, for a translucent wave). Pick it with the swatch or type
+  it. With **One lane per channel**, a comma-separated list like
+  `#4f46e5,#ec4899` colors each channel's lane (up to 8).
+- **Gradient end** — a second hex color. When set, the wave is filled with a
+  horizontal left→right gradient from **Wave color** to this color. Leave
+  empty for a solid wave.
+- **Background** — hex color, or empty for a transparent PNG. An alpha hex
+  like `#00000080` bakes in a see-through scrim.
 - **One lane per channel** — off (default) downmixes to a single clean mono
   wave; on draws each channel (e.g. stereo left/right) in its own horizontal
   lane, sharing the image height.
 - **Amplitude scale** — `lin` is the true waveform; `sqrt`, `cbrt` and `log`
   progressively boost quiet material so it stays visible.
+- **Sampling** — `average` (default) draws the mean level of each pixel
+  column; `peak` draws the loudest sample instead, a fuller wave that keeps
+  drum hits and other transients visible.
 
 ### Limits and edge cases
 
 - Input files up to 10 MiB; anything ffmpeg can decode works (mp3, wav, flac,
   m4a/aac, ogg, opus — and most video containers' audio tracks via the CLI).
 - The output is always a PNG (with an alpha channel when the background is
-  empty). Colors must be strict hex — named colors like `red` are rejected
-  with a hint rather than guessed.
+  empty). Colors must be hex — named colors like `red` are rejected with a
+  hint rather than guessed. Short `#f00`-style hex is expanded for you.
+- A gradient (**Gradient end** set) needs a single **Wave color**, not a
+  comma list — the gradient runs across the whole image, so split-channel
+  lanes all share it.
 - Very quiet recordings can look like a flat line in `lin` scale — that's the
-  honest amplitude, not a bug; switch the scale to `sqrt` or `log`.
+  honest amplitude, not a bug; switch the scale to `sqrt` or `log`, or set
+  **Sampling** to `peak`.
 - A silent file renders only the thin center baseline.
 - One image per run: the whole track is drawn into the width you choose, one
   peak column per horizontal pixel — longer audio isn't wider, it's just more
@@ -54,7 +71,19 @@ Leave the **Background** field empty (the default). The PNG then keeps its
 alpha channel, so everything except the wave itself is fully transparent —
 ideal for dropping the waveform onto your own artwork or a colored card in
 any editor. Set a hex value like `#0b1220` only when you want a flat
-background baked into the image.
+background baked into the image, or an alpha hex like `#00000080` for a
+half-transparent scrim.
+
+</details>
+
+<details>
+<summary>Can the wave be a gradient?</summary>
+
+Yes — set **Gradient end** to a second hex color. The wave is then filled
+with a smooth horizontal gradient that starts at **Wave color** on the left
+and ends at **Gradient end** on the right (try `#f97316` → `#ec4899` for a
+sunset look). Everything else — transparent or solid backgrounds, channel
+lanes, scales — works the same as with a solid color.
 
 </details>
 
@@ -64,7 +93,9 @@ background baked into the image.
 The default `lin` scale draws true amplitude, and quiet audio genuinely has
 small peaks. Switch **Amplitude scale** to `sqrt` — or `log` for the
 strongest boost — to make quiet material fill more of the image height
-without touching the audio itself.
+without touching the audio itself. Setting **Sampling** to `peak` helps too:
+it draws each column at the loudest sample instead of the average, so short
+transients stop disappearing.
 
 </details>
 
@@ -74,7 +105,8 @@ without touching the audio itself.
 The default `1200×300` works well for wide banners, link previews and
 audio-post headers. For a square post, try `1080×1080`; for a compact player
 strip, something like `800×160`. Any size from 16×16 up to 4096×2048 works —
-the whole track is always drawn across the full width.
+the whole track is always drawn across the full width. The **Try** presets
+under the fields cover the common shapes.
 
 </details>
 
@@ -82,9 +114,21 @@ the whole track is always drawn across the full width.
 <summary>Can I show the left and right channels separately?</summary>
 
 Yes — tick **One lane per channel**. A stereo file then renders two stacked
-waves (left on top, right below) sharing the image height. Off, the channels
-are downmixed to one mono wave, which is usually the cleaner look for
-artwork.
+waves (left on top, right below) sharing the image height, and a
+comma-separated **Wave color** list like `#4f46e5,#ec4899` gives each lane
+its own color. Off, the channels are downmixed to one mono wave, which is
+usually the cleaner look for artwork.
+
+</details>
+
+<details>
+<summary>Can I make bar-style or circular waveforms?</summary>
+
+Not with this tool — it draws the classic continuous waveform (ffmpeg's
+`showwavespic`), in solid or gradient color. Bar, dotted and radial
+"sound-wave art" styles need a different renderer and aren't supported here.
+What you can vary: size, colors (including alpha), gradient, background,
+per-channel lanes, amplitude scale and peak sampling.
 
 </details>
 

--- a/blocks/waveform-image/page/meta.toml
+++ b/blocks/waveform-image/page/meta.toml
@@ -1,7 +1,7 @@
 slug          = "waveform-image"
 title         = "Audio Waveform Image Generator — gizza.ai"
-description   = "Turn any audio file into a waveform PNG in your browser — pick the size, wave color and background, or keep it transparent. Nothing is uploaded."
-tags          = ["audio", "waveform", "image", "png", "visualizer", "soundwave", "podcast", "banner"]
+description   = "Turn any audio file into a waveform PNG in your browser — pick the size, solid or gradient wave colors and background, or keep it transparent. Nothing is uploaded."
+tags          = ["audio", "waveform", "image", "png", "visualizer", "soundwave", "podcast", "banner", "gradient", "stereo", "transparent"]
 h1            = "Waveform Image from Audio"
 hero_subtitle = "Pick an audio file and get a shareable waveform PNG — rendered in your browser, nothing is uploaded."
 wasm          = "gizza_ai_waveform_image_web"
@@ -33,12 +33,21 @@ name        = "color"
 source      = "field"
 label       = "Wave color"
 placeholder = "#4f46e5"
+kind        = "color"
+
+[[input]]
+name        = "color2"
+source      = "field"
+label       = "Gradient end (optional)"
+placeholder = "empty = solid — or a hex like #ec4899"
+kind        = "color"
 
 [[input]]
 name        = "background"
 source      = "field"
 label       = "Background"
 placeholder = "transparent — or a hex like #0b1220"
+kind        = "color"
 
 [[input]]
 name   = "split_channels"
@@ -49,3 +58,32 @@ label  = "One lane per channel"
 name   = "scale"
 source = "field"
 label  = "Amplitude scale"
+
+[[input]]
+name   = "sampling"
+source = "field"
+label  = "Sampling"
+
+[[example]]
+label  = "Social banner (dark)"
+params = { width = "1200", height = "300", color = "#4f46e5", color2 = "", background = "#0b1220" }
+
+[[example]]
+label  = "Sunset gradient"
+params = { color = "#f97316", color2 = "#ec4899", background = "#0b1220" }
+
+[[example]]
+label  = "Transparent overlay"
+params = { color = "#4f46e5", color2 = "", background = "" }
+
+[[example]]
+label  = "Square post 1080×1080"
+params = { width = "1080", height = "1080" }
+
+[[example]]
+label  = "Stereo lanes"
+params = { color = "#4f46e5,#ec4899", color2 = "", split_channels = "true" }
+
+[[example]]
+label  = "Quiet voice boost"
+params = { scale = "log", sampling = "peak" }

--- a/blocks/waveform-image/src/lib.rs
+++ b/blocks/waveform-image/src/lib.rs
@@ -39,11 +39,15 @@ struct Args {
     #[serde(default)]
     color: Option<String>,
     #[serde(default)]
+    color2: Option<String>,
+    #[serde(default)]
     background: Option<String>,
     #[serde(default)]
     split_channels: Option<bool>,
     #[serde(default)]
     scale: Option<String>,
+    #[serde(default)]
+    sampling: Option<String>,
 }
 
 /// Single-source param descriptor → chat schema (and CLI + page). The
@@ -67,11 +71,15 @@ fn descriptor() -> ToolDescriptor {
         .param(
             Param::string("color")
                 .default("#4f46e5")
-                .describe("Waveform color as #RGB or #RRGGBB hex, e.g. #4f46e5 or #f00. Default #4f46e5."),
+                .describe("Waveform color as hex: #RGB, #RRGGBB or #RRGGBBAA (alpha), e.g. #4f46e5 or #f00. With split_channels, a comma-separated list colors each channel (e.g. #ff0000,#0000ff). Default #4f46e5."),
+        )
+        .param(
+            Param::string("color2")
+                .describe("Optional gradient end color (same hex forms). When set, the wave is filled with a horizontal left-to-right gradient from color to color2; color must then be a single value. Empty = solid color."),
         )
         .param(
             Param::string("background")
-                .describe("Background color as #RGB or #RRGGBB hex, e.g. #000000. Empty or omitted keeps the background transparent (the PNG has an alpha channel)."),
+                .describe("Background color as hex: #RGB, #RRGGBB or #RRGGBBAA — e.g. #000000, or #00000080 for a see-through scrim. Empty or omitted keeps the background transparent (the PNG has an alpha channel)."),
         )
         .param(
             Param::boolean("split_channels")
@@ -82,6 +90,11 @@ fn descriptor() -> ToolDescriptor {
             Param::enumv("scale", ["lin", "sqrt", "cbrt", "log"])
                 .default("lin")
                 .describe("Amplitude scale. lin is the true waveform; sqrt, cbrt and log progressively boost quiet audio so it stays visible. Default lin."),
+        )
+        .param(
+            Param::enumv("sampling", ["average", "peak"])
+                .default("average")
+                .describe("Per-pixel-column sampling. average (default) draws the mean amplitude; peak draws the loudest sample — a fuller wave that keeps short hits visible. Default average."),
         )
 }
 
@@ -103,7 +116,7 @@ struct WaveformImage;
     summary = "Render a static waveform PNG image from an audio file",
     requires = ["wafer-run/network", "gizza-ai/ffmpeg-runtime"],
     skill(
-        description = "Render a static waveform PNG image from an audio file (any format ffmpeg decodes: mp3, wav, flac, ogg, m4a, opus, ...). Provide either url (HTTP/HTTPS) or ref (id from a prior tool call). width x height set the image size in pixels (default 1200x300); color is the wave's #RRGGBB hex (default #4f46e5); background is an optional #RRGGBB hex (empty = transparent PNG); split_channels draws one lane per channel instead of a single mono wave; scale (lin|sqrt|cbrt|log) boosts quiet audio's visibility. Output is always a PNG image.",
+        description = "Render a static waveform PNG image from an audio file (any format ffmpeg decodes: mp3, wav, flac, ogg, m4a, opus, ...). Provide either url (HTTP/HTTPS) or ref (id from a prior tool call). width x height set the image size in pixels (default 1200x300); color is the wave's hex color (default #4f46e5; alpha via #RRGGBBAA; a comma-separated list colors split channels); color2 turns the wave into a horizontal color->color2 gradient; background is an optional hex (empty = transparent PNG); split_channels draws one lane per channel instead of a single mono wave; scale (lin|sqrt|cbrt|log) boosts quiet audio's visibility; sampling=peak draws the loudest sample per column for a fuller wave. Output is always a PNG image.",
         parameters = schema_json()
     ),
 )]
@@ -123,9 +136,11 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
     let width = args.width.unwrap_or(0.0); // 0 = default (1200)
     let height = args.height.unwrap_or(0.0); // 0 = default (300)
     let color = args.color.as_deref().unwrap_or("");
+    let color2 = args.color2.as_deref().unwrap_or("");
     let background = args.background.as_deref().unwrap_or("");
     let split_channels = args.split_channels.unwrap_or(false);
     let scale = args.scale.as_deref().unwrap_or("");
+    let sampling = args.sampling.as_deref().unwrap_or("");
 
     // 2. Resolve source — URL fetch or attachment lookup (audio/* MIME class).
     let (input_bytes, in_mime, in_filename) =
@@ -135,7 +150,7 @@ fn run(body: Vec<u8>) -> Result<Vec<u8>, SkillError> {
     let in_ext = mime_to_ext(&in_mime).unwrap_or("mp3");
     let ffmpeg_in = format!("in.{in_ext}");
     let (argv, ffmpeg_out) = plan_waveform_image(
-        &ffmpeg_in, width, height, color, background, split_channels, scale,
+        &ffmpeg_in, width, height, color, color2, background, split_channels, scale, sampling,
     )
     .map_err(SkillError::InvalidArgs)?;
 
@@ -169,10 +184,12 @@ mod tests {
                     "ref":            { "type": "string", "description": "Reference id from a prior tool call. Use either url or ref." },
                     "width":          { "type": "integer", "minimum": 16, "maximum": 4096, "default": 1200, "description": "Output image width in pixels, 16-4096. Default 1200 (the common social-banner shape with the default height)." },
                     "height":         { "type": "integer", "minimum": 16, "maximum": 2048, "default": 300, "description": "Output image height in pixels, 16-2048. Default 300. With split_channels the height is divided across the channel lanes." },
-                    "color":          { "type": "string", "default": "#4f46e5", "description": "Waveform color as #RGB or #RRGGBB hex, e.g. #4f46e5 or #f00. Default #4f46e5." },
-                    "background":     { "type": "string", "description": "Background color as #RGB or #RRGGBB hex, e.g. #000000. Empty or omitted keeps the background transparent (the PNG has an alpha channel)." },
+                    "color":          { "type": "string", "default": "#4f46e5", "description": "Waveform color as hex: #RGB, #RRGGBB or #RRGGBBAA (alpha), e.g. #4f46e5 or #f00. With split_channels, a comma-separated list colors each channel (e.g. #ff0000,#0000ff). Default #4f46e5." },
+                    "color2":         { "type": "string", "description": "Optional gradient end color (same hex forms). When set, the wave is filled with a horizontal left-to-right gradient from color to color2; color must then be a single value. Empty = solid color." },
+                    "background":     { "type": "string", "description": "Background color as hex: #RGB, #RRGGBB or #RRGGBBAA — e.g. #000000, or #00000080 for a see-through scrim. Empty or omitted keeps the background transparent (the PNG has an alpha channel)." },
                     "split_channels": { "type": "boolean", "default": false, "description": "Draw each audio channel in its own horizontal lane instead of downmixing to one mono wave. Default false." },
-                    "scale":          { "type": "string", "enum": ["lin", "sqrt", "cbrt", "log"], "default": "lin", "description": "Amplitude scale. lin is the true waveform; sqrt, cbrt and log progressively boost quiet audio so it stays visible. Default lin." }
+                    "scale":          { "type": "string", "enum": ["lin", "sqrt", "cbrt", "log"], "default": "lin", "description": "Amplitude scale. lin is the true waveform; sqrt, cbrt and log progressively boost quiet audio so it stays visible. Default lin." },
+                    "sampling":       { "type": "string", "enum": ["average", "peak"], "default": "average", "description": "Per-pixel-column sampling. average (default) draws the mean amplitude; peak draws the loudest sample — a fuller wave that keeps short hits visible. Default average." }
                 },
                 "additionalProperties": false,
                 "oneOf": [

--- a/blocks/waveform-image/web/src/lib.rs
+++ b/blocks/waveform-image/web/src/lib.rs
@@ -3,8 +3,9 @@
 //! page driver runs it through the browser ffmpeg bridge.
 //!
 //! Page field order (meta.toml) MUST match this param order: `width`,
-//! `height`, `color`, `background`, `split_channels`, `scale`, then the file
-//! (`in_name`). `tool.js` calls `build_argv(...fieldArgs, inName)`.
+//! `height`, `color`, `color2`, `background`, `split_channels`, `scale`,
+//! `sampling`, then the file (`in_name`). `tool.js` calls
+//! `build_argv(...fieldArgs, inName)`.
 
 use wasm_bindgen::prelude::*;
 
@@ -12,25 +13,31 @@ use gizza_ai_block_utils::ArgvPlan;
 use gizza_ai_waveform_image_core::plan_waveform_image;
 
 /// `width`/`height` are the image size in pixels (empty page fields arrive as
-/// `0.0` → the 1200×300 defaults). `color`/`background` are `#RGB`/`#RRGGBB`
-/// hex strings (empty color → the default accent, empty background →
-/// transparent). `split_channels` is the checkbox value string (positive
-/// truthy) and `scale` is `lin|sqrt|cbrt|log` (empty → lin). Returns
+/// `0.0` → the 1200×300 defaults). `color` is a hex color (or comma-separated
+/// per-channel list; empty → the default accent), `color2` an optional
+/// gradient end color, `background` a hex (empty → transparent) — all accept
+/// `#RGB`/`#RGBA`/`#RRGGBB`/`#RRGGBBAA`. `split_channels` is the checkbox
+/// value string (positive truthy), `scale` is `lin|sqrt|cbrt|log` (empty →
+/// lin) and `sampling` is `average|peak` (empty → average). Returns
 /// `{ argv, out_name }` (out_name is always `out.png`) or throws.
 #[wasm_bindgen]
+#[allow(clippy::too_many_arguments)] // mirrors the page field order 1:1
 pub fn build_argv(
     width: f64,
     height: f64,
     color: &str,
+    color2: &str,
     background: &str,
     split_channels: &str,
     scale: &str,
+    sampling: &str,
     in_name: &str,
 ) -> Result<JsValue, JsValue> {
     let split_on = matches!(split_channels, "true" | "1" | "on" | "yes");
-    let (argv, out_name) =
-        plan_waveform_image(in_name, width, height, color, background, split_on, scale)
-            .map_err(|e| JsValue::from_str(&e))?;
+    let (argv, out_name) = plan_waveform_image(
+        in_name, width, height, color, color2, background, split_on, scale, sampling,
+    )
+    .map_err(|e| JsValue::from_str(&e))?;
     serde_wasm_bindgen::to_value(&ArgvPlan { argv, out_name })
         .map_err(|e| JsValue::from_str(&e.to_string()))
 }

--- a/docs/checks/2026-07-03-improve-waveform-image-competitor-analysis.md
+++ b/docs/checks/2026-07-03-improve-waveform-image-competitor-analysis.md
@@ -1,63 +1,135 @@
 # waveform-image — competitor analysis (2026-07-03)
 
-One WebSearch ("online audio waveform image generator PNG tool"); skimmed the top real
-tools: Audioalter waveform-image, lotsofsounds waveform generator, Elysia Tools audio
-waveform generator (itself showwavespic-based), plus WaveVisual / audiowaveform.org /
-Verbatik for the out-of-model art end of the market.
+Two passes. **Build-time pass** (kept below for the record): one WebSearch + skim of the
+top tools, which set the v1 param set (size, colors, transparent background, split
+channels, scale). **Improve pass** (this update): 5 parallel read-only researcher
+subagents, one per competitor, each driving/scraping the live tool and returning the
+competitor-profile schema. Everything paraphrased; no copy, branding or assets taken.
 
-## Table stakes observed (paraphrased)
+## The 5 competitors profiled (improve pass)
 
-| Capability | Seen at | Fit | Decision |
+### 1. Audioalter Waveform Image — audioalter.com/waveform
+- Server-side (uploads to their API, 50 MB cap, files deleted after hours) — our
+  browser-local angle is the direct counter.
+- Params: 6 size presets (all wide 8:1 strips, default 1920×240) + custom width/height
+  (100–4000); wave + background colors via a Chrome-style **rgba picker with alpha
+  sliders and checkerboard swatches** (default: opaque blue on fully transparent).
+- Input mp3/wav/flac/ogg; output PNG (8-bit RGBA) only. No styles, no channel split, no
+  live preview, filename is a server UUID.
+- UX: progressive disclosure (preset select + "custom size" checkbox gate), side-by-side
+  color swatches, processing-status page, result page with inline preview + share.
+- SEO: "your size and colors" pitch, amplitude=loudness mini-education, format list in
+  the meta description, privacy/deletion FAQ.
+
+### 2. lotsofsounds Waveform Generator — lotsofsounds.com/tools/waveform-generator
+- Browser-local (Web Audio + canvas), strong privacy copy. Fixed 1200×300 PNG out.
+- Params: 31 five-stop **gradient presets** (marketing says 32 — off-by-one in their
+  bundle), 3 styles (square/rounded bars, outline), 3 layouts (mirror/top/bottom),
+  4 densities (80/150/250/400 bars), 4 backgrounds (transparent/white/dark/warm).
+- No custom colors/hex, no custom size, no stereo (first channel only, average-of-abs
+  buckets — soft transients), no URL state.
+- UX: dropzone → controls appear after load; swatch-grid color choice only; live
+  re-render on every change; checkerboard for transparency; file chip + remove.
+- SEO: use-case-led sections (podcast promos, video thumbnails, blog embeds), FAQ on
+  formats/limits/commercial use, footer of per-format-pair tool pages; tool is lead-gen
+  for a paid sound-library API.
+
+### 3. Serverless Tools Audio Waveform — serverless.tools/audio-waveform/
+- Browser-local (Web Audio + canvas), privacy banner, claims offline-capable.
+- Params: 3 styles (bars/mirror/line), rounded-vs-sharp toggle, **gradient mode**
+  (fixed hue-rotation of the base color, not a chosen end color), wave + background
+  native color pickers (no hex text), transparent-background checkbox, width 400–2400 /
+  height 100–800 **sliders**, bar width 1–12, bar gap 0–6.
+- RMS per bucket normalized to loudest; channel 0 only; PNG-only export ("Export SVG"
+  strings exist in their i18n table but no button — planned/dropped).
+- UX: two-pane workspace (280px control column + live canvas), controls grouped into
+  Style/Colors/Dimensions cards, sliders with live readouts, metadata chips (duration,
+  sample rate, channels), toast on download, 5-language UI.
+- SEO: long-form article below the tool (features/use-cases/privacy/FAQ), overlay-for-
+  video-editors angle, names the browser APIs as credibility copy.
+
+### 4. WaveVisual — wavevisual.com/audio-waveform-generator
+- A full design studio around the waveform: 7 styles (mirrored/one-sided bars, radial,
+  circular outline, bezier, dotted), **multi-color segment waves + gradient direction**,
+  ~60 background gradient presets, text overlays with fonts/shadows, QR-code-to-audio,
+  layers, ~17 canvas ratios incl. print sizes, trimming, mic/Spotify import.
+- Exports PNG/JPG/SVG/PDF/MP4/GIF/WebM/ProRes-alpha up to 12000px — but free tier is
+  small watermarked PNG/JPG only; paid per-design (~$9) or subscription; video renders
+  server-side.
+- UX: icon rail of task tabs, first-run "what are you making" size wizard, thumbnail
+  style grid, sliders with per-control reset, autosave/undo/share.
+- SEO: sound-wave-art-as-gift (weddings, baby's first words), print/DPI guides,
+  scannable-QR art, several keyword landing pages onto the same editor.
+
+### 5. AudioWave — audiowaveform.org
+- Really an **animated audiogram editor** (800×600 canvas, layers, text/image overlays,
+  11 waveform styles incl. circular/neon/orbital): the only working export is
+  login-gated watermarked WebM video on a credit system, despite copy promising instant
+  image downloads — a credibility gap our instant local PNG attacks directly.
+- Accepts video files as audio sources; template gallery; style thumbnails rendered in
+  the user's chosen color; native color swatches only; no size/ratio control; no
+  privacy messaging at all.
+- SEO: heavy "waveform generator free" keyword stacking, style-led examples gallery,
+  4-step how-to, product-update blog.
+
+## Gap list → decisions (improve pass)
+
+| Gap (≥1 competitor) | Seen at | Fit | Decision |
 |---|---|---|---|
-| Custom image size (width × height) | Audioalter (selectable size), lotsofsounds (fixed 1200×300) | in-model | `width`/`height` integer params, default 1200×300 (the social-banner shape lotsofsounds standardized on), 16–4096 / 16–2048 |
-| Custom waveform color | Audioalter, WaveVisual | in-model | `color` hex param, default `#4f46e5` (site accent); strict `#RGB`/`#RRGGBB` validation (also guards the filtergraph against injection) |
-| Background color / transparent PNG | Audioalter (bg choice), lotsofsounds (transparent for embeds) | in-model | `background` hex param, empty = transparent (showwavespic's native alpha); non-empty renders a `color` source + `overlay` |
-| Broad input format support (mp3/wav/flac/ogg…) | Audioalter (mp3, wav, flac, ogg) | in-model | anything ffmpeg decodes (`audio/*` input, incl. m4a/aac/opus) |
-| PNG download | all of them | in-model | `out.png`, page `format = "image"` renders `<img>` + download link |
-| Stereo/split channel view | (pro tools; showwavespic native option) | in-model | `split_channels` boolean — off = clean mono downmix (one wave), on = one lane per channel |
-| Quiet-audio visibility (log/compressed view) | audio editors; showwavespic native `scale` | in-model | `scale` enum lin/sqrt/cbrt/log, default lin |
-| Bar / circular / "sound wave art" styles | WaveVisual, audiowaveform.org | out-of-model | showwavespic draws sample lines only; bar/radial rendering would need a custom rasterizer — listed, not built |
-| SVG / PDF / MP4 export | WaveVisual, Verbatik | out-of-model | PNG only; animated waveform video is the separate `audiogram` backlog item |
-| Spotify/track-URL import | WaveVisual | out-of-model | page is file-upload; CLI/chat accept a public audio URL which covers the linkable case |
+| Gradient-colored wave | lotsofsounds (31 presets), serverless (hue-shift), WaveVisual (multi-color+direction) | in-model | `color2` param: horizontal left→right `gradients`+`alphaextract`+`alphamerge` fill; verified in system ffmpeg (CLI) and @ffmpeg/core (page) |
+| Color picker UX (not bare text) | Audioalter (rgba picker), serverless + audiowaveform (native pickers), WaveVisual (swatch rows) | in-model | NEW declarative `kind = "color"` in the shared generator: native swatch two-way mirrored onto the canonical hex TEXT input — keeps empty=transparent/default, alpha hex and comma lists expressible (a bare `<input type=color>` can't say "transparent") |
+| Alpha in colors (translucent wave/scrim) | Audioalter (alpha sliders on both colors) | in-model | accept `#RGBA`/`#RRGGBBAA` everywhere (e.g. `background=#00000080`); corner alpha 128 verified end-to-end |
+| Per-channel lane colors | WaveVisual (multi-color), pro tools | in-model | `color` accepts a comma list (≤8), joined to showwavespic's pipe syntax; stereo fixture renders red top lane / blue bottom lane |
+| Fuller/peakier wave (transients) | their bar styles read "full"; both local competitors average-only (soft transients — their stated weakness) | in-model | `sampling` enum average\|peak (showwavespic `filter=peak`); peak > average wave-pixel count asserted on page + CLI |
+| Size/shape presets | Audioalter (6 presets + custom gate), WaveVisual (17 ratios) | in-model | 6 `[[example]]` chips (banner, square post, stereo lanes, sunset gradient, overlay, quiet-voice boost) — presets without a new control |
+| Runnable examples everywhere | all (their pages show real values) | in-model | CLI/deep-link samples: `kind=color` sample rule uses the hex placeholder/schema default and OMITS "empty means transparent" fields (fixes the previous `background=transparent — or a hex like #0b1220` non-runnable example) |
+| Bar / dotted / circular / neon styles | lotsofsounds, serverless, WaveVisual, audiowaveform | out-of-model | needs a custom rasterizer, not showwavespic; honestly FAQ'd ("Can I make bar-style or circular waveforms?") |
+| SVG/PDF vector, video/audiogram export | WaveVisual, audiowaveform | out-of-model | PNG only; animated waveform video is the separate `audiogram` backlog item |
+| Text/logo/QR overlay compositing, background images, templates | WaveVisual, audiowaveform | out-of-model | design-studio scope; background *image* would also need a second file input (page framework supports one) |
+| Spotify/mic import | WaveVisual | out-of-model | page is file-upload; CLI/chat accept a public URL which covers the linkable case |
+| Demo/sample audio to try without a file | WaveVisual | out-of-model (for now) | would mean bundling an audio asset into the page; noted as a possible platform follow-up |
 
-## Design decisions
+**Bug found by re-verifying deeper (not a competitor gap):** the advertised `#RGB`
+short hex (e.g. `#f00`) passed our validation but ffmpeg's color parser only knows
+`#RRGGBB[AA]` — it warned and silently drew a **white** wave on every surface. Fix at
+root cause: `parse_hex_color` now expands 3/4-digit forms before interpolation
+(regression-tested in core, on the page, and via the CLI).
 
-- Single ffmpeg invocation with `showwavespic` (`-frames:v 1 -update 1 out.png`), the exact
-  engine the closest competitor (Elysia) uses. Transparent output is showwavespic's native
-  RGBA; a background color wraps the wave chain in the ffmpeg-wiki
-  `color=c=…:s=WxH[bg];…[wave];[bg][wave]overlay` recipe (size set directly, no scale2ref
-  needed since W×H is known).
-- Mono downmix (`aformat=channel_layouts=mono`) when `split_channels` is off, so stereo
-  files render one clean wave instead of two channels blended on top of each other;
+## Design decisions (v1, build-time — still true)
+
+- Single ffmpeg invocation with `showwavespic` (`-frames:v 1 -update 1 out.png`).
+  Transparent output is showwavespic's native RGBA; a background color wraps the wave
+  chain in the ffmpeg-wiki `color=c=…:s=WxH[bg];…[wave];[bg][wave]overlay` recipe.
+- Mono downmix (`aformat=channel_layouts=mono`) when `split_channels` is off;
   `split_channels=1` skips the downmix and stacks one lane per channel.
-- Colors are strictly validated hex (`#RGB`/`#RRGGBB`, case-insensitive); empty color falls
-  back to the default, empty background means transparent. This doubles as filtergraph
-  hardening — the color strings are interpolated into `-filter_complex`.
-- Dimensions arrive as f64 from the page (empty = 0 = default); they are rounded, then
-  range-checked 16–4096 × 16–2048 with guiding error messages.
-- `scale` (lin|sqrt|cbrt|log) exposed because quiet recordings render as a near-flat line
-  in linear scale — the FAQ points quiet-file users at sqrt/log.
-- Family invariants kept: `Input::Audio` descriptor (url⊕ref), 10 MiB in/out caps,
-  `-waveform.png` filename suffix, drift-guard schema test, chat surface documented as
-  page+CLI only (SW ffmpeg constraint).
+- Colors strictly validated hex (filtergraph hardening — they are interpolated into
+  `-filter_complex`); empty color → default, empty background → transparent.
+- Dimensions arrive as f64 (empty = 0 = default), rounded, range-checked 16–4096 ×
+  16–2048 with guiding error messages.
+- `scale` (lin|sqrt|cbrt|log) exposed for quiet recordings.
+- Family invariants: `Input::Audio` descriptor (url⊕ref), 10 MiB caps,
+  `-waveform.png` suffix, drift-guard schema test, chat surface = page + CLI only
+  (Service-Worker ffmpeg constraint).
 
-## Verification (all run, all green)
+## Verification (improve pass — all run, all green)
 
-- Recipes pre-verified against local ffmpeg before any wasm build: plain/background/split
-  graphs each produced RGBA PNGs at the exact requested size; PIL decode confirmed a
-  transparent corner + #4f46e5 wave pixels (plain), an opaque black corner + red wave
-  (background), and per-channel lanes (split).
-- Unit: 12 core tests + 2 block tests (argv exactness for default/bg/split/scale paths,
-  hex + dimension validation, injection rejection, inclusive bounds, drift guard,
-  `-waveform.png` filename suffix). `wafer build` validates the chat block wasm (545.9 KiB).
-- CLI vs the public beep_short.ogg: default run → 1200×300 PNG, transparent corner, wave
-  pixels present; `width=640 height=200 color=#ff0000 background=#000000` → 640×200 PNG
-  with opaque black corner and 269 red wave pixels; exact-output error cases: `width=4097`
-  → "width must be between 16 and 4096 pixels (0 or empty = 1200), got 4097"; `color=red`
-  → "color must be a hex color like #4f46e5 or #f00, got \"red\"".
-- Playwright (4/4): 320×100 render decoded via canvas — asserts naturalWidth/Height match
-  the REQUEST (not the default), corner alpha 0, >100 indigo wave pixels; background run
-  asserts opaque black corners, full-canvas opacity and a red wave; named-color run asserts
-  the guiding hex error; deep-link `?width=320&height=100&color=%23ff0000&scale=sqrt`
-  asserts prefills, then renders red wave pixels at the requested size.
-- `python3 scripts/check-tool-hygiene.py waveform-image` → exit 0 (strict per-slug mode).
+- Recipes pre-verified against local ffmpeg before any wasm build: gradient
+  (`gradients`+`alphaextract`+`alphamerge`), gradient+background overlay,
+  gradient+split+peak, per-channel pipe colors on a stereo file, `#RRGGBBAA` scrim
+  (corner alpha 128) — and the `#f00` failure mode reproduced (white wave + warning).
+- Unit: 22 core tests + 2 block tests (drift-guard REGENERATED for the 2 new params +
+  reworded color descriptions; argv exactness for gradient/peak/list paths; expansion,
+  alpha, cap and injection cases). `wafer build` validates the chat block (554.3 KiB).
+- Generator: 46 tests incl. new `kind=color` control, swatch-default seeding,
+  `expand_hex` normalization, and the runnable-CLI-example omit rule.
+- Playwright 10/10: the 4 pre-existing cases plus 3-digit-hex regression, gradient
+  left-red/right-blue pixel assertion (proves @ffmpeg/core ships the gradient filters),
+  stereo per-channel lanes, peak>average pixel count, "Sunset gradient" example chip
+  (prefills + re-render + opaque background), swatch→text mirror pick that re-runs.
+- CLI vs the public beep_short.ogg: `color=#f00` → 60 red px (was white);
+  gradient → left-red, transparent corners; `sampling=peak` → 205 px vs 60 default;
+  `background=#00000080` → corner (0,0,0,128); guiding errors for `color2` with a
+  color list and for `sampling=rms`.
+- `python3 scripts/check-tool-hygiene.py waveform-image` → exit 0 (strict per-slug).
+- `npm test` (js unit) 41/41; `solobase build` intentionally skipped (throughput rule);
+  no wafer `tests/*.json` fixtures exist for the ffmpeg family (noted, not invented).

--- a/site/tool.css
+++ b/site/tool.css
@@ -36,6 +36,12 @@ body { margin: 0; font-family: system-ui, -apple-system, "Segoe UI", Roboto, san
 .tool-slider-row .tool-input { width: 92px; flex: 0 0 auto; }
 .tool-slider { flex: 1 1 auto; min-width: 0; margin: 6px 0 12px;
   accent-color: var(--tool-accent); cursor: pointer; }
+/* kind="color": native swatch + canonical hex text pair (tool.js mirrors). */
+.tool-color-row { display: flex; align-items: center; gap: 12px; }
+.tool-color-row .tool-input { flex: 1 1 auto; min-width: 0; }
+.tool-color-swatch { flex: 0 0 auto; width: 44px; height: 38px; padding: 2px;
+  margin: 6px 0 12px; background: #fff; border: 1px solid #cbd5e1;
+  border-radius: 8px; cursor: pointer; }
 /* pre-wrap: multi-line text results (bitwise-calculator, asn1-parser, …) render
    as real lines instead of collapsing into one wrapped paragraph; single-line
    results are unaffected. */

--- a/site/tool.js
+++ b/site/tool.js
@@ -12,9 +12,9 @@ const out = document.getElementById(cfg.output.elementId);
 //   setup(ctx)                → one-time setup; return true to TAKE OVER wiring
 //   renderResult(value, ctx)  → return true if the result was rendered
 //   renderError(message, ctx) → return true if the error was rendered
-// Prefer the declarative meta.toml controls (kind incl. slider/options/default/
-// [[example]]/wide); custom.js is only for layouts/renderers those can't
-// express. Do NOT add per-tool slug branches to this file.
+// Prefer the declarative meta.toml controls (kind incl. slider/color/options/
+// default/[[example]]/wide); custom.js is only for layouts/renderers those
+// can't express. Do NOT add per-tool slug branches to this file.
 let custom = {};
 let customCtx = null;
 
@@ -121,6 +121,7 @@ function wireWidgetChrome(rerun) {
       }
       refreshTagLists();
       refreshSliders();
+      refreshColors();
       rerun();
     });
   }
@@ -149,6 +150,7 @@ function wireWidgetChrome(rerun) {
       applyMetaDefaults(true);
       refreshTagLists();
       refreshSliders();
+      refreshColors();
       const media = document.getElementById("tool-output-media");
       const dl = document.getElementById("tool-output-download");
       if (media) media.hidden = true;
@@ -227,6 +229,55 @@ function wireSliders() {
     });
   }
   refreshSliders();
+}
+
+// ---- Generic color mirror (meta kind="color") ----
+// A native color swatch (id "in-<name>-swatch", data-for="in-<name>") mirrors
+// the canonical hex TEXT input two-way. The text stays the source of truth:
+// empty (transparent / tool default), alpha hex (#RRGGBBAA) and comma lists
+// are all valid there but inexpressible in a native picker. Same commit
+// discipline as sliders: picking mirrors live without events; closing the
+// picker dispatches ONE change on the text input.
+
+// Normalize #RGB/#RGBA/#RRGGBB/#RRGGBBAA to the #rrggbb form the native
+// picker accepts (alpha dropped), or null when not a single hex color.
+function expandHex(v) {
+  const m = /^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i.exec(String(v).trim());
+  if (!m) return null;
+  let h = m[1];
+  if (h.length <= 4) h = [...h].map((c) => c + c).join("");
+  return "#" + h.slice(0, 6).toLowerCase();
+}
+
+// Re-sync every swatch from its text input (after programmatic value writes:
+// example chips, reset, deep-links). An empty/non-hex text falls back to the
+// rendered value attribute (the schema default) or the element's own black.
+function refreshColors() {
+  for (const s of document.querySelectorAll(".tool-color-swatch")) {
+    const el = document.getElementById(s.dataset.for);
+    if (!el) continue;
+    s.value = expandHex(el.value) || expandHex(s.defaultValue) || "#000000";
+  }
+}
+
+function wireColors() {
+  for (const s of document.querySelectorAll(".tool-color-swatch")) {
+    const el = document.getElementById(s.dataset.for);
+    if (!el) continue;
+    s.addEventListener("input", () => {
+      el.value = s.value; // live mirror — programmatic writes fire no events
+      if (cfg.runtime !== "ffmpeg") el.dispatchEvent(new Event("input"));
+    });
+    s.addEventListener("change", () => {
+      el.value = s.value;
+      el.dispatchEvent(new Event("change")); // exactly one run per pick
+    });
+    el.addEventListener("input", () => {
+      const hex = expandHex(el.value);
+      if (hex) s.value = hex;
+    });
+  }
+  refreshColors();
 }
 
 // ---- Generic tag-list widget (meta kind="tag-list") ----
@@ -522,6 +573,7 @@ async function main() {
     applyMetaDefaults();
     wireTagLists();
     wireSliders();
+    wireColors();
     wireWidgetChrome(run);
     if (custom.setup && custom.setup({ ...customCtx, run, fileInput, fieldInputs }) === true) {
       return; // custom module owns all wiring for this tool
@@ -592,6 +644,7 @@ async function main() {
   applyMetaDefaults();
   wireTagLists();
   wireSliders();
+  wireColors();
   wireWidgetChrome(compute);
   if (custom.setup && custom.setup({ ...customCtx, compute }) === true) {
     return; // custom module owns all wiring for this tool

--- a/tests/tool-page-waveform-image.spec.ts
+++ b/tests/tool-page-waveform-image.spec.ts
@@ -12,6 +12,7 @@ import path from 'node:path';
 // opaque background corners.
 
 const FIXTURE = path.resolve(__dirname, 'fixtures/tone-3s.mp3');
+const STEREO_FIXTURE = path.resolve(__dirname, 'fixtures/tone-stereo-3s.mp3');
 
 type Decoded = {
   w: number;
@@ -125,6 +126,8 @@ test('waveform-image deep link prefills size, color and scale, then renders', as
   await expect(page.locator('#in-height')).toHaveValue('100');
   await expect(page.locator('#in-color')).toHaveValue('#ff0000');
   await expect(page.locator('#in-scale')).toHaveValue('sqrt');
+  // The color swatch (kind="color") mirrors the deep-linked text value.
+  await expect(page.locator('#in-color-swatch')).toHaveValue('#ff0000');
   await page.setInputFiles('#in-audio', FIXTURE);
   const media = page.locator('#tool-output-media');
   await expect(media).toBeVisible({ timeout: 90_000 });
@@ -135,4 +138,190 @@ test('waveform-image deep link prefills size, color and scale, then renders', as
   expect(png.h).toBe(100);
   expect(png.corner[3]).toBe(0); // still transparent (no background set)
   expect(png.wavePx).toBeGreaterThan(100); // red wave, sqrt-boosted
+});
+
+// REGRESSION: a 3-digit hex used to reach ffmpeg raw, which warns and
+// silently draws a WHITE wave. Core now expands #f00 → #ff0000.
+test('waveform-image renders a 3-digit hex as the actual color, not white', async ({
+  page,
+}) => {
+  await page.goto('/tools/waveform-image/');
+  await page.waitForSelector('#in-audio');
+  await page.fill('#in-width', '320');
+  await page.fill('#in-height', '100');
+  await page.fill('#in-color', '#f00');
+  await page.setInputFiles('#in-audio', FIXTURE);
+  const media = page.locator('#tool-output-media');
+  await expect(media).toBeVisible({ timeout: 90_000 });
+  const png = await decodePng(page, (await media.getAttribute('src'))!, 'red');
+  expect(png.wavePx).toBeGreaterThan(100); // red wave — the bug drew 0 red px
+});
+
+// Gradient wave (color2): also proves the browser ffmpeg build supports the
+// gradients/alphaextract/alphamerge chain the recipe uses.
+test('waveform-image gradient run fades red on the left to blue on the right', async ({
+  page,
+}) => {
+  await page.goto('/tools/waveform-image/');
+  await page.waitForSelector('#in-audio');
+  await page.fill('#in-width', '320');
+  await page.fill('#in-height', '100');
+  await page.fill('#in-color', '#ff0000');
+  await page.fill('#in-color2', '#0000ff');
+  await page.setInputFiles('#in-audio', FIXTURE);
+  const media = page.locator('#tool-output-media');
+  await expect(media).toBeVisible({ timeout: 90_000 });
+  const src = await media.getAttribute('src');
+  const sides = await page.evaluate(async (dataUrl) => {
+    const img = new Image();
+    await new Promise<void>((res, rej) => {
+      img.onload = () => res();
+      img.onerror = rej;
+      img.src = dataUrl;
+    });
+    const c = document.createElement('canvas');
+    c.width = img.naturalWidth;
+    c.height = img.naturalHeight;
+    const ctx = c.getContext('2d')!;
+    ctx.drawImage(img, 0, 0);
+    const d = ctx.getImageData(0, 0, c.width, c.height).data;
+    let leftRed = 0;
+    let rightBlue = 0;
+    for (let y = 0; y < c.height; y++) {
+      for (let x = 0; x < c.width; x++) {
+        const i = (y * c.width + x) * 4;
+        const [r, g, b, a] = [d[i], d[i + 1], d[i + 2], d[i + 3]];
+        if (a > 0 && x < c.width / 4 && r > 150 && b < 110) leftRed++;
+        if (a > 0 && x >= (3 * c.width) / 4 && b > 150 && r < 110) rightBlue++;
+      }
+    }
+    return { w: c.width, h: c.height, corner: d[3], leftRed, rightBlue };
+  }, src!);
+  expect(sides.w).toBe(320);
+  expect(sides.h).toBe(100);
+  expect(sides.corner).toBe(0); // background still transparent
+  expect(sides.leftRed).toBeGreaterThan(50); // gradient start
+  expect(sides.rightBlue).toBeGreaterThan(50); // gradient end
+});
+
+// Per-channel colors: a stereo file with split lanes and a comma list draws
+// the left channel red (top lane) and the right channel blue (bottom lane).
+test('waveform-image stereo split lanes take per-channel colors', async ({ page }) => {
+  await page.goto('/tools/waveform-image/');
+  await page.waitForSelector('#in-audio');
+  await page.fill('#in-width', '320');
+  await page.fill('#in-height', '100');
+  await page.fill('#in-color', '#ff0000,#0000ff');
+  await page.check('#in-split_channels');
+  await page.setInputFiles('#in-audio', STEREO_FIXTURE);
+  const media = page.locator('#tool-output-media');
+  await expect(media).toBeVisible({ timeout: 90_000 });
+  const src = await media.getAttribute('src');
+  const lanes = await page.evaluate(async (dataUrl) => {
+    const img = new Image();
+    await new Promise<void>((res, rej) => {
+      img.onload = () => res();
+      img.onerror = rej;
+      img.src = dataUrl;
+    });
+    const c = document.createElement('canvas');
+    c.width = img.naturalWidth;
+    c.height = img.naturalHeight;
+    const ctx = c.getContext('2d')!;
+    ctx.drawImage(img, 0, 0);
+    const d = ctx.getImageData(0, 0, c.width, c.height).data;
+    let topRed = 0;
+    let bottomBlue = 0;
+    for (let y = 0; y < c.height; y++) {
+      for (let x = 0; x < c.width; x++) {
+        const i = (y * c.width + x) * 4;
+        const [r, , b, a] = [d[i], d[i + 1], d[i + 2], d[i + 3]];
+        if (a > 0 && y < c.height / 2 && r > 150 && b < 100) topRed++;
+        if (a > 0 && y >= c.height / 2 && b > 150 && r < 100) bottomBlue++;
+      }
+    }
+    return { topRed, bottomBlue };
+  }, src!);
+  expect(lanes.topRed).toBeGreaterThan(100);
+  expect(lanes.bottomBlue).toBeGreaterThan(100);
+});
+
+// sampling=peak draws the loudest sample per column — strictly more wave
+// pixels than the default average on the same input.
+test('waveform-image peak sampling draws a fuller wave than average', async ({ page }) => {
+  await page.goto('/tools/waveform-image/');
+  await page.waitForSelector('#in-audio');
+  await page.fill('#in-width', '320');
+  await page.fill('#in-height', '100');
+  await page.setInputFiles('#in-audio', FIXTURE);
+  const media = page.locator('#tool-output-media');
+  await expect(media).toBeVisible({ timeout: 90_000 });
+  const avgSrc = (await media.getAttribute('src'))!;
+  const avg = await decodePng(page, avgSrc, 'indigo');
+  await page.selectOption('#in-sampling', 'peak');
+  // The change re-runs ffmpeg; wait for the media src to change.
+  await expect
+    .poll(async () => await media.getAttribute('src'), { timeout: 90_000 })
+    .not.toBe(avgSrc);
+  const peak = await decodePng(page, (await media.getAttribute('src'))!, 'indigo');
+  expect(peak.wavePx).toBeGreaterThan(avg.wavePx);
+});
+
+// The "Sunset gradient" example chip pre-fills the gradient + background and
+// re-renders; the color swatches mirror the chip's hex values.
+test('waveform-image example chip applies a gradient preset and re-renders', async ({
+  page,
+}) => {
+  await page.goto('/tools/waveform-image/');
+  await page.waitForSelector('#in-audio');
+  await page.fill('#in-width', '320');
+  await page.fill('#in-height', '100');
+  await page.setInputFiles('#in-audio', FIXTURE);
+  const media = page.locator('#tool-output-media');
+  await expect(media).toBeVisible({ timeout: 90_000 });
+  await page.click('.tool-example-chip:has-text("Sunset gradient")');
+  await expect(page.locator('#in-color')).toHaveValue('#f97316');
+  await expect(page.locator('#in-color2')).toHaveValue('#ec4899');
+  await expect(page.locator('#in-background')).toHaveValue('#0b1220');
+  await expect(page.locator('#in-color-swatch')).toHaveValue('#f97316');
+  await expect(page.locator('#in-color2-swatch')).toHaveValue('#ec4899');
+  await expect(media).toBeVisible({ timeout: 90_000 });
+  await expect
+    .poll(
+      async () => {
+        const png = await decodePng(page, (await media.getAttribute('src'))!, 'red');
+        return png.corner[3];
+      },
+      { timeout: 90_000 },
+    )
+    .toBe(255); // the chip's #0b1220 background is opaque
+});
+
+// The native swatch is a two-way mirror: picking a color writes the hex into
+// the canonical text input (which the run reads).
+test('waveform-image color swatch pick updates the hex field and runs', async ({ page }) => {
+  await page.goto('/tools/waveform-image/');
+  await page.waitForSelector('#in-audio');
+  await page.fill('#in-width', '320');
+  await page.fill('#in-height', '100');
+  await page.setInputFiles('#in-audio', FIXTURE);
+  const media = page.locator('#tool-output-media');
+  await expect(media).toBeVisible({ timeout: 90_000 });
+  // Drive the swatch the way a user's picker-close does (input + change).
+  await page.evaluate(() => {
+    const s = document.getElementById('in-color-swatch') as HTMLInputElement;
+    s.value = '#ff0000';
+    s.dispatchEvent(new Event('input'));
+    s.dispatchEvent(new Event('change'));
+  });
+  await expect(page.locator('#in-color')).toHaveValue('#ff0000');
+  await expect
+    .poll(
+      async () => {
+        const png = await decodePng(page, (await media.getAttribute('src'))!, 'red');
+        return png.wavePx;
+      },
+      { timeout: 90_000 },
+    )
+    .toBeGreaterThan(100); // re-ran with the picked red
 });

--- a/tools/generator/src/control.rs
+++ b/tools/generator/src/control.rs
@@ -62,6 +62,16 @@ pub enum Control {
     Picker {
         input_type: String,
     },
+    /// A hex-color text input paired with a native `<input type="color">`
+    /// swatch (meta `kind = "color"`). The TEXT input keeps the canonical
+    /// `in-<name>` id — it stays the source of truth so empty ("transparent"/
+    /// "use the default"), alpha hex (`#RRGGBBAA`) and multi-color lists stay
+    /// expressible, which a bare native picker can't do. The swatch mirrors it
+    /// two-way via `site/tool.js`. `default` is the schema default hex, shown
+    /// on the swatch at rest.
+    Color {
+        default: Option<String>,
+    },
     /// A text input backed by a `<datalist>` of a named vocabulary (meta `options`).
     Datalist {
         options: Vec<String>,
@@ -72,6 +82,24 @@ pub enum Control {
     TagList {
         options: Vec<String>,
     },
+}
+
+/// Validate a `#RGB`/`#RGBA`/`#RRGGBB`/`#RRGGBBAA` hex color and expand it to
+/// the 6-digit `#rrggbb` form a native `<input type="color">` accepts (alpha
+/// digits are dropped — the swatch can't show alpha). `None` when `s` isn't a
+/// single hex color (empty, named color, multi-color list, …).
+pub fn expand_hex(s: &str) -> Option<String> {
+    let v = s.trim();
+    let digits = v.strip_prefix('#')?;
+    if !matches!(digits.len(), 3 | 4 | 6 | 8) || !digits.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    let full: String = if digits.len() <= 4 {
+        digits.chars().flat_map(|c| [c, c]).collect()
+    } else {
+        digits.to_string()
+    };
+    Some(format!("#{}", full[..6].to_ascii_lowercase()))
 }
 
 /// One tool's param schema: param name → its JSON-schema property object.
@@ -120,6 +148,17 @@ impl ParamSchema {
             k @ ("date" | "time" | "datetime-local") => {
                 return Control::Picker { input_type: k.to_string() };
             }
+            "color" => {
+                // Text stays canonical (empty/alpha/lists work); the swatch
+                // is a mirror. The schema default (if any) seeds the swatch.
+                let default = self
+                    .0
+                    .get(&input.name)
+                    .and_then(|p| p.get("default"))
+                    .and_then(|d| d.as_str())
+                    .map(String::from);
+                return Control::Color { default };
+            }
             "slider" => {
                 // A slider needs real bounds; only a numeric param with both
                 // min and max in the schema qualifies. Anything else falls back
@@ -151,7 +190,7 @@ impl ParamSchema {
             }
             other => {
                 eprintln!(
-                    "warning: [[input]] \"{}\" has unknown kind \"{other}\" (want date|time|datetime-local|tag-list|slider) — falling back to the schema control",
+                    "warning: [[input]] \"{}\" has unknown kind \"{other}\" (want date|time|datetime-local|color|tag-list|slider) — falling back to the schema control",
                     input.name
                 );
             }
@@ -393,8 +432,35 @@ mod tests {
     #[test]
     fn unknown_kind_and_vocab_fall_back_to_schema_control() {
         let s = schema(json!({ "x": { "type": "string" } }));
-        assert_eq!(s.control_for_input(&field("x", "color", "")), Control::Text);
+        assert_eq!(s.control_for_input(&field("x", "range", "")), Control::Text);
         assert_eq!(s.control_for_input(&field("x", "", "nope")), Control::Text);
+    }
+
+    #[test]
+    fn color_kind_pairs_swatch_with_text_and_takes_schema_default() {
+        let s = schema(json!({ "color": { "type": "string", "default": "#4f46e5" } }));
+        assert_eq!(
+            s.control_for_input(&field("color", "color", "")),
+            Control::Color { default: Some("#4f46e5".into()) }
+        );
+        // No schema default (e.g. "empty = transparent") → swatch has no rest value.
+        let s = schema(json!({ "background": { "type": "string" } }));
+        assert_eq!(
+            s.control_for_input(&field("background", "color", "")),
+            Control::Color { default: None }
+        );
+    }
+
+    #[test]
+    fn expand_hex_normalizes_short_and_alpha_forms_for_the_swatch() {
+        assert_eq!(expand_hex("#f00").as_deref(), Some("#ff0000"));
+        assert_eq!(expand_hex(" #ABC ").as_deref(), Some("#aabbcc"));
+        assert_eq!(expand_hex("#f008").as_deref(), Some("#ff0000")); // alpha dropped
+        assert_eq!(expand_hex("#4f46e5").as_deref(), Some("#4f46e5"));
+        assert_eq!(expand_hex("#00000080").as_deref(), Some("#000000"));
+        for bad in ["", "red", "#12345", "#ff0000,#0000ff", "4f46e5"] {
+            assert_eq!(expand_hex(bad), None, "{bad}");
+        }
     }
 
     #[test]

--- a/tools/generator/src/markdown.rs
+++ b/tools/generator/src/markdown.rs
@@ -150,6 +150,17 @@ fn sample_value(control: &Control, placeholder: &str) -> Option<String> {
                     .unwrap_or_else(|| fmt_num(*min)),
             )
         }
+        Control::Color { default } => {
+            // Same omit-rule as Number: a non-hex placeholder (e.g.
+            // "transparent — or a hex like #0b1220") means EMPTY is the
+            // meaningful value, so the param is left out of the example
+            // rather than teaching a value that would be rejected.
+            let hex_ph = ph.as_ref().and_then(|p| crate::control::expand_hex(p).map(|_| p.clone()));
+            if ph.is_some() && hex_ph.is_none() {
+                return None;
+            }
+            hex_ph.or_else(|| default.clone())
+        }
         Control::Picker { input_type } => Some(ph.unwrap_or_else(|| {
             match input_type.as_str() {
                 "time" => "09:30",

--- a/tools/generator/src/template.rs
+++ b/tools/generator/src/template.rs
@@ -138,6 +138,22 @@ pub fn render_page(
                                             input id=(id) class="tool-input" type=(input_type)
                                                   placeholder=(input.placeholder) autocomplete="off";
                                         }
+                                        Control::Color { default } => {
+                                            // Swatch + text pair. The TEXT input keeps the
+                                            // canonical in-<name> id (deep-links, reset, chips,
+                                            // gatherArgs untouched) and stays the source of
+                                            // truth — empty ("transparent"/default), alpha hex
+                                            // and color lists all live there; tool.js mirrors
+                                            // the native swatch generically via data-for.
+                                            @let swatch = default.as_deref().and_then(crate::control::expand_hex);
+                                            div class="tool-color-row" {
+                                                input id=(format!("{id}-swatch")) class="tool-color-swatch" type="color"
+                                                      data-for=(id) value=[swatch.as_deref()] aria-label=(input.label);
+                                                input id=(id) class="tool-input tool-color-value" type="text"
+                                                      placeholder=(input.placeholder)
+                                                      autocomplete="off" autocapitalize="off" spellcheck="false";
+                                            }
+                                        }
                                         Control::Datalist { options } => {
                                             @let list_id = format!("dl-{}", input.name);
                                             input id=(id) class="tool-input" type="text" list=(list_id)
@@ -697,6 +713,65 @@ label       = "Gain"
         assert!(
             html.contains("gizza tool audio-pitch-shift 'url=https://example.com/input' 'semitones=3'"),
             "CLI example includes required field sample"
+        );
+    }
+
+    #[test]
+    fn renders_color_kind_as_swatch_plus_canonical_text() {
+        let meta = ToolMeta::from_toml(
+            r##"
+slug          = "waveform-image"
+title         = "t"
+description   = "d"
+h1            = "h"
+hero_subtitle = "s"
+wasm          = "w"
+export        = "build_argv"
+runtime       = "ffmpeg"
+output_label  = "o"
+format        = "image"
+
+[[input]]
+name   = "audio"
+source = "file"
+accept = "audio/*"
+
+[[input]]
+name        = "color"
+source      = "field"
+label       = "Wave color"
+placeholder = "#4f46e5"
+kind        = "color"
+
+[[input]]
+name        = "background"
+source      = "field"
+label       = "Background"
+placeholder = "transparent — or a hex like #0b1220"
+kind        = "color"
+"##,
+        )
+        .unwrap();
+        let schema = ParamSchema::from_props_for_tests(serde_json::json!({
+            "color": { "type": "string", "default": "#4f46e5" },
+            "background": { "type": "string" }
+        }));
+        let html = render_page(&meta, "<h2>About</h2>", &schema, false, false);
+        // kind="color" → a native swatch mirroring the canonical TEXT input
+        assert!(html.contains(r##"id="in-color-swatch""##), "swatch rendered");
+        assert!(html.contains(r##"data-for="in-color""##), "swatch targets its text input");
+        assert!(
+            html.contains(r##"id="in-color" class="tool-input tool-color-value" type="text""##),
+            "canonical text input kept (empty/alpha/lists stay expressible)"
+        );
+        // schema default seeds the swatch; a default-less color has no value attr
+        assert!(html.contains(r##"id="in-color-swatch" class="tool-color-swatch" type="color" data-for="in-color" value="#4f46e5""##), "swatch seeded with schema default");
+        assert!(!html.contains(r##"data-for="in-background" value="##), "no swatch value without a schema default");
+        // the CLI example uses the hex sample for color and OMITS background
+        // (its non-hex placeholder means "empty = transparent" is the example)
+        assert!(
+            html.contains("gizza tool waveform-image 'url=https://example.com/input' 'color=#4f46e5'"),
+            "CLI example is runnable: hex sample, placeholder-leak omitted"
         );
     }
 


### PR DESCRIPTION
## improve-tool: waveform-image

### Competitor analysis (top 5)
| tool | does better (paraphrased) | dimension |
| ---- | ----------- | --------- |
| Audioalter | size presets + custom gate; rgba pickers with alpha + checkerboard swatches | capabilities/ux |
| lotsofsounds | 31 gradient presets; live re-render; strong privacy copy | capabilities/copy |
| Serverless Tools | gradient mode; grouped control cards; dimension sliders; overlay-for-editors SEO | capabilities/ux/copy |
| WaveVisual | multi-color/gradient waves, 17 canvas ratios, vector/video exports (paid) | capabilities/visual |
| AudioWave (audiowaveform.org) | 11 styles, templates — but login-gated watermarked video only | ux (counter-positioning) |

Full paraphrased profiles + gap table: `docs/checks/2026-07-03-improve-waveform-image-competitor-analysis.md`.

### Schema diff (before → after)
```diff
 properties:
-  color:  "Waveform color as #RGB or #RRGGBB hex, e.g. #4f46e5 or #f00. Default #4f46e5."
+  color:  "Waveform color as hex: #RGB, #RRGGBB or #RRGGBBAA (alpha)… With split_channels, a comma-separated list colors each channel (e.g. #ff0000,#0000ff). Default #4f46e5."
+  color2: "Optional gradient end color (same hex forms). When set, the wave is filled with a horizontal left-to-right gradient from color to color2…"
-  background: "Background color as #RGB or #RRGGBB hex, e.g. #000000…"
+  background: "Background color as hex: #RGB, #RRGGBB or #RRGGBBAA — e.g. #000000, or #00000080 for a see-through scrim…"
+  sampling: { enum: [average, peak], default: average }  # peak = loudest sample per column, fuller wave
   (url/ref/width/height/split_channels/scale unchanged)
```

### Changes by dimension
- **Capabilities:** `color2` gradient wave (`gradients`+`alphaextract`+`alphamerge` — verified in BOTH engines: system ffmpeg for the CLI, @ffmpeg/core for the page); `sampling=peak`; per-channel comma color list (≤8) for split lanes; `#RGBA`/`#RRGGBBAA` alpha hex everywhere (translucent waves + scrim backgrounds).
- **Copy/SEO:** options/worked-example/limits rewritten for the new params; new FAQs (gradient, per-channel colors, honest "no bar/circular styles"); tags + description updated. Original copy only.
- **UX/layout:** NEW declarative `kind = "color"` control in the shared generator (`tools/generator/src/{control,template,markdown}.rs` + `site/tool.js` + `site/tool.css`) — native swatch two-way mirrored onto the canonical hex TEXT input, so empty (= transparent/default), alpha hex and comma lists stay expressible (a bare `<input type="color">` can't say "transparent"); 6 `[[example]]` preset chips (size presets in-model without a new control); `sampling` renders as a `<select>` from the enum.
- **Visual design:** shared `.tool-color-row`/`.tool-color-swatch` styling consistent with the slider row; no per-tool CSS.

### Phase-1 fixes (pre-existing breakage)
- Three-surface verify was green (unit+drift-guard, CLI render, Playwright page+deep-link, hygiene). Deeper probing then found a **correctness bug**: the advertised `#RGB` short hex (e.g. `#f00`) passed validation but ffmpeg's parser only knows `#RRGGBB[AA]` — it warned and silently drew a **white** wave on every surface. Root-cause fix: `parse_hex_color` expands short forms before interpolation; regression tests in core, on the page and via the CLI.
- The generated CLI/deep-link example leaked the background placeholder (`'background=transparent — or a hex like #0b1220'`) — not runnable. Fixed at the platform level via the color-control sample rule (omit when the placeholder means empty-is-meaningful).

### Out-of-model features considered, not built
- Bar/dotted/circular/neon wave styles — needs a custom rasterizer, not showwavespic; honestly FAQ'd instead.
- SVG/PDF vector export; animated waveform video/audiogram — separate `audiogram` backlog item.
- Text/logo/QR overlays, templates, background images — design-studio scope (background image would also need a second file input; page framework supports one).
- Spotify/mic import; bundled demo audio — noted as possible platform follow-up.

### Tested
- Unit: 22 core + 2 block (drift-guard REGENERATED) + 46 generator; `npm test` 41/41.
- Builds: `wafer build` (554.3 KiB OK), `wasm-pack` web, generator render, `sync-tool-manifest`, hygiene gate strict exit 0. `solobase build` intentionally skipped (throughput rule, run-specific instruction).
- Playwright 10/10 incl. deep-link, gradient left-red/right-blue pixel assertions, stereo per-channel lanes (existing `tone-stereo-3s.mp3` fixture), peak>average, 3-digit-hex regression, example-chip and swatch-mirror UX. Canary: `tool-page-audio-pitch-shift` 5/5 (shared tool.js path unregressed).
- CLI (system ffmpeg): `color=#f00` → red (was white); gradient; `sampling=peak` 205 px vs 60; `background=#00000080` corner alpha 128; guiding errors for `color2`+list and `sampling=rms`.
- Limitations: chat ffmpeg is non-functional (Service Worker constraint) — chat surface is schema-only, tool works via page + CLI; no wafer `tests/*.json` fixtures exist for the ffmpeg family (noted, not invented).

> Original work only — no competitor copy, branding, or trademarks copied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)