### PR TITLE
fix(page): schema-typed field coercion (replace digit-sniffing + color band-aid)

### DIFF
--- a/blocks/video-frame-extract/manifest.json
+++ b/blocks/video-frame-extract/manifest.json
@@ -2,5 +2,42 @@
   "name": "gizza-ai/video-frame-extract",
   "version": "0.1.0",
   "interface": "handler@v1",
-  "summary": "Extract a single frame from a video at a given timestamp."
+  "summary": "Extract a single frame from a video at a given timestamp",
+  "tool": {
+    "parameters": {
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "required": [
+            "url"
+          ]
+        },
+        {
+          "required": [
+            "ref"
+          ]
+        }
+      ],
+      "properties": {
+        "ref": {
+          "description": "Reference id from a prior tool call. Use either url or ref.",
+          "type": "string"
+        },
+        "timestamp": {
+          "description": "Timestamp in seconds.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "url": {
+          "description": "Video URL (HTTP/HTTPS). Use either url or ref.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "description": "Extract a single frame from a video at the given timestamp (seconds), output as PNG. The PNG is naturally chainable into image-resize, image-crop, or image-convert via ref. Provide either url (HTTP/HTTPS) or ref (id from a prior tool call)."
+  }
 }

--- a/blocks/video-frame-extract/wafer.toml
+++ b/blocks/video-frame-extract/wafer.toml
@@ -3,4 +3,4 @@ org = "gizza-ai"
 name = "video-frame-extract"
 version = "0.1.0"
 abi = 1
-summary = "Extract a single frame from a video at a given timestamp."
+summary = "Extract a single frame from a video at a given timestamp"

--- a/blocks/video-trim/manifest.json
+++ b/blocks/video-trim/manifest.json
@@ -2,5 +2,48 @@
   "name": "gizza-ai/video-trim",
   "version": "0.1.0",
   "interface": "handler@v1",
-  "summary": "Trim a video to a [start, start+duration] window."
+  "summary": "Trim a video to a [start, start+duration] window",
+  "tool": {
+    "parameters": {
+      "additionalProperties": false,
+      "oneOf": [
+        {
+          "required": [
+            "url"
+          ]
+        },
+        {
+          "required": [
+            "ref"
+          ]
+        }
+      ],
+      "properties": {
+        "duration": {
+          "description": "Duration in seconds.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "ref": {
+          "description": "Reference id from a prior tool call. Use either url or ref.",
+          "type": "string"
+        },
+        "start": {
+          "description": "Start time in seconds.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "url": {
+          "description": "Video URL (HTTP/HTTPS). Use either url or ref.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "start",
+        "duration"
+      ],
+      "type": "object"
+    },
+    "description": "Trim a video to a [start, start+duration] window using stream-copy (no re-encode). Provide either url (HTTP/HTTPS) or ref (id from a prior tool call). The output keeps the source container (mp4 stays mp4, webm stays webm, and so on); an unknown container falls back to mp4. Stream-copy preserves the source codecs and is fast and lossless."
+  }
 }

--- a/blocks/video-trim/wafer.toml
+++ b/blocks/video-trim/wafer.toml
@@ -3,4 +3,4 @@ org = "gizza-ai"
 name = "video-trim"
 version = "0.1.0"
 abi = 1
-summary = "Trim a video to a [start, start+duration] window."
+summary = "Trim a video to a [start, start+duration] window"

--- a/site/tool.js
+++ b/site/tool.js
@@ -556,19 +556,23 @@ async function main() {
       media.hidden = true;
       dl.hidden = true;
       if (outputWf) outputWf.clear();
-      // Coerce numeric-looking field values to Number so wasm-bindgen f64 params
-      // marshal correctly; leave non-numeric (e.g. "contain") and empty strings
-      // as strings — the WASM function handles empty via its own defaults.
-      // readField (not .value) so a checkbox marshals its CHECKED state as
-      // "true"/"false" — a checkbox element's .value is the constant "on"
-      // regardless of state, which would read as always-on.
+      // Coerce a field value to Number ONLY when the param's DECLARED schema
+      // type is numeric (i.numeric, baked from manifest.json tool.parameters by
+      // the generator) — so wasm-bindgen f64 params marshal correctly, while a
+      // string param whose value happens to be digits (a bare hex color
+      // "112233", a numeric-looking label/code) stays a string. Empty and
+      // non-finite values pass through as the raw string; the WASM function
+      // applies its own defaults. readField (not .value) so a checkbox marshals
+      // its CHECKED state as "true"/"false" — a checkbox element's .value is the
+      // constant "on" regardless of state, which would read as always-on.
       const fieldArgs = fieldInputs.map((i) => {
         const el = document.getElementById(i.elementId);
         const v = el ? readField(el) : "";
-        // A color field's value is never a number — a bare digits-only hex
-        // like "112233" must stay a string for the wasm &str param.
-        if (el && el.classList.contains("tool-color-value")) return v;
-        return v !== "" && !isNaN(Number(v)) ? Number(v) : v;
+        if (i.numeric && v !== "") {
+          const n = Number(v);
+          if (Number.isFinite(n)) return n;
+        }
+        return v;
       });
       const r = await runFfmpeg(cfg, mod, ffmpegExec, file, fieldArgs);
       if (seq !== runSeq) return; // superseded while ffmpeg ran — drop the result

--- a/tests/tool-page-image-vignette.spec.ts
+++ b/tests/tool-page-image-vignette.spec.ts
@@ -134,6 +134,27 @@ test('image-vignette bare digits-only hex color stays a color (never a number)',
   expect(p.center.r).toBeGreaterThan(230);
 });
 
+test('image-vignette leading-zero all-digit hex keeps every hex digit (no Number coercion)', async ({
+  page,
+}) => {
+  // Regression for the schema-typed coercion fix: "011733" is all decimal
+  // digits, so the old sniff (and any relapse to numeric coercion) would turn
+  // it into the Number 11733 → "11733", a FIVE-digit string parse_color
+  // rejects → no output. A string color param must pass it through verbatim as
+  // the 6-digit hex #011733 → corners (1, 23, 51). The leading zero is the
+  // tell: it only survives if the value was never a JS number.
+  await page.goto('/tools/image-vignette/');
+  await page.fill('#in-strength', '100');
+  await page.fill('#in-color', '011733');
+  await page.setInputFiles('#in-image', path.resolve(__dirname, 'fixtures/white-64x64.png'));
+
+  const p = await samplePixels(page, await outputSrc(page));
+  expect(Math.abs(p.topLeft.r - 1)).toBeLessThan(30); // 0x01
+  expect(Math.abs(p.topLeft.g - 23)).toBeLessThan(30); // 0x17
+  expect(Math.abs(p.topLeft.b - 51)).toBeLessThan(30); // 0x33
+  expect(p.center.r).toBeGreaterThan(230);
+});
+
 test('image-vignette format=jpg converts the output to JPEG', async ({ page }) => {
   await page.goto('/tools/image-vignette/');
   await page.selectOption('#in-format', 'jpg');

--- a/tools/generator/src/control.rs
+++ b/tools/generator/src/control.rs
@@ -169,6 +169,28 @@ impl ParamSchema {
         !self.props.is_empty()
     }
 
+    /// Whether `name`'s declared JSON-schema type is numeric (`integer` or
+    /// `number`) — the page must marshal its field value as a JS `Number` for
+    /// the wasm `f64` param. False for `string`/`boolean` params, for `enum`
+    /// params (a `<select>` yields a canonical string value, even a
+    /// digits-looking one), and for the empty/stale fallback schema (unknown →
+    /// left a string). This is what lets `tool.js` coerce BY TYPE instead of
+    /// sniffing whether a string looks numeric.
+    pub fn is_numeric(&self, name: &str) -> bool {
+        let Some(p) = self.props.get(name) else {
+            return false;
+        };
+        // An enum is a string-valued <select> regardless of its JSON "type";
+        // its value must never be coerced to a Number.
+        if p.get("enum").is_some() {
+            return false;
+        }
+        matches!(
+            p.get("type").and_then(|t| t.as_str()),
+            Some("integer" | "number")
+        )
+    }
+
     /// Resolve the control for a `source="field"` input: meta-level overrides
     /// (`kind`, `options`) win over the schema-derived control, because the
     /// schema only knows JSON types ("string") while the meta knows the page
@@ -493,6 +515,25 @@ mod tests {
         for bad in ["", "red", "#12345", "#ff0000,#0000ff", "4f46e5"] {
             assert_eq!(expand_hex(bad), None, "{bad}");
         }
+    }
+
+    #[test]
+    fn is_numeric_is_true_only_for_integer_and_number_types() {
+        let s = schema(json!({
+            "width":    { "type": "integer" },
+            "semitones":{ "type": "number" },
+            "color":    { "type": "string" },
+            "flag":     { "type": "boolean" },
+            "mode":     { "type": "string", "enum": ["a", "b"] }
+        }));
+        assert!(s.is_numeric("width"), "integer param is numeric");
+        assert!(s.is_numeric("semitones"), "number param is numeric");
+        assert!(!s.is_numeric("color"), "string param is not numeric");
+        assert!(!s.is_numeric("flag"), "boolean param is not numeric");
+        assert!(!s.is_numeric("mode"), "enum <select> value stays a string");
+        // Unknown / stale-manifest fallback: never coerce.
+        assert!(!s.is_numeric("absent"), "unknown param is not numeric");
+        assert!(!ParamSchema::empty().is_numeric("width"), "empty schema is not numeric");
     }
 
     #[test]

--- a/tools/generator/src/meta.rs
+++ b/tools/generator/src/meta.rs
@@ -117,19 +117,29 @@ impl ToolMeta {
         toml::from_str(text).map_err(|e| format!("meta.toml parse error: {e}"))
     }
 
-    /// Build the `window.GIZZA_TOOL` config object consumed by `tool.js`.
-    pub fn client_config(&self) -> serde_json::Value {
+    /// Build the `window.GIZZA_TOOL` config object consumed by `tool.js`. The
+    /// tool's declared param `schema` is threaded in so each `source="field"`
+    /// input carries its JSON-schema numeric-ness (`"numeric": true` for
+    /// `integer`/`number` params) — `tool.js` coerces field values to `Number`
+    /// BY TYPE instead of sniffing whether a string looks numeric, so a
+    /// digits-only string param (a bare hex color, a numeric-looking label)
+    /// stays a string.
+    pub fn client_config(&self, schema: &crate::control::ParamSchema) -> serde_json::Value {
         let inputs: Vec<serde_json::Value> = self
             .inputs
             .iter()
             .map(|i| {
-                serde_json::json!({
+                let mut obj = serde_json::json!({
                     "name": i.name,
                     "source": i.source,
                     "elementId": format!("in-{}", i.name),
                     "accept": i.accept,
                     "default": i.default,
-                })
+                });
+                if i.source == "field" && schema.is_numeric(&i.name) {
+                    obj["numeric"] = serde_json::json!(true);
+                }
+                obj
             })
             .collect();
         let examples: Vec<serde_json::Value> = self
@@ -238,7 +248,7 @@ placeholder = "2 + 2 * 3"
 source      = "field"
 "#;
         let m = ToolMeta::from_toml(text).unwrap();
-        let cfg = m.client_config();
+        let cfg = m.client_config(&crate::control::ParamSchema::empty());
         assert_eq!(cfg["slug"], "calculator");
         assert_eq!(cfg["module"], "./gizza_ai_calculator_web.js");
         assert_eq!(cfg["export"], "evaluate");
@@ -277,10 +287,69 @@ label  = "Width (px)"
         assert_eq!(m.runtime, "ffmpeg");
         assert_eq!(m.inputs[0].source, "file");
         assert_eq!(m.inputs[0].accept, "image/*");
-        let cfg = m.client_config();
+        let cfg = m.client_config(&crate::control::ParamSchema::empty());
         assert_eq!(cfg["runtime"], "ffmpeg");
         assert_eq!(cfg["inputs"][0]["accept"], "image/*");
         assert_eq!(cfg["format"], "image");
+    }
+
+    #[test]
+    fn client_config_bakes_numeric_flag_by_schema_type() {
+        // A number/integer field must carry "numeric":true; a string field and a
+        // color-kind field (still a schema "string") must not — so tool.js
+        // coerces by declared type, not by sniffing digit-looking strings.
+        let text = r##"
+slug          = "waveform-image"
+title         = "t"
+description   = "d"
+h1            = "h"
+hero_subtitle = "s"
+wasm          = "w"
+export        = "build_argv"
+runtime       = "ffmpeg"
+output_label  = "o"
+format        = "image"
+
+[[input]]
+name   = "audio"
+source = "file"
+accept = "audio/*"
+
+[[input]]
+name        = "height"
+source      = "field"
+label       = "Height"
+
+[[input]]
+name        = "label"
+source      = "field"
+label       = "Label"
+
+[[input]]
+name        = "background"
+source      = "field"
+label       = "Background"
+kind        = "color"
+"##;
+        let m = ToolMeta::from_toml(text).unwrap();
+        let schema = crate::control::ParamSchema::from_props_for_tests(serde_json::json!({
+            "height": { "type": "integer", "minimum": 1 },
+            "label": { "type": "string" },
+            "background": { "type": "string" }
+        }));
+        let cfg = m.client_config(&schema);
+        let inputs = cfg["inputs"].as_array().unwrap();
+        let by_name = |n: &str| inputs.iter().find(|i| i["name"] == n).unwrap();
+        // file input never numeric
+        assert!(!by_name("audio")["numeric"].as_bool().unwrap_or(false));
+        // integer field → numeric:true
+        assert_eq!(by_name("height")["numeric"], serde_json::json!(true));
+        // string field → flag absent (falsy)
+        assert!(by_name("label").get("numeric").is_none());
+        assert!(!by_name("label")["numeric"].as_bool().unwrap_or(false));
+        // color-kind field is a schema string → not numeric (stays a string,
+        // so a bare hex like "112233" survives coercion)
+        assert!(by_name("background").get("numeric").is_none());
     }
 
     #[test]
@@ -323,7 +392,7 @@ end = "end"
             m.waveform,
             Some(WaveformSpec::Binding { start: "start".into(), end: "end".into() })
         );
-        let cfg = m.client_config();
+        let cfg = m.client_config(&crate::control::ParamSchema::empty());
         assert_eq!(cfg["waveform"]["start"], "start");
         assert_eq!(cfg["waveform"]["end"], "end");
     }
@@ -344,11 +413,11 @@ format = "audio"
         let off = format!("{base}waveform = false\n");
         let m = ToolMeta::from_toml(&off).unwrap();
         assert_eq!(m.waveform, Some(WaveformSpec::Enabled(false)));
-        assert_eq!(m.client_config()["waveform"], serde_json::json!(false));
+        assert_eq!(m.client_config(&crate::control::ParamSchema::empty())["waveform"], serde_json::json!(false));
 
         let m = ToolMeta::from_toml(base).unwrap();
         assert_eq!(m.waveform, None);
-        assert_eq!(m.client_config()["waveform"], serde_json::Value::Null);
+        assert_eq!(m.client_config(&crate::control::ParamSchema::empty())["waveform"], serde_json::Value::Null);
     }
 
     #[test]
@@ -367,7 +436,7 @@ format = "audio"
         let on = format!("{base}waveform = true\n");
         let m = ToolMeta::from_toml(&on).unwrap();
         assert_eq!(m.waveform, Some(WaveformSpec::Enabled(true)));
-        assert_eq!(m.client_config()["waveform"], serde_json::json!(true));
+        assert_eq!(m.client_config(&crate::control::ParamSchema::empty())["waveform"], serde_json::json!(true));
 
         // A partial [waveform] table (start without end) matches neither
         // untagged variant and must fail at parse time, not silently bind.

--- a/tools/generator/src/template.rs
+++ b/tools/generator/src/template.rs
@@ -24,7 +24,7 @@ pub fn render_page(
     // literal "</script>" in any value would break out of the element. serde_json
     // does not escape '/', so we neutralize the closing-tag sequence. Values are
     // repo-authored today; this is defense-in-depth against a future meta.toml.
-    let mut client_cfg_json = meta.client_config();
+    let mut client_cfg_json = meta.client_config(schema);
     client_cfg_json["custom"] = serde_json::json!(custom_js);
     let client_cfg = client_cfg_json.to_string().replace("</", "<\\/");
     let json_ld = serde_json::json!({


### PR DESCRIPTION
## Problem

The ffmpeg page path in `site/tool.js` coerced each field value by **sniffing** whether the string looked numeric:

```js
if (el && el.classList.contains("tool-color-value")) return v;   // band-aid
return v !== "" && !isNaN(Number(v)) ? Number(v) : v;            // sniff
```

A string param whose value happens to be digits (a bare hex color `112233`, a numeric-looking label/code) was wrongly turned into a `Number` and mangled. The `tool-color-value` class check was a band-aid patching only the color case.

## Fix: coerce by the param's DECLARED schema type

1. **Bake schema type into the page config.** `ParamSchema::is_numeric(name)` (new, in `control.rs`) is true only for `integer`/`number` params — false for `string`/`boolean`/`enum` and the empty/stale-manifest fallback. `meta.rs` `client_config(&self, schema)` now stamps `"numeric": true` onto each `source="field"` input whose schema type is numeric; `template.rs` threads in the ParamSchema it already loads.

2. **Coerce by type in `tool.js`.** Coerce to `Number` only when `i.numeric` **and** the value is non-empty and parses finite; otherwise pass the string through. The `tool-color-value` special-case is **removed** — colors are string params, so they stay strings by type.

3. **Fill two manifests.** `blocks/video-frame-extract` and `blocks/video-trim` had **no `tool` section**, so the generator fell back to the empty schema and their numeric fields (`timestamp`, `start`, `duration`) never got `numeric:true` — the exact bug. Populated `tool.parameters`/`tool.description` from the live descriptors via `scripts/sync-tool-manifest.py` (which also normalized the wafer.toml/manifest summaries to match the `wafer_block` macro).

## Verification

- `tools/generator && cargo test` — 50 passed, incl. two new tests (`is_numeric_is_true_only_for_integer_and_number_types`, `client_config_bakes_numeric_flag_by_schema_type`).
- Regenerated all pages; numeric flag baked correctly — `video-frame-extract/timestamp`, `video-trim/start+duration` → `numeric:true`; `waveform-image`/`image-vignette` color + enum fields → falsy.
- `scripts/check-tool-hygiene.py` — exit 0 both per-slug and repo-wide (456 tools).
- Playwright green: `tool-page-video-resize`, `tool-page-audio-pitch-shift` (numeric field still works), `tool-page-video-trim` + `tool-page-video-frame-extract` core (newly-manifested numeric fields), `tool-page-image-vignette` + `tool-page-waveform-image` (color/string digit-like value stays a string). New assertion added to the image-vignette spec: a leading-zero all-digit hex `011733` renders `#011733` — it only survives if the value was never turned into the `Number` 11733 (a 5-digit string the color parser rejects), a strong guard against a coercion relapse.

Note: `pkg/` is gitignored, so no regenerated pages are committed. There is no `tool-page-video-frame-extract` spec (only video-trim); video-frame-extract is covered by its manifest fill + numeric-flag bake verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ooH29qLtXCQw6QD69rNNN