### PR TITLE
feat(tools): "Copy image" button on image-output tool pages

### DIFF
--- a/site/tool.css
+++ b/site/tool.css
@@ -80,7 +80,11 @@ body { margin: 0; font-family: system-ui, -apple-system, "Segoe UI", Roboto, san
 .tool-file { display: block; width: 100%; margin-bottom: 10px; font-size: 14px; }
 .tool-output-media { display: block; max-width: 100%; border-radius: 8px; margin-top: 4px; }
 .tool-output-media[hidden] { display: none; }
-.tool-output-download { display: inline-block; margin-top: 8px; font-size: 14px; font-weight: 600;
+/* Media-output actions row (Download link + optional "Copy image" button).
+   Flex keeps the link and button on one baseline-aligned row with no jump when
+   both reveal together; the row owns the top gap so the link needs none. */
+.tool-media-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; margin-top: 8px; }
+.tool-output-download { font-size: 14px; font-weight: 600;
   color: var(--tool-accent); text-decoration: underline; }
 .tool-output-download[hidden] { display: none; }
 

--- a/site/tool.js
+++ b/site/tool.js
@@ -178,8 +178,10 @@ function wireWidgetChrome(rerun) {
       refreshColors();
       const media = document.getElementById("tool-output-media");
       const dl = document.getElementById("tool-output-download");
+      const copyImg = document.getElementById("tool-copy-image");
       if (media) media.hidden = true;
       if (dl) dl.hidden = true;
+      if (copyImg) copyImg.hidden = true;
       // A previous run's error/result must not survive Reset (rerun()
       // early-returns without recomputing when e.g. no file is selected).
       out.classList.remove("error");
@@ -205,6 +207,50 @@ function wireWidgetChrome(rerun) {
         }, 1500);
       } catch (e) {
         // Clipboard unavailable (e.g. non-secure context) — button is best-effort.
+      }
+    });
+  }
+
+  // Copy the current output IMAGE to the clipboard as PNG. Only image-output
+  // ffmpeg tools render #tool-copy-image (the generator gates it on
+  // format="image"); video/audio have no reliable ClipboardItem path. We draw
+  // the visible <img> onto an offscreen canvas and write a PNG blob — PNG
+  // regardless of the output's real jpg/webp/png, because ClipboardItem image
+  // support is reliably PNG-only. Best-effort like the text copy above: if the
+  // clipboard API is missing (non-secure context, older Firefox) or any step
+  // throws/rejects, catch and no-op. Never acts on a non-image output.
+  const copyImage = document.getElementById("tool-copy-image");
+  if (copyImage) {
+    copyImage.addEventListener("click", () => {
+      const img = document.getElementById("tool-output-media");
+      if (!img || img.hidden || !img.src || !String(img.src).startsWith("data:image/")) return;
+      if (!(navigator.clipboard && window.ClipboardItem && navigator.clipboard.write)) return;
+      try {
+        const canvas = document.createElement("canvas");
+        canvas.width = img.naturalWidth || img.width;
+        canvas.height = img.naturalHeight || img.height;
+        const ctx = canvas.getContext("2d");
+        if (!ctx || !canvas.width || !canvas.height) return;
+        ctx.drawImage(img, 0, 0);
+        canvas.toBlob((blob) => {
+          if (!blob) return;
+          navigator.clipboard
+            .write([new ClipboardItem({ "image/png": blob })])
+            .then(() => {
+              copyImage.classList.add("copied");
+              const prev = copyImage.textContent;
+              copyImage.textContent = "Copied!";
+              setTimeout(() => {
+                copyImage.classList.remove("copied");
+                copyImage.textContent = prev;
+              }, 1500);
+            })
+            .catch(() => {
+              // Write rejected (permissions / focus) — best-effort, no-op.
+            });
+        }, "image/png");
+      } catch (e) {
+        // Clipboard/canvas unavailable — best-effort, no-op.
       }
     });
   }
@@ -440,6 +486,9 @@ async function main() {
     const { ffmpegExec } = await import("./ffmpeg.js");
     const media = document.getElementById("tool-output-media");
     const dl = document.getElementById("tool-output-download");
+    // Image-output pages only (the generator gates #tool-copy-image on
+    // format="image"); null for video/audio, where it stays absent.
+    const copyImage = document.getElementById("tool-copy-image");
     if (!media || !dl) {
       // ffmpeg runtime requires a media output (format "image"/"video"/"audio");
       // a misconfigured tool (e.g. runtime=ffmpeg + format=text) has no place to
@@ -555,6 +604,7 @@ async function main() {
       out.classList.remove("error");
       media.hidden = true;
       dl.hidden = true;
+      if (copyImage) copyImage.hidden = true;
       if (outputWf) outputWf.clear();
       // Coerce a field value to Number ONLY when the param's DECLARED schema
       // type is numeric (i.numeric, baked from manifest.json tool.parameters by
@@ -583,6 +633,10 @@ async function main() {
         dl.href = r.dataUrl;
         dl.download = r.outName;
         dl.hidden = false;
+        // Reveal "Copy image" only for image results — guard on the data URL so
+        // a misconfigured non-image never exposes it (video/audio never render
+        // the button at all).
+        if (copyImage) copyImage.hidden = !String(r.dataUrl).startsWith("data:image/");
         // Visual result: decode the output into the read-only waveform. The
         // native <audio controls> stays visible (accessible transport +
         // decode-failure fallback); the waveform adds the before/after view.

--- a/tests/tool-page-image-vignette.spec.ts
+++ b/tests/tool-page-image-vignette.spec.ts
@@ -234,3 +234,57 @@ test('image-vignette rejects a color combined with lighten mode, with guidance',
   await expect(out).toHaveClass(/error/, { timeout: 90_000 });
   await expect(out).toContainText('darken'); // the error names the fix
 });
+
+// The "Copy image" button (generator template + site/tool.js): image-output
+// tools get a declarative button next to Download that copies the CURRENT
+// output image to the clipboard as PNG (offscreen canvas → toBlob →
+// ClipboardItem, so jpg/webp/png all copy as PNG). It stays hidden until a
+// result renders and never appears on video/audio/text tools.
+test('copy-image button: hidden before a result, visible after, copies a PNG to the clipboard', async ({
+  page,
+  context,
+}) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  const pageErrors: string[] = [];
+  page.on('pageerror', (e) => pageErrors.push(String(e)));
+
+  await page.goto('/tools/image-vignette/');
+  const copyBtn = page.locator('#tool-copy-image');
+  // Rendered, but hidden while there is no output.
+  await expect(copyBtn).toHaveCount(1);
+  await expect(copyBtn).toBeHidden();
+
+  await page.setInputFiles('#in-image', path.resolve(__dirname, 'fixtures/white-64x64.png'));
+  // Revealed once the image result renders.
+  await expect(page.locator('#tool-output-media')).toBeVisible({ timeout: 90_000 });
+  await expect(copyBtn).toBeVisible();
+
+  // The output <img> must be decoded before it can be drawn to a canvas.
+  await page.waitForFunction(() => {
+    const img = document.getElementById('tool-output-media') as HTMLImageElement | null;
+    return !!img && img.complete && img.naturalWidth > 0;
+  });
+
+  await copyBtn.click();
+  // "Copied!" affordance proves the ClipboardItem write resolved without throwing.
+  await expect(copyBtn).toHaveClass(/copied/, { timeout: 10_000 });
+  await expect(copyBtn).toHaveText('Copied!');
+
+  // Permissions granted → read the clipboard back and assert a PNG is present.
+  const hasPng = await page.evaluate(async () => {
+    const items = await navigator.clipboard.read();
+    return items.some((it) => it.types.includes('image/png'));
+  });
+  expect(hasPng).toBe(true);
+
+  // Label restores after the affordance window; nothing threw on the page.
+  await expect(copyBtn).toHaveText('Copy image', { timeout: 5_000 });
+  expect(pageErrors).toEqual([]);
+});
+
+test('copy-image button never leaks onto text or video tool pages', async ({ page }) => {
+  await page.goto('/tools/url-encode/'); // text output
+  await expect(page.locator('#tool-copy-image')).toHaveCount(0);
+  await page.goto('/tools/video-mute/'); // video output
+  await expect(page.locator('#tool-copy-image')).toHaveCount(0);
+});

--- a/tools/generator/src/template.rs
+++ b/tools/generator/src/template.rs
@@ -221,7 +221,18 @@ pub fn render_page(
                                 } @else {
                                     audio id="tool-output-media" class="tool-output-media" controls hidden {}
                                 }
-                                a id="tool-output-download" class="tool-output-download" download hidden { "Download" }
+                                // Media-output actions row. Download is offered for
+                                // every media format; "Copy image" only for images —
+                                // video/audio have no reliable ClipboardItem path, so
+                                // the button is NOT rendered for them. Both start
+                                // hidden; tool.js reveals them once a result renders.
+                                div class="tool-media-actions" {
+                                    a id="tool-output-download" class="tool-output-download" download hidden { "Download" }
+                                    @if meta.format == "image" {
+                                        button id="tool-copy-image" class="tool-widget-btn" type="button" hidden
+                                               title="Copy the image to the clipboard" { "Copy image" }
+                                    }
+                                }
                                 output id="tool-output" class="tool-output" { "" }
                             } @else {
                                 output id="tool-output" class="tool-output" { "" }
@@ -844,6 +855,84 @@ labels = { "9:16" = "9:16 — Reels / Shorts / TikTok (1080×1920)", "1:1" = "1:
         let html = render_page(&ffmpeg_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false);
         assert!(html.contains(r#"id="tool-reset""#), "reset present (has fields)");
         assert!(!html.contains(r#"id="tool-copy-output""#), "no copy-result on media output");
+    }
+
+    #[test]
+    fn copy_image_button_only_on_image_output() {
+        // ffmpeg_sample() is format="image" → the Copy-image button is rendered
+        // (hidden, next to the download link), so a result can be copied to the
+        // clipboard as PNG by tool.js.
+        let image_html = render_page(&ffmpeg_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false);
+        assert!(
+            image_html.contains(r#"id="tool-copy-image""#),
+            "image-output page renders the Copy-image button"
+        );
+        assert!(
+            image_html.contains(r#"button id="tool-copy-image" class="tool-widget-btn" type="button" hidden"#),
+            "Copy-image button is a hidden widget button until a result renders"
+        );
+
+        // Video output (select_labels_… sample is format="video") must NOT get it:
+        // there is no reliable ClipboardItem path for video.
+        let video_meta = ToolMeta::from_toml(
+            r#"
+slug          = "video-mute"
+title         = "t"
+description   = "d"
+h1            = "h"
+hero_subtitle = "s"
+wasm          = "w"
+export        = "build_argv"
+runtime       = "ffmpeg"
+output_label  = "o"
+format        = "video"
+
+[[input]]
+name   = "video"
+source = "file"
+accept = "video/*"
+"#,
+        )
+        .unwrap();
+        let video_html = render_page(&video_meta, "<h2>About</h2>", &ParamSchema::empty(), false, false);
+        assert!(
+            !video_html.contains(r#"id="tool-copy-image""#),
+            "video-output page must not render the Copy-image button"
+        );
+
+        // Audio output must NOT get it either.
+        let audio_meta = ToolMeta::from_toml(
+            r#"
+slug          = "audio-normalize"
+title         = "t"
+description   = "d"
+h1            = "h"
+hero_subtitle = "s"
+wasm          = "w"
+export        = "build_argv"
+runtime       = "ffmpeg"
+output_label  = "o"
+format        = "audio"
+
+[[input]]
+name   = "audio"
+source = "file"
+accept = "audio/*"
+"#,
+        )
+        .unwrap();
+        let audio_html = render_page(&audio_meta, "<h2>About</h2>", &ParamSchema::empty(), false, false);
+        assert!(
+            !audio_html.contains(r#"id="tool-copy-image""#),
+            "audio-output page must not render the Copy-image button"
+        );
+
+        // Text output (declarative_sample is format="text") must NOT get it.
+        let text_html = render_page(&declarative_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false);
+        assert!(
+            !text_html.contains(r#"id="tool-copy-image""#),
+            "text-output page must not render the Copy-image button"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Image-output tools previously had only an `<img>` + a Download link. This adds a declarative **"Copy image"** button that copies the current output image to the clipboard as **PNG**.

Scoped to `format == "image"` only — video/audio have no reliable `ClipboardItem` path, so the button is **not** rendered for them (nor for text tools, which already have "Copy result").

## How

- **`tools/generator/src/template.rs`** — the media-output block wraps the Download link + a new `#tool-copy-image` button in a `.tool-media-actions` flex row. The button is gated on `meta.format == "image"`, class `tool-widget-btn`, and starts `hidden` (revealed when a result exists, like the download link).
- **`site/tool.js`** — in the ffmpeg `run()` success path the button is revealed only when the result is a `data:image/…` URL; it is hidden again on run start and Reset. A single click handler (wired once in `wireWidgetChrome`) draws the visible `#tool-output-media` `<img>` onto an offscreen canvas and writes `canvas.toBlob → new ClipboardItem({'image/png': blob})` — canvas→PNG so it works regardless of the output being jpg/webp/png, and because `ClipboardItem` image support is reliably PNG-only. Guarded: missing `navigator.clipboard`/`ClipboardItem`/`write` (non-secure context, older Firefox) or a rejected write is caught and no-ops. Same "Copied!" affordance (label swap ~1.5s + `.copied` class) as the text copy button.
- **`site/tool.css`** — `.tool-media-actions` keeps Download + Copy image on one aligned row with no layout jump; reuses `.tool-widget-btn`/`.copied`.

## Tests

- **Generator unit test** (`copy_image_button_only_on_image_output`): asserts the button renders for an image page and is **absent** for video/audio/text pages. All 51 generator tests pass.
- **Playwright** (`tool-page-image-vignette.spec.ts`): button is hidden before a result, visible after the image renders; clicking it (with clipboard permissions granted) shows "Copied!" and `navigator.clipboard.read()` reports an `image/png` item; no `pageerror`. A second test asserts the button never leaks onto a text (`url-encode`) or video (`video-mute`) page.
- Ran `tool-page-image-vignette` + `tool-page-widget-chrome` + `tool-page-video-mute` → **18 passed** (no regressions, no leakage).
- `python3 scripts/check-tool-hygiene.py` repo-wide → exit 0 (456 tools clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ooH29qLtXCQw6QD69rNNN