### PR TITLE
feat(cli): add gizza mcp stdio server

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -34,6 +34,12 @@ gizza tool image-resize url=https://…/cat.png width=640 --out cat.png
 `0` ok · `1` tool error · `2` usage / bad args · `3` unsupported in the CLI (e.g. GPU
 tools like `imagine`, which need a browser GPU).
 
+## MCP server
+
+`gizza mcp` serves the same tool set over the Model Context Protocol (stdio,
+newline-delimited JSON-RPC) — register it with an MCP client instead of shelling out:
+`claude mcp add gizza -- /path/to/gizza mcp`. See `cli/README.md` for details.
+
 ## Notes
 
 - Image/video tools shell out to the system `ffmpeg` binary — install it to use them.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,7 +25,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+# io-std + io-util: async stdin line-reader for the `gizza mcp` stdio server.
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util"] }
 anyhow = "1"
 tempfile = "3"
 async-trait = "0.1"

--- a/cli/README.md
+++ b/cli/README.md
@@ -50,6 +50,38 @@ gizza describe calculator           # schema for one tool
 gizza describe calculator --json-out
 ```
 
+## MCP server
+
+`gizza mcp` runs a [Model Context Protocol](https://modelcontextprotocol.io) server on
+stdio (newline-delimited JSON-RPC 2.0), exposing every catalog tool to MCP clients such
+as Claude Desktop and Claude Code. Tool names are the short slugs (`calculator`,
+`image-resize`, …); input schemas come straight from the tool manifests. Tools that
+produce a file (image/video/audio) write it to a temp path and return that path in the
+text content.
+
+Claude Code:
+
+```sh
+claude mcp add gizza -- /path/to/gizza mcp
+```
+
+Claude Desktop (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "gizza": {
+      "command": "/path/to/gizza",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Build the binary with `cargo build --release --manifest-path cli/Cargo.toml` (after
+`solobase build`) and point `command` at `cli/target/release/gizza` — or wherever you
+installed it. System `ffmpeg` on `PATH` is still required for image/video/audio tools.
+
 ## SKILL.md (agent contract)
 
 `SKILL.md` at the repo root is a small, **static** machine-readable contract (YAML

--- a/cli/src/bin/gizza.rs
+++ b/cli/src/bin/gizza.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
-use gizza_cli::{args, render, runtime};
+use gizza_cli::{args, mcp, render, runtime};
 
 #[derive(Parser)]
 #[command(name = "gizza", version)]
@@ -46,6 +46,8 @@ enum Commands {
         #[arg(long = "json-out")]
         json_out: bool,
     },
+    /// Run an MCP server on stdio (newline-delimited JSON-RPC) exposing every tool
+    Mcp,
 }
 
 #[tokio::main]
@@ -93,6 +95,13 @@ async fn main() {
                     "Parameters:  {}",
                     serde_json::to_string_pretty(&meta.parameters).unwrap()
                 );
+            }
+        }
+        Commands::Mcp => {
+            let rt = boot_or_die().await;
+            if let Err(e) = mcp::serve(rt).await {
+                eprintln!("MCP server error: {e}");
+                std::process::exit(1);
             }
         }
         Commands::Tool {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -5,6 +5,7 @@ pub fn version() -> &'static str {
 
 pub mod args;
 pub mod ffmpeg_native;
+pub mod mcp;
 pub mod render;
 pub mod runtime;
 

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -1,0 +1,209 @@
+//! `gizza mcp` — a stdio MCP (Model Context Protocol) server exposing every tool.
+//!
+//! Framing is the MCP stdio transport: newline-delimited JSON-RPC 2.0, one JSON
+//! message per line — NOT LSP `Content-Length` headers. Requests get exactly one
+//! response line; notifications get none. EOF on stdin ends the session.
+
+use std::io::Write as _;
+
+use anyhow::Result;
+use serde_json::{json, Value};
+use tokio::io::AsyncBufReadExt as _;
+
+use crate::{render, runtime::ToolRuntime};
+
+/// Protocol revisions this server can speak. A tools-only server behaves
+/// identically under all three, so we echo whichever the client asked for.
+const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2024-11-05", "2025-03-26", "2025-06-18"];
+const LATEST_PROTOCOL_VERSION: &str = "2025-06-18";
+
+/// JSON-RPC dispatch for one MCP session over a booted [`ToolRuntime`].
+pub struct McpServer {
+    rt: ToolRuntime,
+}
+
+impl McpServer {
+    pub fn new(rt: ToolRuntime) -> Self {
+        Self { rt }
+    }
+
+    /// Handle one raw line from the client. Returns the serialized response for
+    /// requests, `None` for notifications and blank lines.
+    pub async fn handle_line(&self, line: &str) -> Option<String> {
+        let line = line.trim();
+        if line.is_empty() {
+            return None;
+        }
+        let msg: Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            // Parse errors have no recoverable id → id null per JSON-RPC 2.0.
+            Err(_) => return Some(error_response(Value::Null, -32700, "Parse error").to_string()),
+        };
+        self.handle_message(msg).await.map(|v| v.to_string())
+    }
+
+    /// Handle one parsed JSON-RPC message. Requests yield `Some(response)`;
+    /// notifications (no `id`) are processed silently and yield `None`.
+    pub async fn handle_message(&self, msg: Value) -> Option<Value> {
+        let Value::Object(obj) = msg else {
+            return Some(error_response(Value::Null, -32600, "Invalid Request"));
+        };
+        let method = obj
+            .get("method")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let params = obj.get("params").cloned().unwrap_or(Value::Null);
+        // No id → notification (notifications/initialized, notifications/cancelled, …).
+        // Nothing here needs action, and notifications must never be answered.
+        let id = obj.get("id").cloned()?;
+        Some(match self.dispatch(method, &params).await {
+            Ok(result) => json!({"jsonrpc": "2.0", "id": id, "result": result}),
+            Err((code, message)) => error_response(id, code, &message),
+        })
+    }
+
+    async fn dispatch(&self, method: &str, params: &Value) -> Result<Value, (i64, String)> {
+        match method {
+            "initialize" => Ok(self.initialize(params)),
+            "ping" => Ok(json!({})),
+            "tools/list" => Ok(self.tools_list()),
+            "tools/call" => self.tools_call(params).await,
+            other => Err((-32601, format!("Method not found: {other}"))),
+        }
+    }
+
+    fn initialize(&self, params: &Value) -> Value {
+        let requested = params
+            .get("protocolVersion")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let version = if SUPPORTED_PROTOCOL_VERSIONS.contains(&requested) {
+            requested
+        } else {
+            LATEST_PROTOCOL_VERSION
+        };
+        json!({
+            "protocolVersion": version,
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "gizza", "version": crate::version()},
+            "instructions": "Local gizza compute tools (math, text, image/video/audio via \
+                system ffmpeg, web fetch). Tools that produce a file write it to a temp \
+                path and return that path in the text content.",
+        })
+    }
+
+    fn tools_list(&self) -> Value {
+        let tools: Vec<Value> = self
+            .rt
+            .tools()
+            .iter()
+            .map(|t| {
+                json!({
+                    "name": t.short,
+                    "description": t.description,
+                    "inputSchema": t.parameters,
+                })
+            })
+            .collect();
+        json!({"tools": tools})
+    }
+
+    async fn tools_call(&self, params: &Value) -> Result<Value, (i64, String)> {
+        let name = params
+            .get("name")
+            .and_then(Value::as_str)
+            .ok_or_else(|| (-32602, "Missing required param: name".to_string()))?;
+        let meta = self
+            .rt
+            .tool(name)
+            .ok_or_else(|| (-32602, format!("Unknown tool: {name}")))?;
+        let args = params
+            .get("arguments")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+        let full_name = meta.name.clone();
+        let body = match self.rt.run_tool(&full_name, args).await {
+            Ok(b) => b,
+            // Execution failures are tool-level errors (isError), not protocol errors.
+            Err(e) => return Ok(tool_result(format!("Dispatch error: {e}"), true)),
+        };
+        // Binary envelope (image/video/audio): write the file, return its path.
+        if let Some(bin) = render::extract_binary(&body) {
+            return Ok(match write_binary_output(&bin) {
+                Ok(path) => {
+                    let summary = render::render(&body, false).stdout;
+                    tool_result(
+                        format!("{summary}\nOutput written to {}", path.display()),
+                        false,
+                    )
+                }
+                Err(e) => tool_result(format!("Failed to write output file: {e}"), true),
+            });
+        }
+        let rendered = render::render(&body, false);
+        Ok(tool_result(rendered.stdout, rendered.exit_code != 0))
+    }
+}
+
+/// Write a tool's binary output to a unique temp file and return its path.
+///
+/// Same traversal-safe basename rule as `gizza tool` (`render::safe_default_out`),
+/// but placed in the OS temp dir: the MCP server's cwd belongs to the client
+/// (often `/`), so outputs must not land there.
+pub fn write_binary_output(bin: &render::BinaryOut) -> std::io::Result<std::path::PathBuf> {
+    let safe = render::safe_default_out(&bin.filename);
+    let name = safe.to_str().unwrap_or("output.bin");
+    let file = tempfile::Builder::new()
+        .prefix("gizza-mcp-")
+        .suffix(&format!("-{name}"))
+        .tempfile()?;
+    std::fs::write(file.path(), &bin.bytes)?;
+    // keep(): the file is handed to the MCP client, so it must outlive us.
+    let (_f, path) = file.keep().map_err(|e| e.error)?;
+    Ok(path)
+}
+
+fn tool_result(text: String, is_error: bool) -> Value {
+    json!({"content": [{"type": "text", "text": text}], "isError": is_error})
+}
+
+fn error_response(id: Value, code: i64, message: &str) -> Value {
+    json!({"jsonrpc": "2.0", "id": id, "error": {"code": code, "message": message}})
+}
+
+/// Run the stdio server: read newline-delimited JSON-RPC from stdin, write one
+/// response per line to stdout. Returns cleanly on stdin EOF.
+pub async fn serve(rt: ToolRuntime) -> Result<()> {
+    let server = McpServer::new(rt);
+    let mut lines = tokio::io::BufReader::new(tokio::io::stdin()).lines();
+    while let Some(line) = lines.next_line().await? {
+        if let Some(resp) = server.handle_line(&line).await {
+            let mut out = std::io::stdout().lock();
+            // Flush per message: stdout is block-buffered on a pipe, and the
+            // client is waiting on this exact line.
+            writeln!(out, "{resp}")?;
+            out.flush()?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn binary_output_lands_in_temp_dir_with_safe_name() {
+        let bin = render::BinaryOut {
+            filename: "../../evil/cat.png".to_string(),
+            bytes: vec![1, 2, 3],
+        };
+        let path = write_binary_output(&bin).expect("write");
+        assert!(path.starts_with(std::env::temp_dir()), "got {path:?}");
+        let name = path.file_name().unwrap().to_str().unwrap();
+        assert!(name.starts_with("gizza-mcp-"), "got {name}");
+        assert!(name.ends_with("-cat.png"), "got {name}");
+        assert_eq!(std::fs::read(&path).unwrap(), vec![1, 2, 3]);
+        std::fs::remove_file(&path).unwrap();
+    }
+}

--- a/cli/tests/mcp.rs
+++ b/cli/tests/mcp.rs
@@ -1,0 +1,169 @@
+//! Dispatch-logic tests for the `gizza mcp` stdio server: handshake, tool
+//! listing/calling, and JSON-RPC error/notification semantics.
+
+use gizza_cli::{mcp::McpServer, runtime};
+use serde_json::{json, Value};
+
+async fn server() -> McpServer {
+    McpServer::new(runtime::boot_minimal().await.expect("boot"))
+}
+
+#[tokio::test]
+async fn initialize_echoes_supported_protocol_version() {
+    let s = server().await;
+    let resp = s
+        .handle_message(json!({
+            "jsonrpc": "2.0", "id": 0, "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "0"}
+            }
+        }))
+        .await
+        .expect("response");
+    assert_eq!(resp["id"], 0);
+    let result = &resp["result"];
+    assert_eq!(result["protocolVersion"], "2025-03-26");
+    assert!(result["capabilities"]["tools"].is_object(), "got {result}");
+    assert_eq!(result["serverInfo"]["name"], "gizza");
+    assert_eq!(result["serverInfo"]["version"], gizza_cli::version());
+}
+
+#[tokio::test]
+async fn initialize_with_unknown_version_offers_latest() {
+    let s = server().await;
+    let resp = s
+        .handle_message(json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {"protocolVersion": "1999-01-01"}
+        }))
+        .await
+        .expect("response");
+    assert_eq!(resp["result"]["protocolVersion"], "2025-06-18");
+}
+
+#[tokio::test]
+async fn tools_list_has_calculator_with_schema() {
+    let s = server().await;
+    let resp = s
+        .handle_message(json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}))
+        .await
+        .expect("response");
+    let tools = resp["result"]["tools"].as_array().expect("tools array");
+    assert!(!tools.is_empty());
+    let calc = tools
+        .iter()
+        .find(|t| t["name"] == "calculator")
+        .unwrap_or_else(|| panic!("calculator not listed in {tools:?}"));
+    assert!(
+        !calc["description"].as_str().unwrap_or_default().is_empty(),
+        "got {calc}"
+    );
+    // inputSchema is the manifest's parameters JSON Schema, passed through verbatim.
+    assert_eq!(calc["inputSchema"]["type"], "object");
+    assert!(
+        calc["inputSchema"]["properties"]["expr"].is_object(),
+        "got {calc}"
+    );
+}
+
+#[tokio::test]
+async fn tools_call_calculator_returns_text_content() {
+    let s = server().await;
+    let resp = s
+        .handle_message(json!({
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": {"name": "calculator", "arguments": {"expr": "6*7"}}
+        }))
+        .await
+        .expect("response");
+    let result = &resp["result"];
+    assert_eq!(result["isError"], false);
+    assert_eq!(result["content"][0]["type"], "text");
+    assert_eq!(result["content"][0]["text"], "42");
+}
+
+#[tokio::test]
+async fn tools_call_tool_error_sets_is_error_not_rpc_error() {
+    let s = server().await;
+    let resp = s
+        .handle_message(json!({
+            "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+            "params": {"name": "calculator", "arguments": {"expr": "1/0"}}
+        }))
+        .await
+        .expect("response");
+    assert!(
+        resp.get("error").is_none(),
+        "tool failure must not be a JSON-RPC error: {resp}"
+    );
+    assert_eq!(resp["result"]["isError"], true);
+    assert!(resp["result"]["content"][0]["text"].is_string());
+}
+
+#[tokio::test]
+async fn tools_call_unknown_tool_is_invalid_params() {
+    let s = server().await;
+    let resp = s
+        .handle_message(json!({
+            "jsonrpc": "2.0", "id": 5, "method": "tools/call",
+            "params": {"name": "no-such-tool", "arguments": {}}
+        }))
+        .await
+        .expect("response");
+    assert_eq!(resp["error"]["code"], -32602);
+}
+
+#[tokio::test]
+async fn ping_returns_empty_result() {
+    let s = server().await;
+    let resp = s
+        .handle_message(json!({"jsonrpc": "2.0", "id": 6, "method": "ping"}))
+        .await
+        .expect("response");
+    assert_eq!(resp["result"], json!({}));
+}
+
+#[tokio::test]
+async fn unknown_method_is_method_not_found() {
+    let s = server().await;
+    let resp = s
+        .handle_message(json!({"jsonrpc": "2.0", "id": 7, "method": "resources/list"}))
+        .await
+        .expect("response");
+    assert_eq!(resp["error"]["code"], -32601);
+    assert_eq!(resp["id"], 7);
+}
+
+#[tokio::test]
+async fn malformed_json_is_parse_error_with_null_id() {
+    let s = server().await;
+    let resp = s.handle_line("{not json").await.expect("response");
+    let v: Value = serde_json::from_str(&resp).expect("valid json response");
+    assert_eq!(v["error"]["code"], -32700);
+    assert_eq!(v["id"], Value::Null);
+}
+
+#[tokio::test]
+async fn notification_gets_no_reply() {
+    let s = server().await;
+    let resp = s
+        .handle_message(json!({"jsonrpc": "2.0", "method": "notifications/initialized"}))
+        .await;
+    assert!(
+        resp.is_none(),
+        "notifications must never be answered: {resp:?}"
+    );
+    // Even an unknown-method notification stays silent.
+    let resp = s
+        .handle_message(json!({"jsonrpc": "2.0", "method": "notifications/whatever"}))
+        .await;
+    assert!(resp.is_none());
+}
+
+#[tokio::test]
+async fn blank_line_is_ignored() {
+    let s = server().await;
+    assert!(s.handle_line("   ").await.is_none());
+}

--- a/cli/tests/mcp_stdio.rs
+++ b/cli/tests/mcp_stdio.rs
@@ -1,0 +1,71 @@
+//! End-to-end smoke test for `gizza mcp`: drive the real binary over stdio with
+//! a scripted MCP session (initialize → initialized → tools/list → tools/call)
+//! and check the newline-delimited JSON-RPC framing.
+
+use std::io::Write as _;
+use std::process::{Command, Stdio};
+
+use serde_json::Value;
+
+#[test]
+fn stdio_session_initialize_list_call() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_gizza"))
+        .arg("mcp")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn gizza mcp");
+
+    let mut stdin = child.stdin.take().expect("stdin");
+    writeln!(
+        stdin,
+        r#"{{"jsonrpc":"2.0","id":0,"method":"initialize","params":{{"protocolVersion":"2025-06-18","capabilities":{{}},"clientInfo":{{"name":"smoke","version":"0"}}}}}}"#
+    )
+    .expect("write initialize");
+    writeln!(
+        stdin,
+        r#"{{"jsonrpc":"2.0","method":"notifications/initialized"}}"#
+    )
+    .expect("write initialized");
+    writeln!(stdin, r#"{{"jsonrpc":"2.0","id":1,"method":"tools/list"}}"#).expect("write list");
+    writeln!(
+        stdin,
+        r#"{{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{{"name":"calculator","arguments":{{"expr":"6*7"}}}}}}"#
+    )
+    .expect("write call");
+    // Close stdin → EOF → the server must exit cleanly on its own.
+    drop(stdin);
+
+    let out = child.wait_with_output().expect("wait");
+    assert!(
+        out.status.success(),
+        "exit={:?} stderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let lines: Vec<Value> = stdout
+        .lines()
+        .map(|l| serde_json::from_str(l).unwrap_or_else(|e| panic!("bad json line ({e}): {l}")))
+        .collect();
+    // Exactly one response per request; none for the notification.
+    assert_eq!(lines.len(), 3, "stdout: {stdout}");
+
+    assert_eq!(lines[0]["id"], 0);
+    assert_eq!(lines[0]["result"]["protocolVersion"], "2025-06-18");
+    assert_eq!(lines[0]["result"]["serverInfo"]["name"], "gizza");
+
+    assert_eq!(lines[1]["id"], 1);
+    let tools = lines[1]["result"]["tools"].as_array().expect("tools");
+    assert!(
+        tools.iter().any(|t| t["name"] == "calculator"),
+        "calculator missing from {} listed tools",
+        tools.len()
+    );
+
+    assert_eq!(lines[2]["id"], 2);
+    assert_eq!(lines[2]["result"]["content"][0]["text"], "42");
+    assert_eq!(lines[2]["result"]["isError"], false);
+}


### PR DESCRIPTION
## What

Adds a `gizza mcp` subcommand: a stdio [MCP](https://modelcontextprotocol.io) server (newline-delimited JSON-RPC 2.0 — MCP stdio framing, not LSP Content-Length headers) that exposes every catalog tool, so MCP clients (Claude Desktop, Claude Code, …) can call gizza tools locally.

- `cli/src/mcp.rs` — the server: `McpServer` (dispatch) + `serve()` (async stdin line loop via `tokio::io`, matching the CLI's existing tokio runtime; no sync bridges).
- Handles `initialize` (echoes the client's `protocolVersion` when supported — `2024-11-05` / `2025-03-26` / `2025-06-18` — else offers `2025-06-18`; capabilities `{"tools":{}}`; serverInfo `gizza`/Cargo version), `notifications/*` (silent — notifications are never answered), `ping`, `tools/list`, `tools/call`. Unknown method → `-32601`, malformed JSON → `-32700` (id `null`), non-object message → `-32600`. EOF on stdin → clean exit 0.
- `tools/list`: one MCP tool per catalog tool — name = short slug (`calculator`, `image-resize`, …), description from the manifest, `inputSchema` = the manifest's `tool.parameters` JSON Schema passed through verbatim. 403 tools listed.
- `tools/call`: executes through the same path as `gizza tool <slug>` (`ToolRuntime::run_tool` → wafer dispatch; nothing reimplemented). Text results return as `content: [{type:"text", text}]` using the same `_for_llm` rendering as the CLI. Tool failures (including runtime dispatch errors) → `isError: true` with the error text, never a JSON-RPC error. Binary outputs (ffmpeg image/video/audio envelopes) are written to a unique temp file (`$TMPDIR/gizza-mcp-XXXXXX-<name>`, traversal-safe basename via the existing `render::safe_default_out`) and the path is returned in the text content — the server's cwd belongs to the client, so outputs must not land there.

## Why

Agents could already shell out per SKILL.md, but MCP is the native integration path for Claude Desktop/Code and friends: schema-typed tools, one long-lived process (one runtime boot instead of one per call), structured errors.

## Dependencies

Zero new crates. The JSON-RPC loop is hand-rolled on `serde_json`; only two tokio features were added (`io-std`, `io-util`) for the async stdin reader, and `tempfile` (already a dependency) persists binary outputs.

## Config example

Claude Code:

```sh
claude mcp add gizza -- /path/to/gizza mcp
```

Claude Desktop (`claude_desktop_config.json`):

```json
{
  "mcpServers": {
    "gizza": { "command": "/path/to/gizza", "args": ["mcp"] }
  }
}
```

## How tested

`cargo test` (debug, full suite — includes the new `tests/mcp.rs` dispatch tests and `tests/mcp_stdio.rs` end-to-end session against the spawned binary):

```
     Running tests/mcp.rs
running 11 tests
test ping_returns_empty_result ... ok
test unknown_method_is_method_not_found ... ok
test tools_call_unknown_tool_is_invalid_params ... ok
test blank_line_is_ignored ... ok
test initialize_with_unknown_version_offers_latest ... ok
test malformed_json_is_parse_error_with_null_id ... ok
test notification_gets_no_reply ... ok
test tools_call_tool_error_sets_is_error_not_rpc_error ... ok
test tools_list_has_calculator_with_schema ... ok
test initialize_echoes_supported_protocol_version ... ok
test tools_call_calculator_returns_text_content ... ok
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 52.27s

     Running tests/mcp_stdio.rs
running 1 test
test stdio_session_initialize_list_call ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 24.37s
```

A second full run with `cargo test --release` against the final sources: all 10 suites green — lib unit tests 9 passed (includes the new `write_binary_output` temp-path test), `arg_mapping` 5, `cli_flags` 3, `discovery` 2, `ffmpeg_tool` 2, `library_api` 2, **`mcp` 11**, **`mcp_stdio` 1**, `pure_tools` 3, `stub` 1 — `0 failed` everywhere, exit 0.

`cargo build --release` → `Finished 'release' profile [optimized] target(s)`.

Release-binary smoke, scripted session piped into `gizza mcp` (initialize → initialized → ping → tools/list → tools/call ×2 → unknown method → malformed JSON, then EOF):

```
{"id":0,"jsonrpc":"2.0","result":{"capabilities":{"tools":{}},"instructions":"…","protocolVersion":"2025-06-18","serverInfo":{"name":"gizza","version":"0.1.0"}}}
{"id":1,"jsonrpc":"2.0","result":{}}
{"id":2,"jsonrpc":"2.0","result":{"tools":[… 403 tools, 503 KB …]}}
{"id":3,"jsonrpc":"2.0","result":{"content":[{"text":"42","type":"text"}],"isError":false}}
{"id":4,"jsonrpc":"2.0","result":{"content":[{"text":"eval failed: non-finite result (inf)","type":"text"}],"isError":true}}
{"error":{"code":-32601,"message":"Method not found: nope/such-method"},"id":5,"jsonrpc":"2.0"}
{"error":{"code":-32700,"message":"Parse error"},"id":null,"jsonrpc":"2.0"}
```

Exit 0, empty stderr, no reply to the notification (7 responses for 7 requests).

Binary-output path (ffmpeg tool via MCP):

```
{"id":1,"jsonrpc":"2.0","result":{"content":[{"text":"linear gradient 64x64 (PNG image, 2 stops, 422 bytes)\nOutput written to /tmp/gizza-mcp-s99Nfm-gradient.png","type":"text"}],"isError":false}}
$ file /tmp/gizza-mcp-s99Nfm-gradient.png
PNG image data, 64 x 64, 8-bit/color RGBA, non-interlaced
```

## Docs

- `cli/README.md`: new "MCP server" section with the config snippets above.
- `SKILL.md`: short "MCP server" pointer.

Review-only — please do not merge without a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
