### PR TITLE
feat(seo): related-tools links, category hubs, homepage tool links

### DIFF
--- a/scripts/gen-seo.sh
+++ b/scripts/gen-seo.sh
@@ -71,9 +71,20 @@ site_mod="$(git_lastmod site)"
 {
   printf '<?xml version="1.0" encoding="UTF-8"?>\n'
   printf '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+  blocks_mod="$(git_lastmod blocks)"
   emit_url "$BASE_URL/" "$site_mod"
   emit_url "$BASE_URL/chat" "$site_mod"
-  emit_url "$BASE_URL/tools/" "$(git_lastmod blocks)"
+  emit_url "$BASE_URL/tools/" "$blocks_mod"
+  # Category hub pages (/tools/<category>/) from the generator's _hubs.json.
+  # Skipped gracefully when the file is missing (generator not yet run); hubs
+  # aggregate many tools, so they share the blocks lastmod like /tools/.
+  hubs_json="$PKG_DIR/tools/_hubs.json"
+  if [[ -f "$hubs_json" ]]; then
+    while IFS= read -r hub_slug; do
+      [[ -z "$hub_slug" ]] && continue
+      emit_url "$BASE_URL/tools/$hub_slug/" "$blocks_mod"
+    done < <(jq -r '.[].slug' "$hubs_json")
+  fi
   for slug in "${page_slugs[@]}"; do
     emit_url "$BASE_URL/tools/$slug/" "$(git_lastmod "blocks/$slug/page")"
   done

--- a/site/index.html
+++ b/site/index.html
@@ -317,6 +317,145 @@ solobase serve</code></pre>
     </div>
   </section>
 
+  <!-- Popular tools + category hubs — static, crawlable internal links only
+       (plain <a href>, no scripts). Curated slugs must exist in blocks/; the
+       category links mirror the generator's fixed taxonomy
+       (tools/generator/src/categories.rs). -->
+  <section class="tools-links" aria-labelledby="tools-links-heading">
+    <style>
+      .tools-links {
+        padding: 48px 20px 0;
+        max-width: 860px;
+        margin: 0 auto;
+        font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      }
+      .tools-links__heading {
+        font-size: 1.5rem;
+        font-weight: 800;
+        color: #0a0a0a;
+        margin: 0 0 8px;
+        text-align: center;
+      }
+      .tools-links__sub {
+        color: #525252;
+        text-align: center;
+        margin: 0 0 28px;
+        line-height: 1.55;
+      }
+      .tools-links__grid {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+        gap: 14px;
+      }
+      .tools-links__grid a {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        height: 100%;
+        box-sizing: border-box;
+        background: #ffffff;
+        border: 1px solid #e5e5e5;
+        border-radius: 12px;
+        padding: 14px 16px;
+        text-decoration: none;
+        box-shadow: 0 1px 3px rgba(0,0,0,.05);
+        transition: border-color .15s ease, box-shadow .15s ease;
+      }
+      .tools-links__grid a:hover,
+      .tools-links__grid a:focus-visible {
+        border-color: #f54e00;
+        box-shadow: 0 4px 14px rgba(245,78,0,.15);
+      }
+      .tools-links__grid strong {
+        font-size: .95rem;
+        font-weight: 700;
+        color: #0a0a0a;
+      }
+      .tools-links__grid a:hover strong { color: #f54e00; }
+      .tools-links__grid span {
+        font-size: 13px;
+        color: #737373;
+        line-height: 1.45;
+      }
+      .tools-links__cats-heading {
+        font-size: 1rem;
+        font-weight: 700;
+        color: #0a0a0a;
+        margin: 32px 0 12px;
+        text-align: center;
+      }
+      .tools-links__cats {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        justify-content: center;
+      }
+      .tools-links__cats a {
+        display: inline-block;
+        padding: 6px 14px;
+        border: 1px solid #e5e5e5;
+        border-radius: 999px;
+        background: #ffffff;
+        color: #0a0a0a;
+        font-size: .85rem;
+        text-decoration: none;
+        transition: border-color .15s ease, color .15s ease;
+      }
+      .tools-links__cats a:hover,
+      .tools-links__cats a:focus-visible {
+        border-color: #f54e00;
+        color: #f54e00;
+      }
+      .tools-links__cats a.tools-links__all {
+        border-color: #f54e00;
+        color: #f54e00;
+        font-weight: 600;
+      }
+    </style>
+
+    <h2 class="tools-links__heading" id="tools-links-heading">Popular tools</h2>
+    <p class="tools-links__sub">Free, browser-local tools — no sign-up, nothing leaves your device.</p>
+
+    <ul class="tools-links__grid">
+      <li><a href="/tools/calculator/"><strong>Calculator</strong><span>Evaluate any math expression instantly</span></a></li>
+      <li><a href="/tools/password-generator/"><strong>Password Generator</strong><span>Strong random passwords &amp; passphrases</span></a></li>
+      <li><a href="/tools/generate-uuid/"><strong>UUID Generator</strong><span>Generate v4 / v7 UUIDs in bulk</span></a></li>
+      <li><a href="/tools/json-beautify/"><strong>JSON Beautifier</strong><span>Format, validate &amp; minify JSON</span></a></li>
+      <li><a href="/tools/json-yaml-convert/"><strong>JSON ⇄ YAML ⇄ TOML</strong><span>Convert between config formats</span></a></li>
+      <li><a href="/tools/unix-timestamp-converter/"><strong>Unix Timestamp Converter</strong><span>Epoch ⇄ human-readable dates</span></a></li>
+      <li><a href="/tools/word-count/"><strong>Word Counter</strong><span>Words, characters &amp; reading time</span></a></li>
+      <li><a href="/tools/unit-converter/"><strong>Unit Converter</strong><span>Metric ⇄ imperial, data sizes &amp; more</span></a></li>
+      <li><a href="/tools/image-convert/"><strong>Image Converter</strong><span>JPEG, PNG, WebP — right in your browser</span></a></li>
+      <li><a href="/tools/audio-convert/"><strong>Audio Converter</strong><span>MP3, WAV, OGG, FLAC &amp; more</span></a></li>
+      <li><a href="/tools/video-compress/"><strong>Video Compressor</strong><span>Shrink file size, keep the quality</span></a></li>
+      <li><a href="/tools/html-to-markdown/"><strong>HTML to Markdown</strong><span>Clean Markdown from any HTML</span></a></li>
+    </ul>
+
+    <h3 class="tools-links__cats-heading">Browse by category</h3>
+    <ul class="tools-links__cats">
+      <li><a href="/tools/audio/">Audio</a></li>
+      <li><a href="/tools/video/">Video</a></li>
+      <li><a href="/tools/image/">Image &amp; design</a></li>
+      <li><a href="/tools/data/">Data</a></li>
+      <li><a href="/tools/documents/">Documents</a></li>
+      <li><a href="/tools/security/">Security &amp; crypto</a></li>
+      <li><a href="/tools/encoding/">Encoding</a></li>
+      <li><a href="/tools/network/">Network &amp; web</a></li>
+      <li><a href="/tools/time/">Date &amp; time</a></li>
+      <li><a href="/tools/math/">Math &amp; statistics</a></li>
+      <li><a href="/tools/text/">Text</a></li>
+      <li><a href="/tools/developer/">Developer</a></li>
+      <li><a href="/tools/utilities/">Utilities</a></li>
+      <li><a class="tools-links__all" href="/tools/">All tools →</a></li>
+    </ul>
+  </section>
+
   <footer class="site-footer">
     <div class="site-footer__brand">
       <a class="site-footer__logo" href="/" aria-label="gizza.ai home">gizza.ai</a>

--- a/tools/generator/src/categories.rs
+++ b/tools/generator/src/categories.rs
@@ -1,0 +1,402 @@
+//! Fixed category taxonomy for the `/tools/` namespace: every tool page is
+//! assigned to one or more categories by tag / slug-keyword rules, and each
+//! category gets a hub page at `/tools/<category-slug>/`.
+//!
+//! Categories are matched IN ORDER — a tool's first match is its PRIMARY
+//! category (used for related-tool tie-breaking and hub ordering). A tool that
+//! matches nothing falls back to the last category (`utilities`), so every
+//! tool always lands in at least one category.
+//!
+//! Hubs live under the same `/tools/<slug>/` namespace as tool pages, so the
+//! generator must fail the build on a category-slug/block-slug collision
+//! (see [`check_slug_collisions`]).
+
+use crate::meta::ToolMeta;
+
+pub struct Category {
+    pub slug: &'static str,
+    pub title: &'static str,
+    pub blurb: &'static str,
+    /// Exact-match tags (compared lowercased/trimmed).
+    tags: &'static [&'static str],
+    /// Slug keywords: a plain word matches one hyphen-separated slug segment;
+    /// a keyword containing '-' matches as a substring of the whole slug
+    /// (e.g. "data-uri" → data-uri-encode without also grabbing parse-uri).
+    slug_words: &'static [&'static str],
+}
+
+/// The full taxonomy, in match order (first match = primary category).
+/// `utilities` is last and rule-less: it only catches the fallback.
+pub const CATEGORIES: &[Category] = &[
+    Category {
+        slug: "audio",
+        title: "Audio tools",
+        blurb: "Convert, trim, normalize and edit audio right in your browser — \
+                MP3, WAV, OGG and more. Nothing is uploaded.",
+        tags: &["audio"],
+        slug_words: &["audio", "waveform"],
+    },
+    Category {
+        slug: "video",
+        title: "Video tools",
+        blurb: "Compress, trim, resize, convert and subtitle video locally — \
+                powered by in-browser FFmpeg, no upload required.",
+        tags: &["video", "ffmpeg", "subtitle", "srt", "vtt", "webvtt", "subrip"],
+        slug_words: &["video", "gif", "srt", "subtitle"],
+    },
+    Category {
+        slug: "image",
+        title: "Image & design tools",
+        blurb: "Convert, resize, compress and recolor images and SVGs — plus \
+                color palettes, gradients and contrast checks.",
+        tags: &["image", "photo", "svg", "png", "webp"],
+        slug_words: &["image", "photo", "svg", "color", "gradient", "mindmap", "vignette"],
+    },
+    Category {
+        slug: "data",
+        title: "Data tools",
+        blurb: "CSV, JSON, YAML, XML and friends — convert, query, diff, \
+                format and clean structured data.",
+        tags: &["csv", "json", "yaml", "xml", "toml", "avro", "json query", "html table generator"],
+        slug_words: &[
+            "csv", "json", "jq", "jsonpath", "jsonata", "yaml", "xml", "xpath", "avro", "toml",
+            "plist", "protobuf", "bencode", "opml", "serialize", "unserialize",
+        ],
+    },
+    Category {
+        slug: "documents",
+        title: "Document tools",
+        blurb: "Markdown, LaTeX, citations, slides and resumes — write, \
+                convert and format documents.",
+        tags: &["markdown", "latex", "bibliography", "citation", "pdf", "epub"],
+        slug_words: &[
+            "markdown", "latex", "bibtex", "citation", "resume", "slides", "document", "toc",
+            "pdf", "epub",
+        ],
+    },
+    Category {
+        slug: "security",
+        title: "Security & crypto tools",
+        blurb: "Hashes, ciphers, JWTs, passwords, keys and threat-intel \
+                helpers — everything runs offline in your browser.",
+        tags: &[
+            "cryptography", "crypto", "cipher", "hash", "checksum", "digest", "password", "2fa",
+            "otp", "threat intelligence", "malware analysis", "key derivation", "kdf",
+            "json web token", "jws", "security", "privacy", "stream cipher", "block cipher",
+            "legacy cipher",
+        ],
+        slug_words: &[
+            "hash", "hashes", "cipher", "encrypt", "decrypt", "jwt", "jwk", "password", "totp",
+            "hotp", "otp", "otpauth", "pgp", "rsa", "ecdsa", "sm2", "sm4", "hmac", "cmac",
+            "pbkdf2", "scrypt", "argon2", "hkdf", "evp", "bcrypt", "keccak", "sha1", "sha256",
+            "sha3", "xor", "fernet", "bip39", "ja3", "ja4", "ioc", "ssh", "pem", "asn1", "luhn",
+            "token", "safelink", "aes", "des",
+        ],
+    },
+    Category {
+        slug: "encoding",
+        title: "Encoding tools",
+        blurb: "Base64, hex, URL encoding, Unicode and other codecs — encode \
+                and decode any format.",
+        tags: &["encoding", "url encode", "morse code"],
+        slug_words: &[
+            "base32", "base58", "base62", "base85", "base64", "bech32", "hex", "binary", "codec",
+            "unicode", "charset", "morse", "encoder", "encode", "byte", "lz", "data-uri",
+        ],
+    },
+    Category {
+        slug: "network",
+        title: "Network & web tools",
+        blurb: "IPs, CIDRs, DNS, URLs, HTTP and email — parse, build and \
+                analyze network and web data.",
+        tags: &["network", "dns", "http", "url", "ipv4", "ipv6", "query string"],
+        slug_words: &[
+            "ip", "ipv4", "ipv6", "cidr", "dns", "tcp", "udp", "tls", "http", "websocket", "url",
+            "urls", "uri", "mac", "ethernet", "grpc", "magnet", "email", "eml", "domains", "link",
+            "header", "query",
+        ],
+    },
+    Category {
+        slug: "time",
+        title: "Date & time tools",
+        blurb: "Timestamps, timezones, durations and cron schedules — convert \
+                and calculate dates and times.",
+        tags: &["time", "date", "timezone", "unix timestamp", "datetime", "cron expression"],
+        slug_words: &[
+            "date", "dates", "datetime", "time", "clock", "timezone", "timestamp", "cron",
+            "seconds", "age", "hms",
+        ],
+    },
+    Category {
+        slug: "math",
+        title: "Math & statistics tools",
+        blurb: "Calculators, statistics, unit conversion and number \
+                crunching — instant results, no spreadsheet needed.",
+        tags: &[
+            "math", "maths", "statistics", "standard deviation", "technical analysis",
+            "trading indicator", "moving average", "z-score",
+        ],
+        slug_words: &[
+            "calculator", "stats", "average", "sum", "percentage", "geometry", "matrix", "graph",
+            "product", "chi", "distribution", "math", "unit", "outlier", "normalize",
+        ],
+    },
+    Category {
+        slug: "text",
+        title: "Text tools",
+        blurb: "Sort, dedupe, clean, count, split and transform text and \
+                lists — the plain-text Swiss army knife.",
+        tags: &["text", "word counter", "text tool", "nlp", "text analysis"],
+        slug_words: &[
+            "text", "line", "lines", "word", "words", "case", "whitespace", "quotes", "slugify",
+            "truncate", "wrap", "unwrap", "split", "join", "sort", "dedupe", "duplicate",
+            "replace", "censor", "substring", "string", "list", "todo", "task", "emoji",
+            "readability", "summarize", "keywords", "chars", "tweet", "cleaner", "diff",
+            "frequency", "count", "ansi",
+        ],
+    },
+    Category {
+        slug: "developer",
+        title: "Developer tools",
+        blurb: "Formatters, minifiers, regex, SQL, UUIDs, mock data and other \
+                coding helpers — all client-side.",
+        tags: &[
+            "developer", "template engine", "seo", "page weight", "web performance", "regex",
+            "html", "css", "javascript", "sql",
+        ],
+        slug_words: &[
+            "regex", "sql", "css", "js", "javascript", "html", "uuid", "mock", "fake", "jinja2",
+            "template", "typescript", "flask", "session", "php", "seo", "sitemap", "form",
+            "syntax", "autoprefixer", "playground", "tree", "gzip",
+        ],
+    },
+    Category {
+        slug: "utilities",
+        title: "Utilities",
+        blurb: "Handy everyday tools that don't fit a single box — validators, \
+                formatters and more.",
+        tags: &[],
+        slug_words: &[],
+    },
+];
+
+/// A category together with its member tools, ready for hub rendering.
+pub struct Hub<'a> {
+    pub category: &'static Category,
+    pub members: Vec<&'a ToolMeta>,
+}
+
+impl Category {
+    fn matches(&self, meta: &ToolMeta) -> bool {
+        let tag_hit = meta
+            .tags
+            .iter()
+            .any(|t| self.tags.contains(&t.trim().to_lowercase().as_str()));
+        tag_hit
+            || self.slug_words.iter().any(|kw| {
+                if kw.contains('-') {
+                    meta.slug.contains(kw)
+                } else {
+                    meta.slug.split('-').any(|w| w == *kw)
+                }
+            })
+    }
+}
+
+/// Every category the tool belongs to, in taxonomy order — never empty
+/// (falls back to the last, rule-less `utilities` category).
+pub fn categories_for(meta: &ToolMeta) -> Vec<&'static Category> {
+    let matched: Vec<&'static Category> =
+        CATEGORIES.iter().filter(|c| c.matches(meta)).collect();
+    if matched.is_empty() {
+        vec![CATEGORIES.last().expect("taxonomy is non-empty")]
+    } else {
+        matched
+    }
+}
+
+/// The tool's primary category: its first match in taxonomy order.
+pub fn primary_category(meta: &ToolMeta) -> &'static Category {
+    categories_for(meta)[0]
+}
+
+/// Group tools into hubs, in taxonomy order, keeping only non-empty
+/// categories. Member order preserves the input (slug-sorted) order, so hub
+/// pages and `_hubs.json` are deterministic.
+pub fn build_hubs(metas: &[ToolMeta]) -> Vec<Hub<'_>> {
+    CATEGORIES
+        .iter()
+        .map(|category| Hub {
+            category,
+            members: metas
+                .iter()
+                .filter(|m| categories_for(m).iter().any(|c| c.slug == category.slug))
+                .collect(),
+        })
+        .filter(|hub| !hub.members.is_empty())
+        .collect()
+}
+
+/// Hubs and tool pages share the `/tools/<slug>/` namespace: a category slug
+/// that equals any block slug would silently overwrite (or be overwritten by)
+/// that tool's page, so the build must fail loudly instead.
+pub fn check_slug_collisions<'a, I>(block_slugs: I) -> Result<(), String>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    for slug in block_slugs {
+        if CATEGORIES.iter().any(|c| c.slug == slug) {
+            return Err(format!(
+                "category slug '{slug}' collides with block '{slug}' — hub pages and tool \
+                 pages share the /tools/ namespace; rename the category in categories.rs"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool(slug: &str, tags: &[&str]) -> ToolMeta {
+        let tags_toml = tags
+            .iter()
+            .map(|t| format!("\"{t}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        ToolMeta::from_toml(&format!(
+            r#"
+slug          = "{slug}"
+title         = "t"
+description   = "d"
+tags          = [{tags_toml}]
+h1            = "h"
+hero_subtitle = "s"
+wasm          = "w"
+export        = "run"
+output_label  = "o"
+format        = "text"
+"#
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn assigns_by_tag_and_by_slug_word() {
+        // tag rule: "audio" tag → audio, even without an audio slug word
+        let m = tool("waveform-image", &["audio", "png"]);
+        let cats: Vec<&str> = categories_for(&m).iter().map(|c| c.slug).collect();
+        assert_eq!(cats[0], "audio", "audio tag wins as primary (taxonomy order)");
+        assert!(cats.contains(&"image"), "slug word 'image' adds image membership");
+
+        // slug-word rule: hyphen-separated word match, not substring
+        let m = tool("image-resize", &[]);
+        assert_eq!(primary_category(&m).slug, "image");
+    }
+
+    #[test]
+    fn hyphenated_keyword_matches_substring_only() {
+        // "data-uri" (hyphenated) matches data-uri-encode as a substring…
+        let m = tool("data-uri-encode", &[]);
+        assert_eq!(primary_category(&m).slug, "encoding");
+        // …while plain "uri" must NOT pull parse-uri into encoding: it lands
+        // in network via its own word rule.
+        let m = tool("parse-uri", &[]);
+        assert_eq!(primary_category(&m).slug, "network");
+    }
+
+    #[test]
+    fn multi_membership_keeps_taxonomy_order_and_first_is_primary() {
+        // "extract-audio-from-video": audio (first) + video — primary is audio.
+        let m = tool("extract-audio-from-video", &["audio", "video"]);
+        let cats: Vec<&str> = categories_for(&m).iter().map(|c| c.slug).collect();
+        assert_eq!(cats, vec!["audio", "video"]);
+        assert_eq!(primary_category(&m).slug, "audio");
+    }
+
+    #[test]
+    fn unmatched_tool_falls_back_to_utilities() {
+        let m = tool("iban-validator", &["iban checker", "mod 97"]);
+        let cats = categories_for(&m);
+        assert_eq!(cats.len(), 1);
+        assert_eq!(cats[0].slug, "utilities");
+    }
+
+    #[test]
+    fn tag_matching_is_case_insensitive_and_trimmed() {
+        let m = tool("some-tool", &[" Audio "]);
+        assert_eq!(primary_category(&m).slug, "audio");
+    }
+
+    #[test]
+    fn assignment_is_deterministic() {
+        let m = tool("hash-text", &["hash", "hex", "base64", "cryptography"]);
+        let a: Vec<&str> = categories_for(&m).iter().map(|c| c.slug).collect();
+        let b: Vec<&str> = categories_for(&m).iter().map(|c| c.slug).collect();
+        assert_eq!(a, b);
+        assert_eq!(a[0], "security", "hash tools are security-primary");
+    }
+
+    #[test]
+    fn build_hubs_groups_in_taxonomy_order_and_drops_empty() {
+        let metas = vec![
+            tool("audio-convert", &["audio"]),
+            tool("video-trim", &["video"]),
+            tool("iban-validator", &[]),
+        ];
+        let hubs = build_hubs(&metas);
+        let slugs: Vec<&str> = hubs.iter().map(|h| h.category.slug).collect();
+        assert_eq!(slugs, vec!["audio", "video", "utilities"]);
+        assert_eq!(hubs[0].members[0].slug, "audio-convert");
+    }
+
+    #[test]
+    fn category_slug_collision_fails_the_build() {
+        // simulated collision: a block named after a category slug
+        let err = check_slug_collisions(["calculator", "audio"]).unwrap_err();
+        assert!(err.contains("'audio'"), "collision names the offending slug: {err}");
+        assert!(err.contains("/tools/"), "explains the shared namespace: {err}");
+        // no collision → ok
+        check_slug_collisions(["calculator", "hash-text"]).unwrap();
+    }
+
+    #[test]
+    fn category_slugs_are_unique() {
+        let mut slugs: Vec<&str> = CATEGORIES.iter().map(|c| c.slug).collect();
+        slugs.sort_unstable();
+        slugs.dedup();
+        assert_eq!(slugs.len(), CATEGORIES.len(), "duplicate category slug");
+    }
+
+    /// Guard on the REAL tool population (skipped when blocks/ is absent,
+    /// e.g. in a crate-only checkout): every tool must land somewhere, and
+    /// the `utilities` fallback must stay small — a growing fallback means
+    /// the match rules need new keywords, not that tools are uncategorizable.
+    #[test]
+    fn real_population_fallback_stays_small() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let blocks = root.join("blocks");
+        if !blocks.is_dir() {
+            return;
+        }
+        let metas = crate::collect_tool_metas(&blocks).expect("collect metas");
+        assert!(!metas.is_empty());
+        let metas: Vec<ToolMeta> = metas.into_iter().map(|(_, m)| m).collect();
+        let hubs = build_hubs(&metas);
+        for hub in &hubs {
+            eprintln!("{:<12} {:>3} tools", hub.category.slug, hub.members.len());
+        }
+        let fallback_members: Vec<&str> = hubs
+            .iter()
+            .find(|h| h.category.slug == "utilities")
+            .map_or_else(Vec::new, |h| h.members.iter().map(|m| m.slug.as_str()).collect());
+        let fallback = fallback_members.len();
+        eprintln!("fallback (utilities): {fallback} — {fallback_members:?}");
+        assert!(
+            fallback <= 40,
+            "{fallback} tools fell through to the utilities fallback — tighten the \
+             category match rules in categories.rs"
+        );
+    }
+}

--- a/tools/generator/src/index.rs
+++ b/tools/generator/src/index.rs
@@ -1,5 +1,6 @@
 //! Build-time JSON index of all tool pages, consumed by the in-app tools modal.
 
+use crate::categories::Hub;
 use crate::meta::ToolMeta;
 use serde::Serialize;
 
@@ -23,6 +24,30 @@ pub fn tools_index_json(metas: &[ToolMeta]) -> String {
         })
         .collect();
     serde_json::to_string(&entries).expect("serialize tools index")
+}
+
+#[derive(Serialize)]
+struct HubIndexEntry<'a> {
+    slug: &'a str,
+    title: &'a str,
+    description: &'a str,
+    count: usize,
+}
+
+/// Serialize `[{slug,title,description,count}]` for every category hub —
+/// written to `tools/_hubs.json` and consumed by `scripts/gen-seo.sh` to add
+/// the hub URLs to the sitemap.
+pub fn hubs_json(hubs: &[Hub]) -> String {
+    let entries: Vec<HubIndexEntry> = hubs
+        .iter()
+        .map(|h| HubIndexEntry {
+            slug: h.category.slug,
+            title: h.category.title,
+            description: h.category.blurb,
+            count: h.members.len(),
+        })
+        .collect();
+    serde_json::to_string(&entries).expect("serialize hubs index")
 }
 
 /// Markdown catalog of every tool — the `text/markdown` twin of the `/tools/`
@@ -102,6 +127,20 @@ source      = "field"
     #[test]
     fn empty_metas_is_empty_array() {
         assert_eq!(tools_index_json(&[]), "[]");
+    }
+
+    #[test]
+    fn hubs_json_has_slug_title_description_count() {
+        let metas = vec![calc()];
+        let hubs = crate::categories::build_hubs(&metas);
+        let v: serde_json::Value = serde_json::from_str(&hubs_json(&hubs)).unwrap();
+        assert!(v.is_array());
+        // calc() is tagged "math" → exactly one hub, the math category
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        assert_eq!(v[0]["slug"], "math");
+        assert_eq!(v[0]["title"], "Math & statistics tools");
+        assert!(v[0]["description"].as_str().unwrap().contains("Calculators"));
+        assert_eq!(v[0]["count"], 1);
     }
 
     #[test]

--- a/tools/generator/src/main.rs
+++ b/tools/generator/src/main.rs
@@ -5,12 +5,14 @@
 //! Assumes each tool's wasm-pack output already exists at
 //! `blocks/<tool>/web/pkg/`.
 
+mod categories;
 mod control;
 mod faq;
 mod index;
 mod markdown;
 mod meta;
 mod og;
+mod related;
 mod template;
 mod vocab;
 
@@ -37,7 +39,13 @@ fn run() -> Result<(), String> {
         eprintln!("no tool pages found (no blocks/*/page/meta.toml)");
     }
 
+    // Category hub pages share the /tools/<slug>/ namespace with tool pages —
+    // fail the build loudly if a block slug ever collides with a category.
+    let block_slugs = collect_block_slugs(&blocks)?;
+    categories::check_slug_collisions(block_slugs.iter().map(String::as_str))?;
+
     let og_renderer = og::OgRenderer::new();
+    let metas_only: Vec<ToolMeta> = metas.iter().map(|(_, m)| m.clone()).collect();
 
     for (tool_dir, m) in &metas {
         let out = pkg_tools.join(&m.slug);
@@ -61,11 +69,24 @@ fn run() -> Result<(), String> {
         if has_custom_css {
             copy_file(&custom_css, &out.join("custom.css"))?;
         }
-        let html = template::render_page(m, &content_html, &schema, has_custom_js, has_custom_css);
+        // Top-5 related tools by shared tags — internal links on the page and
+        // its markdown twin.
+        let related = related::related_tools(m, &metas_only);
+        let html = template::render_page(
+            m,
+            &content_html,
+            &schema,
+            has_custom_js,
+            has_custom_css,
+            &related,
+        );
         fs::write(out.join("index.html"), html)
             .map_err(|e| format!("write index.html: {e}"))?;
-        fs::write(out.join("index.md"), markdown::tool_markdown(m, &content_md, &schema))
-            .map_err(|e| format!("write index.md: {e}"))?;
+        fs::write(
+            out.join("index.md"),
+            markdown::tool_markdown(m, &content_md, &schema, &related),
+        )
+        .map_err(|e| format!("write index.md: {e}"))?;
         // Per-tool Open Graph card — the page's og:image/twitter:image target.
         fs::write(out.join("og.png"), og_renderer.tool_card(m)?)
             .map_err(|e| format!("write og.png: {e}"))?;
@@ -96,12 +117,15 @@ fn run() -> Result<(), String> {
 
     // Static index for the in-app tools modal (fetched client-side; lives under
     // /tools/ so it is covered by the runtime SW's /tools/ bypass).
-    let metas_only: Vec<ToolMeta> = metas.iter().map(|(_, m)| m.clone()).collect();
     fs::write(
         pkg_tools.join("_index.json"),
         index::tools_index_json(&metas_only),
     )
     .map_err(|e| format!("write tools/_index.json: {e}"))?;
+
+    // Category hubs: group the same metas by the fixed taxonomy. Rendered
+    // below as /tools/<category>/ pages and linked from the landing nav.
+    let hubs = categories::build_hubs(&metas_only);
 
     // `/tools/` landing page — a build-time card grid of every tool, rendered
     // from the same `metas` as the per-tool pages + `_index.json` (one source of
@@ -109,7 +133,7 @@ fn run() -> Result<(), String> {
     // etc. resolve when the page is served at `/tools/`.
     fs::write(
         pkg_tools.join("index.html"),
-        template::render_tools_index(&metas_only),
+        template::render_tools_index(&metas_only, &hubs),
     )
     .map_err(|e| format!("write tools/index.html: {e}"))?;
     // Markdown twin of the landing page (the "tools .md page") for LLMs/agents.
@@ -126,7 +150,52 @@ fn run() -> Result<(), String> {
         .map_err(|e| format!("write tools/og.png: {e}"))?;
     eprintln!("rendered tools/ (landing page, {} tools)", metas_only.len());
 
+    // Category hub pages at /tools/<category>/ — a member-card grid with its
+    // own SEO head, OG card and chrome assets (same relative-asset pattern as
+    // the landing page).
+    for hub in &hubs {
+        let out = pkg_tools.join(hub.category.slug);
+        fs::create_dir_all(&out).map_err(|e| format!("mkdir {}: {e}", out.display()))?;
+        fs::write(
+            out.join("index.html"),
+            template::render_category_hub(hub, &hubs),
+        )
+        .map_err(|e| format!("write tools/{}/index.html: {e}", hub.category.slug))?;
+        fs::write(out.join("og.png"), og_renderer.hub_card(hub.category)?)
+            .map_err(|e| format!("write tools/{}/og.png: {e}", hub.category.slug))?;
+        for asset in ["tool.css", "header.css", "header.js", "tools-index.js"] {
+            copy_file(&root.join("site").join(asset), &out.join(asset))?;
+        }
+        eprintln!(
+            "rendered tools/{}/ (hub, {} tools)",
+            hub.category.slug,
+            hub.members.len()
+        );
+    }
+    // Machine-readable hub index — consumed by scripts/gen-seo.sh to add the
+    // hub URLs to the sitemap.
+    fs::write(pkg_tools.join("_hubs.json"), index::hubs_json(&hubs))
+        .map_err(|e| format!("write tools/_hubs.json: {e}"))?;
+
     Ok(())
+}
+
+/// Every direct subdirectory name of `blocks/` — the full block-slug
+/// namespace, including blocks without a page (a future page would collide
+/// with a hub just the same).
+fn collect_block_slugs(blocks: &Path) -> Result<Vec<String>, String> {
+    let mut out = Vec::new();
+    if !blocks.is_dir() {
+        return Ok(out);
+    }
+    for entry in fs::read_dir(blocks).map_err(|e| format!("read blocks/: {e}"))? {
+        let entry = entry.map_err(|e| format!("blocks entry: {e}"))?;
+        if entry.path().is_dir() {
+            out.push(entry.file_name().to_string_lossy().into_owned());
+        }
+    }
+    out.sort();
+    Ok(out)
 }
 
 /// Find every `blocks/<tool>/page/meta.toml`, parse it, sorted by slug.

--- a/tools/generator/src/markdown.rs
+++ b/tools/generator/src/markdown.rs
@@ -9,8 +9,14 @@ use crate::meta::{Input, ToolMeta};
 const SITE: &str = "https://gizza.ai";
 
 /// Render a tool's `index.md`: a generated header (description, run-it, inputs,
-/// output) followed by the tool's prose `content.md`, verbatim.
-pub fn tool_markdown(meta: &ToolMeta, content_md: &str, schema: &ParamSchema) -> String {
+/// output) followed by the tool's prose `content.md`, verbatim, and a
+/// "Related tools" link list (same top-5 as the HTML page).
+pub fn tool_markdown(
+    meta: &ToolMeta,
+    content_md: &str,
+    schema: &ParamSchema,
+    related: &[&ToolMeta],
+) -> String {
     let mut s = String::new();
     s.push_str(&format!("# {}\n\n", meta.h1));
     s.push_str(&format!("{}\n\n", meta.description));
@@ -63,6 +69,16 @@ pub fn tool_markdown(meta: &ToolMeta, content_md: &str, schema: &ParamSchema) ->
     s.push_str("---\n\n");
     s.push_str(content_md.trim_end());
     s.push('\n');
+
+    if !related.is_empty() {
+        s.push_str("\n## Related tools\n\n");
+        for r in related {
+            s.push_str(&format!(
+                "- [{}]({}/tools/{}/): {}\n",
+                r.h1, SITE, r.slug, r.description
+            ));
+        }
+    }
     s
 }
 
@@ -298,7 +314,7 @@ source = "clock"
 
     #[test]
     fn field_tool_has_header_runit_inputs_output_prose() {
-        let md = tool_markdown(&field_tool(), "Some **prose** about the calculator.", &crate::control::ParamSchema::empty());
+        let md = tool_markdown(&field_tool(), "Some **prose** about the calculator.", &crate::control::ParamSchema::empty(), &[]);
         assert!(md.contains("# Free Online Calculator"));
         assert!(md.contains("`gizza tool calculator \"2 + 2 * 3\"`"), "CLI example");
         assert!(md.contains("https://gizza.ai/tools/calculator/"), "web URL");
@@ -309,7 +325,7 @@ source = "clock"
 
     #[test]
     fn file_tool_uses_url_example_and_accept() {
-        let md = tool_markdown(&file_tool(), "prose", &crate::control::ParamSchema::empty());
+        let md = tool_markdown(&file_tool(), "prose", &crate::control::ParamSchema::empty(), &[]);
         assert!(
             md.contains("`gizza tool image-grayscale 'url=https://example.com/input'`"),
             "url= CLI example"
@@ -410,14 +426,53 @@ placeholder = "cotton, linen"
 
     #[test]
     fn live_tool_takes_no_manual_arguments() {
-        let md = tool_markdown(&live_tool(), "prose", &crate::control::ParamSchema::empty());
+        let md = tool_markdown(&live_tool(), "prose", &crate::control::ParamSchema::empty(), &[]);
         assert!(md.contains("`gizza tool clock`"), "no-arg CLI example");
         assert!(md.contains("_no manual inputs — runs automatically_"), "no manual inputs note");
     }
 
     #[test]
+    fn related_tools_appended_as_markdown_link_list() {
+        let percentage = ToolMeta::from_toml(
+            r#"
+slug          = "percentage-calculator"
+title         = "t"
+description   = "Work out percentages instantly."
+h1            = "Percentage Calculator"
+hero_subtitle = "s"
+wasm          = "w"
+export        = "run"
+output_label  = "o"
+format        = "text"
+"#,
+        )
+        .unwrap();
+        let related = vec![&percentage];
+        let md = tool_markdown(
+            &field_tool(),
+            "prose",
+            &crate::control::ParamSchema::empty(),
+            &related,
+        );
+        assert!(md.contains("## Related tools"), "related section present");
+        assert!(
+            md.contains(
+                "- [Percentage Calculator](https://gizza.ai/tools/percentage-calculator/): \
+                 Work out percentages instantly."
+            ),
+            "related entry is an absolute markdown link with the description"
+        );
+        // the section comes AFTER the prose content
+        assert!(md.find("prose").unwrap() < md.find("## Related tools").unwrap());
+
+        // no related tools → no empty section
+        let md = tool_markdown(&field_tool(), "prose", &crate::control::ParamSchema::empty(), &[]);
+        assert!(!md.contains("## Related tools"));
+    }
+
+    #[test]
     fn field_tool_documents_query_parameters_with_example() {
-        let md = tool_markdown(&field_tool(), "prose", &crate::control::ParamSchema::empty());
+        let md = tool_markdown(&field_tool(), "prose", &crate::control::ParamSchema::empty(), &[]);
         assert!(md.contains("## Query parameters"), "query-params section present");
         assert!(md.contains("- `expr`"), "field param listed");
         assert!(
@@ -428,7 +483,7 @@ placeholder = "cotton, linen"
 
     #[test]
     fn file_tool_documents_url_query_parameter() {
-        let md = tool_markdown(&file_tool(), "prose", &crate::control::ParamSchema::empty());
+        let md = tool_markdown(&file_tool(), "prose", &crate::control::ParamSchema::empty(), &[]);
         assert!(md.contains("## Query parameters"));
         assert!(md.contains("- `url`"), "media tools document ?url=");
     }
@@ -436,7 +491,7 @@ placeholder = "cotton, linen"
     #[test]
     fn live_tool_has_no_query_parameters_section() {
         // clock has only a "clock" input — nothing to deep-link.
-        let md = tool_markdown(&live_tool(), "prose", &crate::control::ParamSchema::empty());
+        let md = tool_markdown(&live_tool(), "prose", &crate::control::ParamSchema::empty(), &[]);
         assert!(!md.contains("## Query parameters"), "no query-params for auto-only tools");
     }
 }

--- a/tools/generator/src/og.rs
+++ b/tools/generator/src/og.rs
@@ -50,6 +50,15 @@ impl OgRenderer {
         ))
     }
 
+    /// Render the card for a category hub page (`/tools/<category>/`).
+    pub fn hub_card(&self, category: &crate::categories::Category) -> Result<Vec<u8>, String> {
+        self.render(&card_svg(
+            category.title,
+            category.blurb,
+            &format!("gizza.ai/tools/{}", category.slug),
+        ))
+    }
+
     /// Render the card for the `/tools/` landing page.
     pub fn index_card(&self, tool_count: usize) -> Result<Vec<u8>, String> {
         self.render(&card_svg(

--- a/tools/generator/src/related.rs
+++ b/tools/generator/src/related.rs
@@ -1,0 +1,146 @@
+//! Related-tools ranking: for each tool, the top 5 others by shared-tag
+//! count, rendered as internal links on the tool page and its markdown twin.
+//!
+//! Ordering is fully deterministic: score (shared normalized tags) descending,
+//! then same-primary-category before different, then slug ascending. Tools
+//! with zero shared tags still rank (category and slug break the tie), so
+//! every page gets a full related section even for niche tag sets.
+
+use std::collections::BTreeSet;
+
+use crate::categories::primary_category;
+use crate::meta::ToolMeta;
+
+/// How many related tools each page links to.
+pub const RELATED_COUNT: usize = 5;
+
+fn normalized_tags(meta: &ToolMeta) -> BTreeSet<String> {
+    meta.tags.iter().map(|t| t.trim().to_lowercase()).collect()
+}
+
+/// The top [`RELATED_COUNT`] tools related to `target`, excluding itself.
+pub fn related_tools<'a>(target: &ToolMeta, all: &'a [ToolMeta]) -> Vec<&'a ToolMeta> {
+    let target_tags = normalized_tags(target);
+    let target_primary = primary_category(target).slug;
+    let mut ranked: Vec<(usize, bool, &ToolMeta)> = all
+        .iter()
+        .filter(|m| m.slug != target.slug)
+        .map(|m| {
+            let shared = normalized_tags(m).intersection(&target_tags).count();
+            let same_primary = primary_category(m).slug == target_primary;
+            (shared, same_primary, m)
+        })
+        .collect();
+    ranked.sort_by(|a, b| {
+        b.0.cmp(&a.0)
+            .then_with(|| b.1.cmp(&a.1))
+            .then_with(|| a.2.slug.cmp(&b.2.slug))
+    });
+    ranked.into_iter().take(RELATED_COUNT).map(|(_, _, m)| m).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool(slug: &str, tags: &[&str]) -> ToolMeta {
+        let tags_toml = tags
+            .iter()
+            .map(|t| format!("\"{t}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        ToolMeta::from_toml(&format!(
+            r#"
+slug          = "{slug}"
+title         = "t"
+description   = "d"
+tags          = [{tags_toml}]
+h1            = "h"
+hero_subtitle = "s"
+wasm          = "w"
+export        = "run"
+output_label  = "o"
+format        = "text"
+"#
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn ranks_by_shared_tag_count_descending() {
+        let all = vec![
+            tool("audio-convert", &["audio", "convert", "mp3", "wav"]),
+            tool("audio-compress", &["audio", "compress", "mp3"]),
+            tool("audio-eq", &["audio", "equalizer"]),
+            tool("video-trim", &["video", "trim"]),
+        ];
+        let related = related_tools(&all[0], &all);
+        // audio-compress shares 2 tags (audio, mp3) > audio-eq's 1 > video-trim's 0
+        let slugs: Vec<&str> = related.iter().map(|m| m.slug.as_str()).collect();
+        assert_eq!(slugs, vec!["audio-compress", "audio-eq", "video-trim"]);
+    }
+
+    #[test]
+    fn excludes_self_and_caps_at_five() {
+        let mut all = vec![tool("audio-convert", &["audio"])];
+        for i in 0..8 {
+            all.push(tool(&format!("audio-{i}"), &["audio"]));
+        }
+        let related = related_tools(&all[0], &all);
+        assert_eq!(related.len(), RELATED_COUNT);
+        assert!(related.iter().all(|m| m.slug != "audio-convert"), "self excluded");
+    }
+
+    #[test]
+    fn tie_breaks_same_primary_category_then_slug() {
+        // Both share exactly one tag ("trim") with the target; the same-
+        // primary-category tool (audio) must outrank the video tool, even
+        // though "video-trim" < "z-audio-loop" alphabetically.
+        let all = vec![
+            tool("audio-fade", &["trim"]),
+            tool("z-audio-loop", &["trim"]),
+            tool("video-trim", &["trim"]),
+        ];
+        let related = related_tools(&all[0], &all);
+        let slugs: Vec<&str> = related.iter().map(|m| m.slug.as_str()).collect();
+        assert_eq!(slugs, vec!["z-audio-loop", "video-trim"]);
+
+        // Pure slug tie-break: same score, same primary category.
+        let all = vec![
+            tool("audio-fade", &["audio"]),
+            tool("audio-loop", &["audio"]),
+            tool("audio-eq", &["audio"]),
+        ];
+        let related = related_tools(&all[0], &all);
+        let slugs: Vec<&str> = related.iter().map(|m| m.slug.as_str()).collect();
+        assert_eq!(slugs, vec!["audio-eq", "audio-loop"], "slug ascending on full tie");
+    }
+
+    #[test]
+    fn tag_comparison_is_normalized() {
+        let all = vec![
+            tool("a-tool", &["Audio ", "MP3"]),
+            tool("b-tool", &["audio", "mp3"]),
+            tool("c-tool", &["unrelated"]),
+        ];
+        let related = related_tools(&all[0], &all);
+        assert_eq!(related[0].slug, "b-tool", "case/whitespace-insensitive tag match");
+    }
+
+    #[test]
+    fn ranking_is_deterministic() {
+        let all = vec![
+            tool("a", &["x"]),
+            tool("b", &["x"]),
+            tool("c", &["x"]),
+            tool("d", &["y"]),
+        ];
+        let first: Vec<String> =
+            related_tools(&all[0], &all).iter().map(|m| m.slug.clone()).collect();
+        for _ in 0..3 {
+            let again: Vec<String> =
+                related_tools(&all[0], &all).iter().map(|m| m.slug.clone()).collect();
+            assert_eq!(first, again);
+        }
+    }
+}

--- a/tools/generator/src/template.rs
+++ b/tools/generator/src/template.rs
@@ -1,23 +1,36 @@
 //! Renders the option-C tool page: top nav + hero tool + SEO content + footer,
 //! with SEO `<head>` tags and JSON-LD.
 
+use crate::categories::Hub;
 use crate::control::{fmt_num, Control, ParamSchema};
 use crate::markdown::{cli_example as shared_cli_example, example_deeplink};
 use crate::meta::ToolMeta;
 use gizza_chrome::{header as chrome_header, footer as chrome_footer, Active};
-use maud::{html, PreEscaped, DOCTYPE};
+use maud::{html, Markup, PreEscaped, DOCTYPE};
+
+/// The shared header's brand block — identical on every generated page.
+fn brand_link() -> Markup {
+    html! {
+        a.tool-brand href="https://gizza.ai" {
+            img src="/logo.webp" alt="gizza.ai logo";
+            span { "gizza.ai" }
+        }
+    }
+}
 
 /// Render the full HTML document for a tool page. `content_html` is the
 /// markdown-rendered SEO section. `custom_js`/`custom_css` say whether the tool
 /// ships a `page/custom.js`/`page/custom.css` (copied next to the page by
 /// main.rs) — the escape hatch for bespoke UI that the declarative meta.toml
-/// controls can't express.
+/// controls can't express. `related` is the tag-ranked top-5 from
+/// `related::related_tools`, rendered as internal links.
 pub fn render_page(
     meta: &ToolMeta,
     content_html: &str,
     schema: &ParamSchema,
     custom_js: bool,
     custom_css: bool,
+    related: &[&ToolMeta],
 ) -> String {
     let canonical = format!("https://gizza.ai/tools/{}/", meta.slug);
     // Both JSON blobs below are emitted raw inside <script> via PreEscaped, so a
@@ -100,6 +113,9 @@ pub fn render_page(
                 }
                 link rel="icon" href="https://gizza.ai/favicon-32.png" sizes="32x32";
                 style { (PreEscaped(TOOL_CLI_CSS)) }
+                @if !related.is_empty() {
+                    style { (PreEscaped(TOOL_RELATED_CSS)) }
+                }
                 script type="application/ld+json" { (PreEscaped(json_ld)) }
                 script type="application/ld+json" { (PreEscaped(breadcrumbs_ld)) }
                 @if let Some(faq_ld) = &faq_ld {
@@ -108,15 +124,7 @@ pub fn render_page(
                 script type="module" src="./header.js" {}
             }
             body {
-                ({
-                    let brand = html! {
-                        a.tool-brand href="https://gizza.ai" {
-                            img src="/logo.webp" alt="gizza.ai logo";
-                            span { "gizza.ai" }
-                        }
-                    };
-                    chrome_header(brand, Active::Tool)
-                })
+                (chrome_header(brand_link(), Active::Tool))
                 main class="tool-main" {
                     section class="tool-hero" {
                         h1 { (meta.h1) }
@@ -297,6 +305,22 @@ pub fn render_page(
                     section class="tool-content" {
                         (PreEscaped(content_html))
                     }
+                    // Internal links to the tag-nearest tools — crawlable
+                    // `<a href>`s that spread link equity across the catalog
+                    // and give readers a next step.
+                    @if !related.is_empty() {
+                        section class="tool-related" {
+                            h2 { "Related tools" }
+                            ul class="tool-related-list" {
+                                @for r in related {
+                                    li class="tool-related-item" {
+                                        a class="tool-related-link" href=(format!("/tools/{}/", r.slug)) { (r.h1) }
+                                        p class="tool-related-desc" { (r.description) }
+                                    }
+                                }
+                            }
+                        }
+                    }
                     section class="tool-dev-group" {
                         h2 { "Developer & Automation Access" }
                         div class="tool-dev-grid" {
@@ -392,6 +416,18 @@ const TOOL_CLI_CSS: &str = r#"
 .tool-cli-note { font-size: .85rem; margin: 12px 0 0; color: var(--tool-muted, #6b7280); margin-top: auto; padding-top: 10px; }
 "#;
 
+/// Inline styles for the per-tool "Related tools" section (same card idiom as
+/// the CLI block above; only emitted when the section renders).
+const TOOL_RELATED_CSS: &str = r#"
+.tool-related { max-width: 720px; margin: 48px auto 0; }
+.tool-related h2 { font-size: 1.3rem; margin: 0 0 12px; color: var(--tool-ink, #0f172a); border-bottom: 1px solid #e2e8f0; padding-bottom: 8px; }
+.tool-related-list { list-style: none; margin: 0; padding: 0; display: grid; gap: 10px; }
+.tool-related-item { background: #ffffff; border: 1px solid #e2e8f0; border-radius: 12px; padding: 14px 16px; box-shadow: 0 1px 3px rgba(0,0,0,0.05); }
+.tool-related-link { font-weight: 650; color: var(--tool-accent, #4f46e5); text-decoration: none; }
+.tool-related-link:hover, .tool-related-link:focus-visible { text-decoration: underline; }
+.tool-related-desc { margin: 4px 0 0; font-size: .9rem; color: var(--tool-muted, #6b7280); line-height: 1.45; }
+"#;
+
 /// Inline styles for the `/tools/` landing grid (uses the `--tool-*` tokens
 /// from `tool.css`, with literal fallbacks matching them).
 const TOOLS_INDEX_CSS: &str = r#"
@@ -411,6 +447,14 @@ const TOOLS_INDEX_CSS: &str = r#"
 .tools-index__search input:focus { border-color: var(--tool-accent, #4f46e5); box-shadow: 0 0 0 3px rgba(79,70,229,.12); }
 .tools-index__empty { text-align: center; color: var(--tool-muted, #6b7280); margin: 24px 0 8px; }
 .tools-grid li[hidden] { display: none; }
+.tools-cats { display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; margin: 0 0 28px; }
+.tools-cats__link { display: inline-flex; align-items: center; gap: 6px; padding: 6px 14px; border: 1px solid #e5e7eb; border-radius: 999px; background: #fff; text-decoration: none; color: var(--tool-ink, #0f172a); font-size: .88rem; transition: border-color .15s, color .15s; }
+.tools-cats__link:hover, .tools-cats__link:focus-visible { border-color: var(--tool-accent, #4f46e5); color: var(--tool-accent, #4f46e5); }
+.tools-cats__link[aria-current="page"] { border-color: var(--tool-accent, #4f46e5); background: rgba(79,70,229,.08); color: var(--tool-accent, #4f46e5); }
+.tools-cats__count { font-size: .75rem; color: var(--tool-muted, #6b7280); }
+.tools-breadcrumb { font-size: .85rem; color: var(--tool-muted, #6b7280); margin: 0 0 10px; }
+.tools-breadcrumb a { color: inherit; text-decoration: none; }
+.tools-breadcrumb a:hover { text-decoration: underline; }
 "#;
 
 /// Client-side filter for the `/tools/` grid — reuses `filterTools` from
@@ -441,19 +485,43 @@ async function apply() {
 input.addEventListener('input', apply);
 "#;
 
-/// Render the `/tools/` landing page: shared chrome + a responsive card grid of
-/// every tool that has a page. Built from the same `ToolMeta` slice as the
-/// per-tool pages and `_index.json` — one source of truth, no drift.
-pub fn render_tools_index(metas: &[ToolMeta]) -> String {
-    let canonical = "https://gizza.ai/tools/";
-    let title = "All Tools — gizza.ai";
-    let description = "Browse every gizza.ai tool — free, private, browser-local utilities. \
-        No sign-up, nothing leaves your device, works offline.";
-    // JSON-LD ItemList of the tools (SEO); `</`-neutralized like the other pages.
-    let item_list = serde_json::json!({
+/// The shared `<head>` SEO cluster for the `/tools/` landing and category hub
+/// pages: title/description/canonical, OG + twitter card tags and relative
+/// stylesheet/icon links (both pages get their chrome assets copied alongside).
+fn index_head_meta(title: &str, description: &str, canonical: &str, og_image: &str) -> Markup {
+    html! {
+        meta charset="utf-8";
+        meta name="viewport" content="width=device-width, initial-scale=1";
+        title { (title) }
+        meta name="description" content=(description);
+        link rel="canonical" href=(canonical);
+        meta property="og:type" content="website";
+        meta property="og:title" content=(title);
+        meta property="og:description" content=(description);
+        meta property="og:url" content=(canonical);
+        meta property="og:image" content=(og_image);
+        meta property="og:image:width" content="1200";
+        meta property="og:image:height" content="630";
+        meta property="og:image:alt" content=(title);
+        meta name="twitter:card" content="summary_large_image";
+        meta name="twitter:title" content=(title);
+        meta name="twitter:description" content=(description);
+        meta name="twitter:image" content=(og_image);
+        link rel="stylesheet" href="https://site-kit.suppers.ai/dist/design-system.css";
+        link rel="stylesheet" href="./tool.css";
+        link rel="stylesheet" href="./header.css";
+        link rel="icon" href="https://gizza.ai/favicon-32.png" sizes="32x32";
+        style { (PreEscaped(TOOLS_INDEX_CSS)) }
+    }
+}
+
+/// ItemList JSON-LD for a set of tool cards, `</`-neutralized like the other
+/// JSON-LD blobs. Shared by the landing page and the category hubs.
+fn item_list_json_ld(name: &str, metas: &[&ToolMeta]) -> String {
+    serde_json::json!({
         "@context": "https://schema.org",
         "@type": "ItemList",
-        "name": "gizza.ai tools",
+        "name": name,
         "itemListElement": metas.iter().enumerate().map(|(i, m)| serde_json::json!({
             "@type": "ListItem",
             "position": i + 1,
@@ -462,34 +530,68 @@ pub fn render_tools_index(metas: &[ToolMeta]) -> String {
         })).collect::<Vec<_>>(),
     })
     .to_string()
-    .replace("</", "<\\/");
+    .replace("</", "<\\/")
+}
+
+/// The server-rendered tool-card grid (crawlable `<a href>` per tool) —
+/// shared by the `/tools/` landing and the category hub pages. `data-slug`
+/// is what the landing's client-side filter keys on.
+fn tools_grid(metas: &[&ToolMeta]) -> Markup {
+    html! {
+        ul #tools-grid class="tools-grid" {
+            @for m in metas {
+                li data-slug=(m.slug) {
+                    a class="tools-card" href=(format!("/tools/{}/", m.slug)) {
+                        h2 class="tools-card__title" { (m.h1) }
+                        p class="tools-card__desc" { (m.description) }
+                        @if !m.tags.is_empty() {
+                            div class="tools-card__tags" {
+                                @for t in m.tags.iter().take(3) {
+                                    span class="tools-card__tag" { (t) }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Crawlable category-hub nav (title + tool count per hub), shared by the
+/// landing page and the hubs themselves; `current` marks the open hub.
+fn category_nav(hubs: &[Hub], current: Option<&str>) -> Markup {
+    html! {
+        nav class="tools-cats" aria-label="Tool categories" {
+            @for hub in hubs {
+                @let is_current = current == Some(hub.category.slug);
+                a class="tools-cats__link" href=(format!("/tools/{}/", hub.category.slug))
+                  aria-current=[is_current.then_some("page")] {
+                    (hub.category.title)
+                    span class="tools-cats__count" { (hub.members.len()) }
+                }
+            }
+        }
+    }
+}
+
+/// Render the `/tools/` landing page: shared chrome + a category nav + a
+/// responsive card grid of every tool that has a page. Built from the same
+/// `ToolMeta` slice as the per-tool pages and `_index.json` — one source of
+/// truth, no drift.
+pub fn render_tools_index(metas: &[ToolMeta], hubs: &[Hub]) -> String {
+    let canonical = "https://gizza.ai/tools/";
+    let title = "All Tools — gizza.ai";
+    let description = "Browse every gizza.ai tool — free, private, browser-local utilities. \
+        No sign-up, nothing leaves your device, works offline.";
+    let refs: Vec<&ToolMeta> = metas.iter().collect();
+    let item_list = item_list_json_ld("gizza.ai tools", &refs);
 
     let markup = html! {
         (DOCTYPE)
         html lang="en" {
             head {
-                meta charset="utf-8";
-                meta name="viewport" content="width=device-width, initial-scale=1";
-                title { (title) }
-                meta name="description" content=(description);
-                link rel="canonical" href=(canonical);
-                meta property="og:type" content="website";
-                meta property="og:title" content=(title);
-                meta property="og:description" content=(description);
-                meta property="og:url" content=(canonical);
-                meta property="og:image" content="https://gizza.ai/tools/og.png";
-                meta property="og:image:width" content="1200";
-                meta property="og:image:height" content="630";
-                meta property="og:image:alt" content=(title);
-                meta name="twitter:card" content="summary_large_image";
-                meta name="twitter:title" content=(title);
-                meta name="twitter:description" content=(description);
-                meta name="twitter:image" content="https://gizza.ai/tools/og.png";
-                link rel="stylesheet" href="https://site-kit.suppers.ai/dist/design-system.css";
-                link rel="stylesheet" href="./tool.css";
-                link rel="stylesheet" href="./header.css";
-                link rel="icon" href="https://gizza.ai/favicon-32.png" sizes="32x32";
-                style { (PreEscaped(TOOLS_INDEX_CSS)) }
+                (index_head_meta(title, description, canonical, "https://gizza.ai/tools/og.png"))
                 script type="application/ld+json" { (PreEscaped(item_list)) }
                 script type="application/ld+json" {
                     (PreEscaped(breadcrumbs_json_ld(&[
@@ -500,15 +602,7 @@ pub fn render_tools_index(metas: &[ToolMeta]) -> String {
                 script type="module" src="./header.js" {}
             }
             body {
-                ({
-                    let brand = html! {
-                        a.tool-brand href="https://gizza.ai" {
-                            img src="/logo.webp" alt="gizza.ai logo";
-                            span { "gizza.ai" }
-                        }
-                    };
-                    chrome_header(brand, Active::Tool)
-                })
+                (chrome_header(brand_link(), Active::Tool))
                 main class="tools-index" {
                     section class="tools-index__hero" {
                         h1 { "All tools" }
@@ -522,29 +616,65 @@ pub fn render_tools_index(metas: &[ToolMeta]) -> String {
                                   aria-label="Search tools";
                         }
                     }
+                    // Category hubs — crawlable links with per-hub tool counts.
+                    (category_nav(hubs, None))
                     // Cards are server-rendered (crawlable for SEO); the filter
                     // below just shows/hides them client-side via filterTools.
-                    ul #tools-grid class="tools-grid" {
-                        @for m in metas {
-                            li data-slug=(m.slug) {
-                                a class="tools-card" href=(format!("/tools/{}/", m.slug)) {
-                                    h2 class="tools-card__title" { (m.h1) }
-                                    p class="tools-card__desc" { (m.description) }
-                                    @if !m.tags.is_empty() {
-                                        div class="tools-card__tags" {
-                                            @for t in m.tags.iter().take(3) {
-                                                span class="tools-card__tag" { (t) }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    (tools_grid(&refs))
                     p #tools-empty class="tools-index__empty" hidden { "No tools match your search." }
                 }
                 (chrome_footer())
                 script type="module" { (PreEscaped(TOOLS_FILTER_JS)) }
+            }
+        }
+    };
+    markup.into_string()
+}
+
+/// Render a category hub page at `/tools/<category>/`: the category's title,
+/// blurb and member-card grid, with its own canonical/OG/ItemList/breadcrumb
+/// SEO head, a visible breadcrumb back to `/tools/`, and the sibling-category
+/// nav. No client-side filter here — that stays a landing-page affordance
+/// (its `_index.json` fetch is relative to `/tools/`).
+pub fn render_category_hub(hub: &Hub, all_hubs: &[Hub]) -> String {
+    let cat = hub.category;
+    let canonical = format!("https://gizza.ai/tools/{}/", cat.slug);
+    let title = format!("{} — gizza.ai", cat.title);
+    let og_image = format!("https://gizza.ai/tools/{}/og.png", cat.slug);
+    let item_list = item_list_json_ld(cat.title, &hub.members);
+    let breadcrumbs = breadcrumbs_json_ld(&[
+        ("Home", "https://gizza.ai/"),
+        ("Tools", "https://gizza.ai/tools/"),
+        (cat.title, &canonical),
+    ]);
+
+    let markup = html! {
+        (DOCTYPE)
+        html lang="en" {
+            head {
+                (index_head_meta(&title, cat.blurb, &canonical, &og_image))
+                script type="application/ld+json" { (PreEscaped(item_list)) }
+                script type="application/ld+json" { (PreEscaped(breadcrumbs)) }
+                script type="module" src="./header.js" {}
+            }
+            body {
+                (chrome_header(brand_link(), Active::Tool))
+                main class="tools-index" {
+                    section class="tools-index__hero" {
+                        p class="tools-breadcrumb" {
+                            a href="/" { "Home" }
+                            " › "
+                            a href="/tools/" { "All tools" }
+                            " › "
+                            span { (cat.title) }
+                        }
+                        h1 { (cat.title) }
+                        p class="tools-index__sub" { (cat.blurb) }
+                    }
+                    (category_nav(all_hubs, Some(cat.slug)))
+                    (tools_grid(&hub.members))
+                }
+                (chrome_footer())
             }
         }
     };
@@ -582,7 +712,7 @@ source      = "field"
 
     #[test]
     fn includes_seo_head_and_widget() {
-        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false);
+        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
         assert!(html.contains("<title>Free Online Calculator — gizza.ai</title>"));
         assert!(html.contains(r#"<link rel="canonical" href="https://gizza.ai/tools/calculator/">"#));
         assert!(
@@ -598,7 +728,7 @@ source      = "field"
 
     #[test]
     fn emits_per_tool_og_image_and_breadcrumbs() {
-        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false);
+        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
         assert!(
             html.contains(r#"content="https://gizza.ai/tools/calculator/og.png""#),
             "og:image + twitter:image point at the per-tool card"
@@ -617,11 +747,11 @@ source      = "field"
     fn faq_json_ld_mirrors_content_faq_section() {
         let with_faq = "<h2>FAQ</h2>\
             <details><summary>Is it private?</summary><p>Yes — runs locally.</p></details>";
-        let html = render_page(&sample(), with_faq, &ParamSchema::empty(), false, false);
+        let html = render_page(&sample(), with_faq, &ParamSchema::empty(), false, false, &[]);
         assert!(html.contains(r#""@type":"FAQPage""#), "FAQPage JSON-LD present");
         assert!(html.contains(r#""name":"Is it private?""#));
 
-        let without = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false);
+        let without = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
         assert!(
             !without.contains("FAQPage"),
             "no FAQPage block when the page has no FAQ section"
@@ -630,7 +760,7 @@ source      = "field"
 
     #[test]
     fn page_documents_query_param_deep_link() {
-        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false);
+        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
         assert!(html.contains("Open it by URL"), "deep-link section present");
         assert!(
             html.contains("https://gizza.ai/tools/calculator/?expr="),
@@ -640,7 +770,7 @@ source      = "field"
 
     #[test]
     fn includes_shared_chrome_header_and_footer() {
-        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false);
+        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
         // Shared header markers from gizza-chrome
         assert!(
             html.contains(r#"id="explore-search""#),
@@ -664,7 +794,9 @@ source      = "field"
 
     #[test]
     fn tools_index_lists_all_tools_with_chrome() {
-        let html = render_tools_index(&[sample()]);
+        let metas = [sample()];
+        let hubs = crate::categories::build_hubs(&metas);
+        let html = render_tools_index(&metas, &hubs);
         // landing-page SEO + shared chrome
         assert!(html.contains("<title>All Tools — gizza.ai</title>"));
         assert!(html.contains(r#"<link rel="canonical" href="https://gizza.ai/tools/">"#));
@@ -683,6 +815,105 @@ source      = "field"
         assert!(html.contains(r#"content="https://gizza.ai/tools/og.png""#));
         assert!(html.contains(r#"name="twitter:card" content="summary_large_image""#));
         assert!(html.contains(r#""@type":"BreadcrumbList""#));
+    }
+
+    #[test]
+    fn tools_index_renders_category_nav_with_counts() {
+        // sample() ("calculator", no tags) lands in math via its slug word.
+        let metas = [sample()];
+        let hubs = crate::categories::build_hubs(&metas);
+        let html = render_tools_index(&metas, &hubs);
+        assert!(
+            html.contains(r#"<nav class="tools-cats" aria-label="Tool categories">"#),
+            "category nav present above the grid"
+        );
+        assert!(
+            html.contains(r#"<a class="tools-cats__link" href="/tools/math/""#),
+            "crawlable hub link"
+        );
+        assert!(
+            html.contains(r#"Math &amp; statistics tools<span class="tools-cats__count">1</span>"#),
+            "hub link shows the title and tool count"
+        );
+        // the nav renders BEFORE the card grid
+        let nav = html.find(r#"<nav class="tools-cats""#).unwrap();
+        let grid = html.find(r#"data-slug="calculator""#).unwrap();
+        assert!(nav < grid, "category nav sits above the grid");
+    }
+
+    #[test]
+    fn category_hub_page_has_seo_head_grid_and_nav() {
+        let metas = [sample()];
+        let hubs = crate::categories::build_hubs(&metas);
+        let hub = &hubs[0];
+        assert_eq!(hub.category.slug, "math");
+        let html = render_category_hub(hub, &hubs);
+        // SEO head: canonical, description, per-hub og card
+        assert!(html.contains("<title>Math &amp; statistics tools — gizza.ai</title>"));
+        assert!(html.contains(r#"<link rel="canonical" href="https://gizza.ai/tools/math/">"#));
+        assert!(html.contains(r#"content="https://gizza.ai/tools/math/og.png""#), "per-hub og.png");
+        assert!(html.contains(r#"name="description" content="Calculators"#), "blurb as meta description");
+        // JSON-LD: member ItemList + Home › Tools › Category breadcrumbs
+        assert!(html.contains(r#""@type":"ItemList""#));
+        assert!(html.contains(r#""url":"https://gizza.ai/tools/calculator/""#), "member in ItemList");
+        assert!(html.contains(r#""@type":"BreadcrumbList""#));
+        // serde_json orders keys alphabetically: item precedes name
+        assert!(html.contains(r#""item":"https://gizza.ai/tools/math/","name":"Math & statistics tools""#));
+        // hero: h1 = category title + blurb, visible breadcrumb back to /tools/
+        assert!(html.contains("<h1>Math &amp; statistics tools</h1>"));
+        assert!(html.contains(r#"<a href="/tools/">All tools</a>"#), "links back to the landing");
+        // member card grid, crawlable
+        assert!(html.contains(r#"<a class="tools-card" href="/tools/calculator/""#));
+        assert!(html.contains("Free Online Calculator"));
+        // sibling nav marks the current hub
+        assert!(html.contains(r#"href="/tools/math/" aria-current="page""#));
+        // no client-side filter here — its _index.json fetch is landing-relative
+        assert!(!html.contains(r#"id="tools-filter""#), "no search filter on hub pages");
+        // shared chrome
+        assert!(html.contains(r#"id="explore-search""#), "shared header present");
+        assert!(html.contains("Resources"), "shared footer present");
+    }
+
+    #[test]
+    fn related_tools_section_renders_between_content_and_dev_access() {
+        let related_meta = ToolMeta::from_toml(
+            r#"
+slug          = "percentage-calculator"
+title         = "t"
+description   = "Work out percentages instantly."
+h1            = "Percentage Calculator"
+hero_subtitle = "s"
+wasm          = "w"
+export        = "run"
+output_label  = "o"
+format        = "text"
+"#,
+        )
+        .unwrap();
+        let related = vec![&related_meta];
+        let html =
+            render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &related);
+        assert!(html.contains(r#"<section class="tool-related">"#), "related section present");
+        assert!(html.contains("<h2>Related tools</h2>"));
+        assert!(
+            html.contains(r#"<a class="tool-related-link" href="/tools/percentage-calculator/">Percentage Calculator</a>"#),
+            "linked title"
+        );
+        assert!(
+            html.contains(r#"<p class="tool-related-desc">Work out percentages instantly.</p>"#),
+            "one-line description"
+        );
+        assert!(html.contains(".tool-related-list"), "related CSS emitted");
+        // placement: content → related → Developer & Automation Access
+        let content = html.find(r#"class="tool-content""#).unwrap();
+        let related_at = html.find(r#"class="tool-related""#).unwrap();
+        let dev = html.find("Developer &amp; Automation Access").unwrap();
+        assert!(content < related_at && related_at < dev, "related sits between content and dev access");
+
+        // no related tools → neither the section nor its CSS
+        let html =
+            render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
+        assert!(!html.contains("tool-related"), "no empty related section");
     }
 
     fn ffmpeg_sample() -> ToolMeta {
@@ -758,7 +989,7 @@ params = { birthdate = "1990-04-15" }
 
     #[test]
     fn renders_declarative_controls_examples_and_widget_chrome() {
-        let html = render_page(&declarative_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false);
+        let html = render_page(&declarative_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
         // meta kind="date" → native picker, no per-tool JS type-swapping
         assert!(html.contains(r#"id="in-birthdate" class="tool-input" type="date""#), "date picker rendered");
         // meta options="timezones" → datalist autocomplete
@@ -823,7 +1054,7 @@ label       = "Gain"
             "semitones": { "type": "number", "minimum": -24, "maximum": 24 },
             "gain": { "type": "number", "minimum": -60, "maximum": 60 }
         }));
-        let html = render_page(&meta, "<h2>About</h2>", &schema, false, false);
+        let html = render_page(&meta, "<h2>About</h2>", &schema, false, false, &[]);
         // kind="slider" → a range input mirroring the canonical number box
         assert!(html.contains(r#"id="in-semitones-slider""#), "slider rendered");
         assert!(html.contains(r#"data-for="in-semitones""#), "slider targets its number box");
@@ -883,7 +1114,7 @@ kind        = "color"
             "color": { "type": "string", "default": "#4f46e5" },
             "background": { "type": "string" }
         }));
-        let html = render_page(&meta, "<h2>About</h2>", &schema, false, false);
+        let html = render_page(&meta, "<h2>About</h2>", &schema, false, false, &[]);
         // kind="color" → a native swatch mirroring the canonical TEXT input
         assert!(html.contains(r##"id="in-color-swatch""##), "swatch rendered");
         assert!(html.contains(r##"data-for="in-color""##), "swatch targets its text input");
@@ -933,7 +1164,7 @@ labels = { "9:16" = "9:16 — Reels / Shorts / TikTok (1080×1920)", "1:1" = "1:
         let schema = ParamSchema::from_props_for_tests(serde_json::json!({
             "aspect": { "type": "string", "enum": ["9:16", "1:1", "16:9"], "default": "9:16" }
         }));
-        let html = render_page(&meta, "<h2>About</h2>", &schema, false, false);
+        let html = render_page(&meta, "<h2>About</h2>", &schema, false, false, &[]);
         // labeled options: canonical value attr + enriched visible text
         assert!(
             html.contains(r#"<option value="9:16" selected>9:16 — Reels / Shorts / TikTok (1080×1920)</option>"#),
@@ -949,7 +1180,7 @@ labels = { "9:16" = "9:16 — Reels / Shorts / TikTok (1080×1920)", "1:1" = "1:
 
     #[test]
     fn media_tools_get_reset_but_not_copy_result() {
-        let html = render_page(&ffmpeg_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false);
+        let html = render_page(&ffmpeg_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
         assert!(html.contains(r#"id="tool-reset""#), "reset present (has fields)");
         assert!(!html.contains(r#"id="tool-copy-output""#), "no copy-result on media output");
     }
@@ -959,7 +1190,7 @@ labels = { "9:16" = "9:16 — Reels / Shorts / TikTok (1080×1920)", "1:1" = "1:
         // ffmpeg_sample() is format="image" → the Copy-image button is rendered
         // (hidden, next to the download link), so a result can be copied to the
         // clipboard as PNG by tool.js.
-        let image_html = render_page(&ffmpeg_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false);
+        let image_html = render_page(&ffmpeg_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
         assert!(
             image_html.contains(r#"id="tool-copy-image""#),
             "image-output page renders the Copy-image button"
@@ -991,7 +1222,7 @@ accept = "video/*"
 "#,
         )
         .unwrap();
-        let video_html = render_page(&video_meta, "<h2>About</h2>", &ParamSchema::empty(), false, false);
+        let video_html = render_page(&video_meta, "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
         assert!(
             !video_html.contains(r#"id="tool-copy-image""#),
             "video-output page must not render the Copy-image button"
@@ -1018,14 +1249,14 @@ accept = "audio/*"
 "#,
         )
         .unwrap();
-        let audio_html = render_page(&audio_meta, "<h2>About</h2>", &ParamSchema::empty(), false, false);
+        let audio_html = render_page(&audio_meta, "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
         assert!(
             !audio_html.contains(r#"id="tool-copy-image""#),
             "audio-output page must not render the Copy-image button"
         );
 
         // Text output (declarative_sample is format="text") must NOT get it.
-        let text_html = render_page(&declarative_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false);
+        let text_html = render_page(&declarative_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
         assert!(
             !text_html.contains(r#"id="tool-copy-image""#),
             "text-output page must not render the Copy-image button"
@@ -1034,7 +1265,7 @@ accept = "audio/*"
 
     #[test]
     fn renders_file_input_and_media_output() {
-        let html = render_page(&ffmpeg_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false);
+        let html = render_page(&ffmpeg_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
         assert!(html.contains(r#"type="file""#), "file input present");
         assert!(html.contains(r#"id="in-image""#), "file input id");
         assert!(html.contains(r#"accept="image/*""#), "accept attr");


### PR DESCRIPTION
PR 2 of the SEO & AI-readability program, **stacked on #178 (`seo/structured-data`)** — review only the top commit.

## What

Internal linking across the tool catalog: every page now links sideways (related tools), upward (category hubs, breadcrumbs) and downward (homepage → popular tools → hubs → tools), so crawlers and readers can reach any of the 324 tool pages through short, topical paths instead of one flat 324-card grid.

### Category taxonomy (`tools/generator/src/categories.rs`, new)
- Fixed 13 categories, matched **in order** by exact-tag and slug-keyword rules (a keyword containing `-` matches as a slug substring, e.g. `data-uri` without grabbing `parse-uri`). First match = primary category; a tool can belong to several.
- Every tool lands in ≥1 category; the rule-less `utilities` category catches the rest. Real population: **only 3/324 fall through** (gpx-analyzer, iban-validator, phone-format), guarded by a `fallback <= 40` test against the real `blocks/` tree.
- Hubs share the `/tools/<slug>/` namespace with tool pages, so the generator **fails the build** on a category/block slug collision (`check_slug_collisions`, wired in `main.rs` against all 456 block dirs, unit-tested with a simulated collision).

Final category set and counts (multi-membership, so counts sum > 324):

| category | tools | | category | tools |
|---|---|---|---|---|
| audio | 13 | | network | 45 |
| video | 17 | | time | 10 |
| image | 21 | | math | 23 |
| data | 42 | | text | 53 |
| documents | 14 | | developer | 35 |
| security | 69 | | encoding | 21 |
| utilities | 3 | | | |

### Related tools (`tools/generator/src/related.rs`, new)
- Top 5 per tool by shared normalized-tag count desc, tie-break same-primary-category first, then slug asc — fully deterministic, self excluded.
- Rendered as a "Related tools" section (linked title + one-line description) between the content and "Developer & Automation Access" sections, styled via an inline-CSS const like the existing blocks; also appended as `## Related tools` (absolute links) in each tool's `index.md` twin.
- Example (audio-convert): extract-audio-from-video, audio-compress, audio-to-mono, trim-audio, audio-eq.

### Category hub pages (`pkg/tools/<category>/index.html`)
- Reuses the landing grid via shared `tools_grid` / `category_nav` / `index_head_meta` helpers (no copy-paste of the landing markup).
- h1 = category title + blurb, canonical `https://gizza.ai/tools/<cat>/`, meta description, member ItemList JSON-LD, `Home › Tools › {Category}` BreadcrumbList, per-hub 1200×630 `og.png` via the existing `OgRenderer`, crawlable member-card grid, visible breadcrumb back to `/tools/` and sibling-category nav (current hub marked `aria-current`).
- No client-side search filter on hubs — its `_index.json` fetch is landing-relative.

### /tools/ landing
- Crawlable category nav (title + tool count per hub) between the hero and the grid.

### Sitemap plumbing
- Generator writes `pkg/tools/_hubs.json` (`[{slug,title,description,count}]`).
- `scripts/gen-seo.sh` reads it with jq and emits the 13 hub URLs (lastmod = `git_lastmod blocks`, same as `/tools/`); skipped gracefully when the file is missing. `shellcheck` findings unchanged vs base (3× pre-existing SC2016).

### Homepage (`site/index.html`)
- Static, crawlable "Popular tools" section — 12 curated tools (calculator, password-generator, generate-uuid, json-beautify, json-yaml-convert, unix-timestamp-converter, word-count, unit-converter, image-convert, audio-convert, video-compress, html-to-markdown; every slug verified against `blocks/`) plus pill links to all 13 category hubs. Plain `<section>`/`<h2>`/`<a>` markup with a scoped `<style>`, matching the existing about-section conventions.

## Tested

- `cargo test` in `tools/generator`: **81 passed, 0 failed** (new: category assignment/fallback/multi-membership/determinism, simulated slug-collision failure, real-population fallback guard, related scoring/tie-breaks/determinism, hub-page markup, related-section markup + placement, landing category nav, `_hubs.json`, markdown related list).
- `cargo clippy --all-targets`: no new warnings (only the pre-existing `ParamSchema::empty` dead-code warning, present on the base branch).
- Full release generator run over the repo: 324 tool pages + 13 hubs rendered; spot-checked `pkg/tools/audio/index.html` (canonical, per-hub og.png, ItemList + BreadcrumbList JSON-LD, 13 member cards, sibling nav with `aria-current`, no filter input), the related section + `index.md` twin of `audio-convert`, and `pkg/tools/_hubs.json`.
- `GIZZA=gizza scripts/gen-seo.sh`: sitemap contains all 13 hub URLs with lastmod (340 URLs total = 3 top-level + 13 hubs + 324 tools); re-ran with `_hubs.json` removed → script still succeeds with 0 hub entries.
- Homepage section rendered in a browser (screenshot-checked); all 25 new `/tools/...` links verified to resolve to an existing block or category.

🤖 Generated with [Claude Code](https://claude.com/claude-code)