### PR TITLE
feat(seo): per-tool tool.json descriptors, llms-full.txt, agent surfaces

### DIFF
--- a/scripts/gen-seo.sh
+++ b/scripts/gen-seo.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # gen-seo.sh — gizza list-driven SEO file generator
-# Writes pkg/sitemap.xml, pkg/robots.txt, pkg/llms.txt
+# Writes pkg/sitemap.xml, pkg/robots.txt, pkg/llms.txt, pkg/llms-full.txt
 # Run from repo root (or pass repo root as first argument).
 set -euo pipefail
 
@@ -134,9 +134,34 @@ site_mod="$(git_lastmod site)"
   printf -- '- [Discord](https://discord.com/invite/jKqMcbrVzm): community and support\n'
   printf -- '- [Donate](https://github.com/sponsors/Jsuppers): support the project\n'
   printf -- '- [CLI README](https://github.com/gizza-ai/gizza-ai/blob/main/cli/README.md): gizza CLI reference\n'
-  printf -- '- [SKILL.md](https://github.com/gizza-ai/gizza-ai/blob/main/SKILL.md): agent integration guide\n\n'
+  printf -- '- [SKILL.md](https://github.com/gizza-ai/gizza-ai/blob/main/SKILL.md): agent integration guide\n'
+  printf -- '- [llms-full.txt](%s/llms-full.txt): every tool page'\''s full markdown documentation in one file\n\n' "$BASE_URL"
   printf 'For the authoritative machine-readable tool catalog, see `/tools/_index.json` or\n'
   printf 'run `gizza list --json-out`. The catalog is build-time static and always up to date.\n'
+  printf "Every tool also serves a JSON Schema descriptor at \`/tools/<slug>/tool.json\`\n"
+  printf '(identity, URLs, CLI invocation and tool parameters).\n'
 } > "$PKG_DIR/llms.txt"
 
-echo "gen-seo.sh: wrote $PKG_DIR/sitemap.xml, $PKG_DIR/robots.txt, $PKG_DIR/llms.txt"
+# --- llms-full.txt (header + every pkg/tools/*/index.md, slug order) ---
+# The generator writes the per-tool index.md files before this script runs in
+# deploy; when they are absent (e.g. gen-seo.sh run standalone), skip with a
+# warning rather than emitting a header-only file.
+mapfile -t index_mds < <(
+  [[ -d "$PKG_DIR/tools" ]] &&
+    find "$PKG_DIR/tools" -mindepth 2 -maxdepth 2 -name index.md -type f | sort
+)
+if ((${#index_mds[@]} == 0)); then
+  echo "gen-seo.sh: warning: no pkg/tools/*/index.md files — skipping llms-full.txt (run the tool-page generator first)" >&2
+else
+  {
+    printf '# gizza.ai — full tool documentation'
+    for md in "${index_mds[@]}"; do
+      # $(<file) drops trailing newlines, so documents are separated by
+      # exactly one '---' block regardless of each file's final newline.
+      printf '\n\n---\n\n%s' "$(<"$md")"
+    done
+    printf '\n'
+  } > "$PKG_DIR/llms-full.txt"
+fi
+
+echo "gen-seo.sh: wrote $PKG_DIR/sitemap.xml, $PKG_DIR/robots.txt, $PKG_DIR/llms.txt${index_mds[0]:+, $PKG_DIR/llms-full.txt}"

--- a/tools/generator/src/descriptor.rs
+++ b/tools/generator/src/descriptor.rs
@@ -1,0 +1,283 @@
+//! Per-tool machine-readable descriptor (`tool.json`) — slug, name, category,
+//! URLs (page / markdown twin / descriptor / deep-link example), the same
+//! copy-paste CLI invocation as the page, and the block manifest's `tool`
+//! schema (description + parameters JSON Schema, verbatim) — so agents can
+//! discover and call a tool without scraping HTML.
+
+use crate::categories;
+use crate::control::ParamSchema;
+use crate::markdown::{cli_example, example_deeplink};
+use crate::meta::ToolMeta;
+use serde::Serialize;
+use serde_json::Value;
+use std::path::Path;
+
+/// Public site origin — matches the literal used in `template.rs`/`markdown.rs`.
+const SITE: &str = "https://gizza.ai";
+
+/// The `tool.json` document. Field order here is the emitted key order
+/// (serde serializes struct fields in declaration order).
+#[derive(Serialize)]
+struct Descriptor<'a> {
+    slug: &'a str,
+    name: String,
+    /// Block version from `manifest.json`; omitted when the manifest is missing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<String>,
+    title: &'a str,
+    description: &'a str,
+    tags: &'a [String],
+    /// Primary category slug (first taxonomy match — see `categories.rs`).
+    category: &'static str,
+    urls: Urls,
+    /// Copy-paste-runnable CLI invocation — identical to the page/markdown example.
+    cli: String,
+    /// The manifest's `tool` block (description + parameters JSON Schema,
+    /// passed through verbatim). Omitted — with a stderr warning — when the
+    /// block has no manifest or no `tool` object.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool: Option<ToolSpec>,
+}
+
+#[derive(Serialize)]
+struct Urls {
+    page: String,
+    markdown: String,
+    descriptor: String,
+    /// Pre-filled auto-run URL — identical to the page/markdown example.
+    /// Omitted for auto-only tools (nothing to deep-link, same rule as the
+    /// markdown twin's "Query parameters" section).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    deep_link_example: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ToolSpec {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parameters: Option<Value>,
+}
+
+/// Read `<tool_dir>/manifest.json` as raw JSON. `None` when missing or
+/// unparseable — `tool_descriptor` warns and degrades instead of aborting the
+/// build over one stale manifest.
+pub fn load_manifest(tool_dir: &Path) -> Option<Value> {
+    let text = std::fs::read_to_string(tool_dir.join("manifest.json")).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+/// Build the pretty-printed `tool.json` for one tool. `manifest` is the raw
+/// `blocks/<slug>/manifest.json` (from [`load_manifest`]); when it — or its
+/// `tool` object — is missing, the descriptor is still written without the
+/// `tool` key so the discovery surface never disappears with a stale manifest.
+pub fn tool_descriptor(meta: &ToolMeta, schema: &ParamSchema, manifest: Option<&Value>) -> String {
+    let base = format!("{SITE}/tools/{}/", meta.slug);
+    let tool = match manifest {
+        None => {
+            eprintln!(
+                "warning: no readable manifest.json for {} — tool.json omits the `tool` schema",
+                meta.slug
+            );
+            None
+        }
+        Some(m) => match m.get("tool").filter(|t| t.is_object()) {
+            None => {
+                eprintln!(
+                    "warning: manifest for {} has no `tool` object — tool.json omits the `tool` schema",
+                    meta.slug
+                );
+                None
+            }
+            Some(t) => Some(ToolSpec {
+                description: t.get("description").cloned(),
+                parameters: t.get("parameters").cloned(),
+            }),
+        },
+    };
+    let descriptor = Descriptor {
+        slug: &meta.slug,
+        name: format!("gizza-ai/{}", meta.slug),
+        version: manifest
+            .and_then(|m| m.get("version"))
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        title: &meta.title,
+        description: &meta.description,
+        tags: &meta.tags,
+        category: categories::primary_category(meta).slug,
+        urls: Urls {
+            page: base.clone(),
+            markdown: format!("{base}index.md"),
+            descriptor: format!("{base}tool.json"),
+            deep_link_example: meta
+                .inputs
+                .iter()
+                .any(|i| i.source == "field" || i.source == "file")
+                .then(|| example_deeplink(meta, schema)),
+        },
+        cli: cli_example(meta, schema),
+        tool,
+    };
+    serde_json::to_string_pretty(&descriptor).expect("serialize tool descriptor")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn audio_tool() -> ToolMeta {
+        ToolMeta::from_toml(
+            r#"
+slug          = "audio-convert"
+title         = "Convert Audio — gizza.ai"
+description   = "Convert audio between formats in your browser."
+tags          = ["audio"]
+h1            = "Convert Audio"
+hero_subtitle = "Upload an audio file."
+wasm          = "gizza_ai_audio_convert_web"
+export        = "build_argv"
+output_label  = "Audio"
+format        = "audio"
+runtime       = "ffmpeg"
+
+[[input]]
+name   = "audio"
+label  = "Audio"
+source = "file"
+accept = "audio/*"
+
+[[input]]
+name   = "format"
+label  = "Format"
+source = "field"
+"#,
+        )
+        .unwrap()
+    }
+
+    fn manifest() -> Value {
+        json!({
+            "name": "gizza-ai/audio-convert",
+            "version": "0.1.0",
+            "interface": "handler@v1",
+            "summary": "Convert audio between formats",
+            "role": "skill",
+            "tool": {
+                "description": "Convert an audio file to mp3, wav, ogg, flac or m4a.",
+                "parameters": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "url": { "type": "string", "description": "Audio URL." },
+                        "format": { "type": "string", "enum": ["mp3", "wav"], "default": "mp3" }
+                    },
+                    "required": ["format"]
+                }
+            }
+        })
+    }
+
+    fn schema_of(manifest: &Value) -> ParamSchema {
+        ParamSchema::from_props_for_tests(manifest["tool"]["parameters"]["properties"].clone())
+    }
+
+    #[test]
+    fn happy_path_has_identity_urls_cli_and_schema() {
+        let m = manifest();
+        let json = tool_descriptor(&audio_tool(), &schema_of(&m), Some(&m));
+        let v: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["slug"], "audio-convert");
+        assert_eq!(v["name"], "gizza-ai/audio-convert");
+        assert_eq!(v["version"], "0.1.0");
+        assert_eq!(v["title"], "Convert Audio — gizza.ai");
+        assert_eq!(v["description"], "Convert audio between formats in your browser.");
+        assert_eq!(v["tags"][0], "audio");
+        assert_eq!(v["category"], "audio", "primary category slug");
+        assert_eq!(v["urls"]["page"], "https://gizza.ai/tools/audio-convert/");
+        assert_eq!(v["urls"]["markdown"], "https://gizza.ai/tools/audio-convert/index.md");
+        assert_eq!(v["urls"]["descriptor"], "https://gizza.ai/tools/audio-convert/tool.json");
+        assert_eq!(
+            v["urls"]["deep_link_example"],
+            "https://gizza.ai/tools/audio-convert/?url=https://example.com/input&format=mp3",
+            "deep-link example matches example_deeplink"
+        );
+        assert_eq!(
+            v["cli"],
+            "gizza tool audio-convert 'url=https://example.com/input' 'format=mp3'",
+            "CLI example matches cli_example"
+        );
+        assert_eq!(
+            v["tool"]["description"],
+            "Convert an audio file to mp3, wav, ogg, flac or m4a."
+        );
+        // Pretty-printed (multi-line) output.
+        assert!(json.contains('\n'), "pretty-printed");
+    }
+
+    #[test]
+    fn missing_manifest_is_tolerated_without_tool_or_version() {
+        let json = tool_descriptor(&audio_tool(), &ParamSchema::empty(), None);
+        let v: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["slug"], "audio-convert");
+        assert_eq!(v["name"], "gizza-ai/audio-convert");
+        assert!(v.get("tool").is_none(), "tool key omitted");
+        assert!(v.get("version").is_none(), "version omitted");
+        assert_eq!(v["urls"]["descriptor"], "https://gizza.ai/tools/audio-convert/tool.json");
+        assert!(v["cli"].as_str().unwrap().starts_with("gizza tool audio-convert"));
+    }
+
+    #[test]
+    fn manifest_without_tool_object_keeps_version_but_omits_tool() {
+        let m = json!({ "name": "gizza-ai/audio-convert", "version": "0.2.0" });
+        let v: Value =
+            serde_json::from_str(&tool_descriptor(&audio_tool(), &ParamSchema::empty(), Some(&m)))
+                .unwrap();
+        assert_eq!(v["version"], "0.2.0");
+        assert!(v.get("tool").is_none(), "tool key omitted");
+    }
+
+    #[test]
+    fn parameters_schema_is_passed_through_verbatim() {
+        let m = manifest();
+        let v: Value =
+            serde_json::from_str(&tool_descriptor(&audio_tool(), &schema_of(&m), Some(&m)))
+                .unwrap();
+        assert_eq!(
+            v["tool"]["parameters"], m["tool"]["parameters"],
+            "full JSON Schema — required, enum, defaults, additionalProperties — intact"
+        );
+    }
+
+    #[test]
+    fn auto_only_tool_has_no_deep_link_example() {
+        let clock = ToolMeta::from_toml(
+            r#"
+slug          = "clock"
+title         = "Clock — gizza.ai"
+description   = "The current time, live."
+h1            = "Clock"
+hero_subtitle = "Live time."
+wasm          = "gizza_ai_clock_web"
+export        = "now"
+live          = true
+output_label  = "Time"
+format        = "text"
+
+[[input]]
+name   = "now"
+label  = "Now"
+source = "clock"
+"#,
+        )
+        .unwrap();
+        let v: Value =
+            serde_json::from_str(&tool_descriptor(&clock, &ParamSchema::empty(), None)).unwrap();
+        assert!(
+            v["urls"].get("deep_link_example").is_none(),
+            "nothing to deep-link on an auto-only tool"
+        );
+        assert_eq!(v["cli"], "gizza tool clock");
+    }
+}

--- a/tools/generator/src/index.rs
+++ b/tools/generator/src/index.rs
@@ -10,9 +10,13 @@ struct IndexEntry<'a> {
     title: &'a str,
     description: &'a str,
     tags: &'a [String],
+    /// Site-relative path of the tool's machine-readable descriptor
+    /// (`tool.json` — identity, URLs, CLI example, parameters JSON Schema).
+    descriptor: String,
 }
 
-/// Serialize `[{slug,title,description,tags}]` for every tool, in the given order.
+/// Serialize `[{slug,title,description,tags,descriptor}]` for every tool, in
+/// the given order.
 pub fn tools_index_json(metas: &[ToolMeta]) -> String {
     let entries: Vec<IndexEntry> = metas
         .iter()
@@ -21,6 +25,7 @@ pub fn tools_index_json(metas: &[ToolMeta]) -> String {
             title: &m.title,
             description: &m.description,
             tags: &m.tags,
+            descriptor: format!("/tools/{}/tool.json", m.slug),
         })
         .collect();
     serde_json::to_string(&entries).expect("serialize tools index")
@@ -110,6 +115,10 @@ source      = "field"
         assert_eq!(v[0]["description"], "Evaluate expressions instantly.");
         assert_eq!(v[0]["tags"][0], "math");
         assert_eq!(v[0]["tags"][1], "arithmetic");
+        assert_eq!(
+            v[0]["descriptor"], "/tools/calculator/tool.json",
+            "entry links the machine-readable descriptor"
+        );
     }
 
     #[test]

--- a/tools/generator/src/main.rs
+++ b/tools/generator/src/main.rs
@@ -7,6 +7,7 @@
 
 mod categories;
 mod control;
+mod descriptor;
 mod faq;
 mod index;
 mod markdown;
@@ -87,6 +88,13 @@ fn run() -> Result<(), String> {
             markdown::tool_markdown(m, &content_md, &schema, &related),
         )
         .map_err(|e| format!("write index.md: {e}"))?;
+        // Machine-readable descriptor (identity, URLs, CLI example and the
+        // manifest's tool schema) — the agent-facing twin of the page.
+        fs::write(
+            out.join("tool.json"),
+            descriptor::tool_descriptor(m, &schema, descriptor::load_manifest(tool_dir).as_ref()),
+        )
+        .map_err(|e| format!("write tool.json: {e}"))?;
         // Per-tool Open Graph card — the page's og:image/twitter:image target.
         fs::write(out.join("og.png"), og_renderer.tool_card(m)?)
             .map_err(|e| format!("write og.png: {e}"))?;

--- a/tools/generator/src/markdown.rs
+++ b/tools/generator/src/markdown.rs
@@ -23,7 +23,12 @@ pub fn tool_markdown(
 
     s.push_str("## Run it\n\n");
     s.push_str(&format!("- **CLI:** `{}`\n", cli_example(meta, schema)));
-    s.push_str(&format!("- **Web:** {}/tools/{}/\n\n", SITE, meta.slug));
+    s.push_str(&format!("- **Web:** {}/tools/{}/\n", SITE, meta.slug));
+    s.push_str(&format!(
+        "- **Agents:** machine-readable descriptor (parameters JSON Schema) at \
+         {}/tools/{}/tool.json\n\n",
+        SITE, meta.slug
+    ));
 
     s.push_str("## Inputs\n\n");
     let manual: Vec<&Input> = meta
@@ -321,6 +326,18 @@ source = "clock"
         assert!(md.contains("`expr` — Expression _(field)_"), "input listed");
         assert!(md.contains("Result (number)"), "output listed");
         assert!(md.contains("Some **prose** about the calculator."), "prose appended");
+    }
+
+    #[test]
+    fn run_it_mentions_the_machine_readable_descriptor() {
+        let md = tool_markdown(&field_tool(), "prose", &crate::control::ParamSchema::empty(), &[]);
+        assert!(
+            md.contains(
+                "- **Agents:** machine-readable descriptor (parameters JSON Schema) at \
+                 https://gizza.ai/tools/calculator/tool.json"
+            ),
+            "Run it lists the tool.json descriptor"
+        );
     }
 
     #[test]

--- a/tools/generator/src/template.rs
+++ b/tools/generator/src/template.rs
@@ -93,6 +93,7 @@ pub fn render_page(
                 meta name="description" content=(meta.description);
                 link rel="canonical" href=(canonical);
                 link rel="alternate" type="text/markdown" href="index.md";
+                link rel="alternate" type="application/json" href="tool.json";
                 meta property="og:type" content="website";
                 meta property="og:title" content=(meta.title);
                 meta property="og:description" content=(meta.description);
@@ -366,6 +367,13 @@ pub fn render_page(
                                 }
                             }
                         }
+                        // Full-width footer line under the grid — the third
+                        // automation surface next to the CLI and deep-link cards.
+                        p class="tool-dev-note" {
+                            "Machine-readable descriptor: "
+                            a href="tool.json" { "tool.json" }
+                            " — title + parameters JSON Schema for agents."
+                        }
                     }
                 }
                 (chrome_footer())
@@ -414,6 +422,8 @@ const TOOL_CLI_CSS: &str = r#"
 .tool-cli-copy-btn.copied .copy-icon { display: none; }
 .tool-cli-copy-btn.copied .check-icon { display: block; }
 .tool-cli-note { font-size: .85rem; margin: 12px 0 0; color: var(--tool-muted, #6b7280); margin-top: auto; padding-top: 10px; }
+.tool-dev-note { font-size: .85rem; color: var(--tool-muted, #6b7280); margin: 14px 2px 0; }
+.tool-dev-note a { color: var(--tool-accent, #4f46e5); }
 "#;
 
 /// Inline styles for the per-tool "Related tools" section (same card idiom as
@@ -756,6 +766,24 @@ source      = "field"
             !without.contains("FAQPage"),
             "no FAQPage block when the page has no FAQ section"
         );
+    }
+
+    #[test]
+    fn links_machine_readable_descriptor_in_head_and_dev_section() {
+        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
+        assert!(
+            html.contains(r#"<link rel="alternate" type="application/json" href="tool.json">"#),
+            "tool.json discovery link in the head",
+        );
+        assert!(
+            html.contains(r#"<p class="tool-dev-note">Machine-readable descriptor: <a href="tool.json">tool.json</a>"#),
+            "dev section links the descriptor",
+        );
+        // placement: the note sits inside the dev group, after the grid
+        let grid = html.find(r#"class="tool-dev-grid""#).unwrap();
+        let note = html.find(r#"class="tool-dev-note""#).unwrap();
+        assert!(grid < note, "note renders under the dev-access grid");
+        assert!(html.contains(".tool-dev-note"), "note CSS emitted");
     }
 
     #[test]


### PR DESCRIPTION
PR 3 of the stacked SEO & AI-readability program (base: `seo/internal-linking`, PR #180).

## What

Machine-readable agent surfaces for every page tool:

- **`pkg/tools/<slug>/tool.json`** — new `tools/generator/src/descriptor.rs` emits a per-tool descriptor: `slug`, `name` (`gizza-ai/<slug>`), `version`, `title`, `description`, `tags`, primary `category`, `urls` (page / markdown twin / descriptor / deep-link example), the copy-paste `cli` invocation (same `shared_cli_example` as the page), and the block manifest's `tool.description` + `tool.parameters` JSON Schema **verbatim**. Missing manifest / missing `tool` object → stderr warning, key omitted, descriptor still written. Pretty-printed.
- **Page**: `<link rel="alternate" type="application/json" href="tool.json">` in the head, plus a full-width "Machine-readable descriptor" footer note under the Developer & Automation Access grid (kept the two-card grid intact; a note read better than a third card since the descriptor is a link, not a copy-paste snippet).
- **`_index.json`**: each entry gains `"descriptor": "/tools/<slug>/tool.json"`. Verified all consumers (`site/tools-index.js`, `site/header.js`, `site/tools-modal.js`) read named fields only — extra field tolerated.
- **Markdown twin**: `## Run it` gains one `- **Agents:** … tool.json` line.
- **`scripts/gen-seo.sh`**: writes `pkg/llms-full.txt` = `# gizza.ai — full tool documentation` header + every `pkg/tools/*/index.md` in slug order, separated by exactly `\n\n---\n\n` (`$(<file)` strips trailing newlines). Skips with a stderr warning when the generator hasn't run. `llms.txt` Resources links `/llms-full.txt` and notes the per-tool `/tools/<slug>/tool.json` descriptors.

## Why

The HTML page and markdown twin serve humans and browsing LLMs; agents calling tools programmatically need the parameters JSON Schema, canonical CLI invocation and deep-link in one fetchable document — sourced from the same manifest that drives the page form, so there is no drift.

## Tested

- `cargo test` in `tools/generator`: **88 passed, 0 failed** (new: 5 descriptor tests — happy path, missing manifest, manifest-without-tool, schema-verbatim, auto-only deep-link omission; head+dev-section link test; `_index.json` descriptor-field assert; markdown twin line test).
- `cargo clippy --all-targets`: no new warnings vs base (the one `dead_code` note on `ParamSchema::empty` pre-exists on base).
- Full release run from repo root: **324** `tool.json` files written, zero manifest warnings; all 324 parse as JSON. Spot-check `pkg/tools/audio-convert/tool.json` via `python3 -m json.tool`: valid, `category: "audio"`, `tool.parameters` byte-equal to `blocks/audio-convert/manifest.json` (asserted programmatically).
- `GIZZA=gizza scripts/gen-seo.sh`: `pkg/llms-full.txt` starts with the header, contains **324** documents (`data.split('\n\n---\n\n')` → 325 parts), 1.6 MB; `pkg/llms.txt` links `/llms-full.txt` and the descriptor note. Degrade path exercised against an empty root: warning printed, no header-only file, exit 0.
- `shellcheck scripts/gen-seo.sh`: same 2 pre-existing SC2016 notes as base, no new findings (the new backticked line uses double quotes with escaped backticks).
- `npm test`: 39/41 pass; the 2 failures (`pkg/sw.js missing — run solobase build`) pre-exist in this environment and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)