### PR TITLE
feat(seo): programmatic "X to Y" converter pair pages

### DIFF
--- a/scripts/gen-seo.sh
+++ b/scripts/gen-seo.sh
@@ -103,6 +103,18 @@ site_mod="$(git_lastmod site)"
   for slug in "${page_slugs[@]}"; do
     emit_url "$BASE_URL/tools/$slug/" "$(git_lastmod "blocks/$slug/page")"
   done
+  # "X to Y" conversion pair pages (/tools/<parent>/<src>-to-<tgt>/) from the
+  # generator's _pairs.json. Skipped gracefully when the file is missing
+  # (generator not yet run); each pair page is generated from its parent
+  # converter's page sources, so it shares that parent's lastmod.
+  pairs_json="$PKG_DIR/tools/_pairs.json"
+  if [[ -f "$pairs_json" ]]; then
+    while IFS= read -r pair_path; do
+      [[ -z "$pair_path" ]] && continue
+      parent="${pair_path%%/*}"
+      emit_url "$BASE_URL/tools/$pair_path/" "$(git_lastmod "blocks/$parent/page")"
+    done < <(jq -r '.[].path' "$pairs_json")
+  fi
   printf '</urlset>\n'
 } > "$PKG_DIR/sitemap.xml"
 

--- a/scripts/gen-seo.test.sh
+++ b/scripts/gen-seo.test.sh
@@ -34,6 +34,12 @@ printf 'title = "Ghost Tool"\ndescription = "A tool only present on disk"\n' > "
 # Create pkg/ dir
 mkdir -p "$tmpdir/pkg"
 
+# Pair pages: the generator writes pkg/tools/_pairs.json; gen-seo.sh adds each
+# path to the sitemap. (calculator stands in for a converter parent here.)
+mkdir -p "$tmpdir/pkg/tools"
+printf '[{"path":"calculator/wav-to-mp3","title":"Convert WAV to MP3"}]\n' \
+  > "$tmpdir/pkg/tools/_pairs.json"
+
 # Run gen-seo.sh from the temp dir (as repo root)
 BASE_URL="https://example.test" \
 GIZZA="$tmpdir/bin/gizza" \
@@ -65,6 +71,11 @@ fi
 # it must still appear in the sitemap (derived directly from the filesystem)
 if ! grep -qF "https://example.test/tools/ghost-tool/" "$sitemap"; then
   echo "FAIL: sitemap missing ghost-tool page URL (page exists but not in gizza list)"
+  exit 1
+fi
+# conversion pair pages from pkg/tools/_pairs.json land in the sitemap
+if ! grep -qF "https://example.test/tools/calculator/wav-to-mp3/" "$sitemap"; then
+  echo "FAIL: sitemap missing pair page URL from _pairs.json"
   exit 1
 fi
 

--- a/tools/generator/src/formats.rs
+++ b/tools/generator/src/formats.rs
@@ -1,0 +1,416 @@
+//! Per-format fact table for the programmatic "X to Y" converter pair pages
+//! (see `pairs.rs`). One entry per audio/image format the two converter tools
+//! can read or write, with the copy fragments the pair pages are assembled
+//! from — every fragment is format-specific, so no two pair pages share their
+//! prose (the thin-content guard).
+//!
+//! All claims must stay consistent with the parent tools' documented behavior
+//! (`blocks/audio-convert/page/content.md`, `blocks/image-convert/page/content.md`):
+//! audio bitrate 32–320 kbps (lossy targets only), album art dropped, 10 MiB
+//! input limit; image quality 1–100 (JPEG/WebP only), PNG lossless.
+
+/// Which converter tool a format belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Family {
+    Audio,
+    Image,
+}
+
+/// Facts and copy fragments for one format.
+pub struct FormatInfo {
+    /// Canonical key — also the value the parent tool's `?format=` accepts
+    /// when the format is a conversion target (e.g. "jpeg", not "jpg").
+    pub key: &'static str,
+    /// Alternate slug spellings that resolve to this entry (e.g. "jpg").
+    pub aliases: &'static [&'static str],
+    /// Display name ("MP3", "WebP").
+    pub name: &'static str,
+    /// Codec/container one-liner for the comparison table.
+    pub codec: &'static str,
+    pub family: Family,
+    /// True when encoding to this format discards audio/image detail.
+    pub lossy: bool,
+    /// Full-sentence identity blurb — the intro's per-format paragraph.
+    pub blurb: &'static str,
+    /// Short phrase: what the format is typically used for.
+    pub uses: &'static str,
+    /// Short phrase: its headline strength (comparison-table cell).
+    pub strength: &'static str,
+    /// Short phrase: its headline caveat (comparison-table cell).
+    pub caveat: &'static str,
+    /// Comparison-table cell: typical file size.
+    pub size_note: &'static str,
+    /// Comparison-table cell: where it plays/opens.
+    pub compat: &'static str,
+    /// Image-only comparison-table cell: transparency support.
+    pub transparency: Option<&'static str>,
+    /// Image-only comparison-table cell: animation support.
+    pub animation: Option<&'static str>,
+}
+
+/// The full fact table: the 8 audio formats and 6 image formats the converter
+/// pair pages cover.
+pub const FORMATS: &[FormatInfo] = &[
+    // ---- audio ----
+    FormatInfo {
+        key: "mp3",
+        aliases: &[],
+        name: "MP3",
+        codec: "MPEG Layer III audio",
+        family: Family::Audio,
+        lossy: true,
+        blurb: "MP3 is the most widely supported audio format there is — a lossy \
+                codec that shrinks audio to a fraction of its uncompressed size \
+                and plays on virtually anything with a speaker.",
+        uses: "sharing, podcasts and everyday listening",
+        strength: "plays everywhere; small files",
+        caveat: "lossy — encoding discards some audio detail to save space",
+        size_note: "small — about 1.4 MB per minute at 192 kbps",
+        compat: "universal — effectively every device and app",
+        transparency: None,
+        animation: None,
+    },
+    FormatInfo {
+        key: "wav",
+        aliases: &[],
+        name: "WAV",
+        codec: "uncompressed 16-bit PCM in a RIFF container",
+        family: Family::Audio,
+        lossy: false,
+        blurb: "WAV stores raw, uncompressed PCM samples — the audio equivalent \
+                of a bitmap. Files are huge, but every editor, DAW and operating \
+                system opens them without a second thought.",
+        uses: "editing, DAWs and audio production",
+        strength: "universal uncompressed PCM — ideal for editing",
+        caveat: "huge files for what they hold",
+        size_note: "very large — roughly 10 MB per minute of 16-bit stereo",
+        compat: "universal — opens in every editor and OS",
+        transparency: None,
+        animation: None,
+    },
+    FormatInfo {
+        key: "ogg",
+        aliases: &[],
+        name: "OGG",
+        codec: "Vorbis audio in an Ogg container",
+        family: Family::Audio,
+        lossy: true,
+        blurb: "OGG (Vorbis) is a free, open lossy format with very good quality \
+                per byte — a favourite in games, open-source software and \
+                projects that want to avoid patent-encumbered codecs.",
+        uses: "games, open-source pipelines and the web",
+        strength: "open and royalty-free; good quality per byte",
+        caveat: "less at home in Apple's ecosystem than MP3 or M4A",
+        size_note: "small — comparable to MP3 at the same bitrate",
+        compat: "broad, though Apple software often needs a third-party player",
+        transparency: None,
+        animation: None,
+    },
+    FormatInfo {
+        key: "flac",
+        aliases: &[],
+        name: "FLAC",
+        codec: "Free Lossless Audio Codec",
+        family: Family::Audio,
+        lossy: false,
+        blurb: "FLAC compresses audio without losing anything — a perfect, \
+                bit-for-bit copy at a fraction of the WAV size, which makes it \
+                the default choice for archiving music.",
+        uses: "archiving and lossless music libraries",
+        strength: "lossless and compressed — a perfect copy, smaller than WAV",
+        caveat: "much larger than lossy formats; some older hardware skips it",
+        size_note: "medium — typically 50–70% of the equivalent WAV",
+        compat: "wide in modern software; patchy on older hardware players",
+        transparency: None,
+        animation: None,
+    },
+    FormatInfo {
+        key: "m4a",
+        aliases: &[],
+        name: "M4A",
+        codec: "AAC audio in an MPEG-4 container",
+        family: Family::Audio,
+        lossy: true,
+        blurb: "M4A wraps AAC audio in an MPEG-4 container — the format iTunes \
+                and Apple Music use. AAC squeezes better quality than MP3 out of \
+                the same bitrate, at the cost of slightly narrower support.",
+        uses: "Apple devices and small high-quality files",
+        strength: "better quality than MP3 at the same bitrate",
+        caveat: "slightly less universal than MP3",
+        size_note: "small — like MP3, often better quality per byte",
+        compat: "excellent on Apple devices; broad elsewhere",
+        transparency: None,
+        animation: None,
+    },
+    FormatInfo {
+        key: "aac",
+        aliases: &[],
+        name: "AAC",
+        codec: "raw AAC (Advanced Audio Coding) stream",
+        family: Family::Audio,
+        lossy: true,
+        blurb: "AAC is the codec behind M4A files, streaming services and much \
+                of broadcast audio; as a bare .aac stream it carries the same \
+                lossy audio without the MPEG-4 wrapper — and without proper tag \
+                support.",
+        uses: "streams, broadcast audio and recorder output",
+        strength: "modern lossy codec, efficient at every bitrate",
+        caveat: "bare .aac streams carry no metadata and trip up some players",
+        size_note: "small — similar to MP3 at the same bitrate",
+        compat: "the codec is everywhere, but fewer apps open bare .aac files",
+        transparency: None,
+        animation: None,
+    },
+    FormatInfo {
+        key: "opus",
+        aliases: &[],
+        name: "Opus",
+        codec: "Opus audio in an Ogg container",
+        family: Family::Audio,
+        lossy: true,
+        blurb: "Opus delivers the best quality per bit of any mainstream codec — \
+                it beats MP3, Vorbis and AAC at almost every bitrate and powers \
+                WhatsApp voice notes, Discord and WebRTC. Device support, \
+                though, is still patchy outside browsers and messengers.",
+        uses: "voice notes, VoIP and low-bitrate streaming",
+        strength: "best quality per bit of any mainstream codec",
+        caveat: "patchy support on older devices, car stereos and Apple apps",
+        size_note: "smallest — excellent quality even at low bitrates",
+        compat: "great in browsers and messengers; patchy on older hardware",
+        transparency: None,
+        animation: None,
+    },
+    FormatInfo {
+        key: "aiff",
+        aliases: &[],
+        name: "AIFF",
+        codec: "uncompressed PCM in Apple's AIFF container",
+        family: Family::Audio,
+        lossy: false,
+        blurb: "AIFF is Apple's classic uncompressed audio container — the Mac \
+                counterpart to WAV. Same raw PCM audio, same huge files, mostly \
+                seen in pro-audio sessions and older Mac workflows.",
+        uses: "Mac pro-audio sessions and sample libraries",
+        strength: "uncompressed PCM, like WAV; native on macOS",
+        caveat: "huge files; rarer than WAV outside Apple software",
+        size_note: "very large — roughly 10 MB per minute, like WAV",
+        compat: "native on macOS; most editors elsewhere open it too",
+        transparency: None,
+        animation: None,
+    },
+    // ---- image ----
+    FormatInfo {
+        key: "png",
+        aliases: &[],
+        name: "PNG",
+        codec: "lossless DEFLATE-compressed bitmap",
+        family: Family::Image,
+        lossy: false,
+        blurb: "PNG is the standard lossless web image: screenshots, UI \
+                graphics, logos and anything with sharp edges or transparency \
+                come out pixel-perfect.",
+        uses: "screenshots, graphics, logos and anything needing transparency",
+        strength: "lossless, with a full alpha channel",
+        caveat: "large for photographs — photos compress far better as JPEG or WebP",
+        size_note: "efficient for flat graphics, large for photos",
+        compat: "universal",
+        transparency: Some("yes — full alpha channel"),
+        animation: Some("no"),
+    },
+    FormatInfo {
+        key: "jpeg",
+        aliases: &["jpg"],
+        name: "JPEG",
+        codec: "lossy DCT-compressed JPEG",
+        family: Family::Image,
+        lossy: true,
+        blurb: "JPEG is the default format for photographs — lossy compression \
+                tuned for natural images keeps files small, and support is \
+                universal. It has no alpha channel, so transparency is always \
+                flattened.",
+        uses: "photos and everyday web images",
+        strength: "small files for photos; opens absolutely everywhere",
+        caveat: "no transparency; visible artifacts at low quality settings",
+        size_note: "small — the quality knob trades size against artifacts",
+        compat: "universal",
+        transparency: Some("no — transparent areas are flattened"),
+        animation: Some("no"),
+    },
+    FormatInfo {
+        key: "webp",
+        aliases: &[],
+        name: "WebP",
+        codec: "WebP — written lossy here, with a quality knob",
+        family: Family::Image,
+        lossy: true,
+        blurb: "WebP is the modern web format: at similar visual quality it \
+                produces noticeably smaller files than both JPEG and PNG, and \
+                it supports alpha transparency.",
+        uses: "modern web images — photos and graphics alike",
+        strength: "smaller than JPEG/PNG at similar quality, with transparency",
+        caveat: "a few older apps and viewers still don't open it",
+        size_note: "smallest of the web formats at comparable quality",
+        compat: "all modern browsers; some older desktop software lags",
+        transparency: Some("yes — alpha supported"),
+        animation: Some("possible in WebP, but this converter writes still images"),
+    },
+    FormatInfo {
+        key: "gif",
+        aliases: &[],
+        name: "GIF",
+        codec: "LZW-compressed, 256-color palette bitmap",
+        family: Family::Image,
+        lossy: false,
+        blurb: "GIF is the veteran web format: a 256-color palette, universal \
+                support and — famously — animation. For still images its color \
+                limit shows, which is why single frames usually travel better \
+                as PNG, JPEG or WebP.",
+        uses: "simple animations and legacy graphics",
+        strength: "universally supported; can hold animation",
+        caveat: "only 256 colors per frame; animation is not carried over to still formats",
+        size_note: "small for flat art, poor for photos",
+        compat: "universal",
+        transparency: Some("1-bit — a pixel is either fully opaque or fully transparent"),
+        animation: Some("yes — but never preserved by a still-image conversion"),
+    },
+    FormatInfo {
+        key: "bmp",
+        aliases: &[],
+        name: "BMP",
+        codec: "uncompressed Windows bitmap",
+        family: Family::Image,
+        lossy: false,
+        blurb: "BMP is the old Windows bitmap: raw uncompressed pixels with \
+                essentially no size optimization. It opens everywhere on \
+                Windows but wastes space — which is usually why people convert \
+                it.",
+        uses: "legacy Windows software and raw exports",
+        strength: "dead simple and lossless",
+        caveat: "uncompressed — enormous files for what they show",
+        size_note: "very large — no compression at all",
+        compat: "universal on Windows; most other platforms too",
+        transparency: Some("effectively none in common BMP files"),
+        animation: Some("no"),
+    },
+    FormatInfo {
+        key: "tiff",
+        aliases: &[],
+        name: "TIFF",
+        codec: "TIFF container, usually uncompressed or LZW",
+        family: Family::Image,
+        lossy: false,
+        blurb: "TIFF is the print-and-scan workhorse: a flexible, usually \
+                lossless container beloved by scanners, print shops and photo \
+                archives. Files are often huge and can even hold multiple \
+                pages, which makes them awkward to share.",
+        uses: "scanning, print production and photo archives",
+        strength: "high-fidelity master files",
+        caveat: "often huge; can hold multiple pages, and this converter is built for single images",
+        size_note: "large to very large",
+        compat: "great in imaging software; browsers generally won't display it",
+        transparency: Some("possible, but uncommon"),
+        animation: Some("no — multi-page instead"),
+    },
+];
+
+/// Look up a format by canonical key or alias ("jpg" resolves to "jpeg").
+pub fn lookup(key: &str) -> Option<&'static FormatInfo> {
+    FORMATS
+        .iter()
+        .find(|f| f.key == key || f.aliases.contains(&key))
+}
+
+/// Display name for a slug segment: alias spellings keep their own casing
+/// ("jpg" → "JPG") so a page's h1 matches the query the visitor typed, while
+/// canonical keys use the format's display name ("jpeg" → "JPEG").
+pub fn display_for_segment(segment: &str) -> String {
+    match lookup(segment) {
+        Some(info) if info.key == segment => info.name.to_string(),
+        _ => segment.to_ascii_uppercase(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_finds_every_canonical_key() {
+        for key in [
+            "mp3", "wav", "ogg", "flac", "m4a", "aac", "opus", "aiff", // audio
+            "png", "jpeg", "webp", "gif", "bmp", "tiff", // image
+        ] {
+            let info = lookup(key).unwrap_or_else(|| panic!("missing format {key}"));
+            assert_eq!(info.key, key);
+        }
+        assert!(lookup("mid").is_none());
+        assert!(lookup("").is_none());
+    }
+
+    #[test]
+    fn jpg_alias_resolves_to_jpeg() {
+        let info = lookup("jpg").expect("jpg alias");
+        assert_eq!(info.key, "jpeg");
+        assert_eq!(info.name, "JPEG");
+        // Alias display keeps the typed spelling; canonical keeps the name.
+        assert_eq!(display_for_segment("jpg"), "JPG");
+        assert_eq!(display_for_segment("jpeg"), "JPEG");
+        assert_eq!(display_for_segment("webp"), "WebP");
+        assert_eq!(display_for_segment("opus"), "Opus");
+    }
+
+    #[test]
+    fn families_and_lossiness_match_the_parent_tools() {
+        // Lossy audio targets per blocks/audio-convert (bitrate applies):
+        for k in ["mp3", "ogg", "m4a", "aac", "opus"] {
+            let f = lookup(k).unwrap();
+            assert_eq!(f.family, Family::Audio, "{k}");
+            assert!(f.lossy, "{k} is lossy");
+        }
+        for k in ["wav", "flac", "aiff"] {
+            let f = lookup(k).unwrap();
+            assert_eq!(f.family, Family::Audio, "{k}");
+            assert!(!f.lossy, "{k} is lossless");
+        }
+        // Image: PNG lossless (quality ignored); JPEG/WebP take the quality knob.
+        assert!(!lookup("png").unwrap().lossy);
+        assert!(lookup("jpeg").unwrap().lossy);
+        assert!(lookup("webp").unwrap().lossy);
+        for k in ["png", "jpeg", "webp", "gif", "bmp", "tiff"] {
+            assert_eq!(lookup(k).unwrap().family, Family::Image, "{k}");
+        }
+    }
+
+    #[test]
+    fn image_formats_carry_transparency_and_animation_cells() {
+        for f in FORMATS {
+            match f.family {
+                Family::Image => {
+                    assert!(f.transparency.is_some(), "{} transparency cell", f.key);
+                    assert!(f.animation.is_some(), "{} animation cell", f.key);
+                }
+                Family::Audio => {
+                    assert!(f.transparency.is_none(), "{}", f.key);
+                    assert!(f.animation.is_none(), "{}", f.key);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn every_entry_has_nonempty_copy_fragments() {
+        for f in FORMATS {
+            for (field, value) in [
+                ("codec", f.codec),
+                ("blurb", f.blurb),
+                ("uses", f.uses),
+                ("strength", f.strength),
+                ("caveat", f.caveat),
+                ("size_note", f.size_note),
+                ("compat", f.compat),
+            ] {
+                assert!(!value.trim().is_empty(), "{} {field} empty", f.key);
+            }
+        }
+    }
+}

--- a/tools/generator/src/main.rs
+++ b/tools/generator/src/main.rs
@@ -9,10 +9,12 @@ mod categories;
 mod control;
 mod descriptor;
 mod faq;
+mod formats;
 mod index;
 mod markdown;
 mod meta;
 mod og;
+mod pairs;
 mod related;
 mod template;
 mod vocab;
@@ -48,6 +50,11 @@ fn run() -> Result<(), String> {
     let og_renderer = og::OgRenderer::new();
     let metas_only: Vec<ToolMeta> = metas.iter().map(|(_, m)| m.clone()).collect();
 
+    // "X to Y" conversion pair pages nested under the converter tools —
+    // enumerated once, linked from each parent's "Popular conversions"
+    // section and rendered below after the parent pages exist.
+    let pair_specs = pairs::all_pairs();
+
     for (tool_dir, m) in &metas {
         let out = pkg_tools.join(&m.slug);
         fs::create_dir_all(&out).map_err(|e| format!("mkdir {}: {e}", out.display()))?;
@@ -73,6 +80,9 @@ fn run() -> Result<(), String> {
         // Top-5 related tools by shared tags — internal links on the page and
         // its markdown twin.
         let related = related::related_tools(m, &metas_only);
+        // Converter tools get a crawlable "Popular conversions" section
+        // linking every pair page nested under them (empty for other tools).
+        let pair_links = pairs::pair_links_for_parent(&pair_specs, &m.slug);
         let html = template::render_page(
             m,
             &content_html,
@@ -80,6 +90,7 @@ fn run() -> Result<(), String> {
             has_custom_js,
             has_custom_css,
             &related,
+            &pair_links,
         );
         fs::write(out.join("index.html"), html)
             .map_err(|e| format!("write index.html: {e}"))?;
@@ -122,6 +133,57 @@ fn run() -> Result<(), String> {
         }
         eprintln!("rendered tools/{}/", m.slug);
     }
+
+    // "X to Y" pair pages: one landing page per (source, target) format pair,
+    // nested under its parent converter (pkg/tools/<parent>/<src>-to-<tgt>/).
+    // Rendered after the parent loop so the collision check below sees every
+    // file the parent page ships. Assets (tool.css, header.js, …) are linked
+    // from the parent directory — nothing is copied per pair.
+    let mut rendered_pairs: Vec<&pairs::PairSpec> = Vec::new();
+    for pair in &pair_specs {
+        let Some((_, parent)) = metas.iter().find(|(_, m)| m.slug == pair.parent) else {
+            eprintln!(
+                "warning: pair {} skipped (parent {} has no page)",
+                pair.slug(),
+                pair.parent
+            );
+            continue;
+        };
+        let out = pkg_tools.join(pair.parent).join(pair.slug());
+        // A pair directory must never shadow a file the parent ships
+        // (index.html, og.png, the wasm bundle, …) — fail loudly, not subtly.
+        if out.exists() && !out.is_dir() {
+            return Err(format!(
+                "pair page {} collides with an existing file in tools/{}/",
+                out.display(),
+                pair.parent
+            ));
+        }
+        fs::create_dir_all(&out).map_err(|e| format!("mkdir {}: {e}", out.display()))?;
+        fs::write(
+            out.join("index.html"),
+            pairs::render_pair_page(parent, pair, &pair_specs),
+        )
+        .map_err(|e| format!("write {}/index.html: {e}", pair.path()))?;
+        fs::write(out.join("index.md"), pairs::pair_markdown(parent, pair))
+            .map_err(|e| format!("write {}/index.md: {e}", pair.path()))?;
+        let card = og_renderer.pair_card(
+            &pair.h1(),
+            &pair.og_tagline(),
+            &format!("gizza.ai/tools/{}", pair.path()),
+        )?;
+        fs::write(out.join("og.png"), card)
+            .map_err(|e| format!("write {}/og.png: {e}", pair.path()))?;
+        rendered_pairs.push(pair);
+    }
+    // Machine-readable pair index — consumed by scripts/gen-seo.sh to add the
+    // pair URLs to the sitemap (same pattern as _hubs.json).
+    fs::write(
+        pkg_tools.join("_pairs.json"),
+        pairs::pairs_json(&rendered_pairs),
+    )
+    .map_err(|e| format!("write tools/_pairs.json: {e}"))?;
+    eprintln!("rendered {} conversion pair pages", rendered_pairs.len());
 
     // Static index for the in-app tools modal (fetched client-side; lives under
     // /tools/ so it is covered by the runtime SW's /tools/ bypass).

--- a/tools/generator/src/og.rs
+++ b/tools/generator/src/og.rs
@@ -50,6 +50,17 @@ impl OgRenderer {
         ))
     }
 
+    /// Render the card for a conversion pair page
+    /// (`/tools/<parent>/<src>-to-<tgt>/`).
+    pub fn pair_card(
+        &self,
+        title: &str,
+        tagline: &str,
+        footer: &str,
+    ) -> Result<Vec<u8>, String> {
+        self.render(&card_svg(title, tagline, footer))
+    }
+
     /// Render the card for a category hub page (`/tools/<category>/`).
     pub fn hub_card(&self, category: &crate::categories::Category) -> Result<Vec<u8>, String> {
         self.render(&card_svg(

--- a/tools/generator/src/pairs.rs
+++ b/tools/generator/src/pairs.rs
@@ -1,0 +1,1252 @@
+//! Programmatic "X to Y" converter landing pages — one page per (source,
+//! target) format pair of the two real converter tools, at
+//! `pkg/tools/<parent>/<src>-to-<tgt>/`. These answer the queries people
+//! actually type ("wav to mp3", "png to webp") and deep-link the parent
+//! converter with the target preselected.
+//!
+//! Every section of a pair page is assembled from the per-format fact table in
+//! `formats.rs` plus direction-specific copy (lossy→lossless, lossless→lossy,
+//! …), so no two pages share their prose — the guard against thin/doorway
+//! content. A test enforces ≥250 words of visible prose on every page.
+
+use crate::formats::{self, Family, FormatInfo};
+use crate::meta::ToolMeta;
+use crate::template::{brand_link, breadcrumbs_json_ld};
+use gizza_chrome::{footer as chrome_footer, header as chrome_header, Active};
+use maud::{html, Markup, PreEscaped, DOCTYPE};
+
+/// Source formats the audio converter accepts (anything ffmpeg decodes; these
+/// are the ones worth a landing page) and the targets it writes.
+pub const AUDIO_SOURCES: &[&str] = &["mp3", "wav", "ogg", "flac", "m4a", "aac", "opus", "aiff"];
+pub const AUDIO_TARGETS: &[&str] = &["mp3", "wav", "ogg", "flac", "m4a"];
+
+/// Image sources (per the parent tool's input FAQ) and targets. Sources use
+/// the everyday "jpg" spelling; the target keeps the tool's canonical
+/// `?format=jpeg` value. `jpg` → `jpeg` counts as identity (same format).
+pub const IMAGE_SOURCES: &[&str] = &["png", "jpg", "webp", "gif", "bmp", "tiff"];
+pub const IMAGE_TARGETS: &[&str] = &["jpeg", "png", "webp"];
+
+/// One source→target conversion page under a parent converter tool.
+pub struct PairSpec {
+    /// Parent tool slug ("audio-convert" | "image-convert").
+    pub parent: &'static str,
+    /// Source slug segment (may be an alias spelling, e.g. "jpg").
+    pub src: &'static str,
+    /// Target slug segment — always the parent tool's `?format=` value.
+    pub tgt: &'static str,
+}
+
+/// How quality moves across the conversion — drives the direction-specific
+/// intro, caveat and FAQ copy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Direction {
+    LosslessToLossy,
+    LossyToLossless,
+    LossyToLossy,
+    LosslessToLossless,
+}
+
+impl PairSpec {
+    pub fn src_info(&self) -> &'static FormatInfo {
+        formats::lookup(self.src).unwrap_or_else(|| panic!("unknown format {}", self.src))
+    }
+
+    pub fn tgt_info(&self) -> &'static FormatInfo {
+        formats::lookup(self.tgt).unwrap_or_else(|| panic!("unknown format {}", self.tgt))
+    }
+
+    /// Display names as typed in the slug ("jpg" → "JPG", "jpeg" → "JPEG").
+    pub fn src_name(&self) -> String {
+        formats::display_for_segment(self.src)
+    }
+
+    pub fn tgt_name(&self) -> String {
+        formats::display_for_segment(self.tgt)
+    }
+
+    /// Directory name under the parent: "wav-to-mp3".
+    pub fn slug(&self) -> String {
+        format!("{}-to-{}", self.src, self.tgt)
+    }
+
+    /// Sitemap/`_pairs.json` path: "audio-convert/wav-to-mp3".
+    pub fn path(&self) -> String {
+        format!("{}/{}", self.parent, self.slug())
+    }
+
+    pub fn canonical(&self) -> String {
+        format!("https://gizza.ai/tools/{}/", self.path())
+    }
+
+    pub fn h1(&self) -> String {
+        format!("Convert {} to {}", self.src_name(), self.tgt_name())
+    }
+
+    pub fn title(&self) -> String {
+        format!(
+            "Convert {} to {} Online — Free & Private — gizza.ai",
+            self.src_name(),
+            self.tgt_name()
+        )
+    }
+
+    pub fn description(&self) -> String {
+        let base = format!(
+            "Convert {} to {} right in your browser — free, private, nothing is uploaded.",
+            self.src_name(),
+            self.tgt_name()
+        );
+        let hook = match self.src_info().family {
+            Family::Audio => match self.direction() {
+                Direction::LosslessToLossy => "Pick a bitrate (32–320 kbps) and shrink the file dramatically.",
+                Direction::LossyToLossless => "Get a lossless file any editor opens — no further quality loss.",
+                Direction::LossyToLossy => "One-click re-encode for compatibility.",
+                Direction::LosslessToLossless => "A perfect, bit-for-bit lossless copy.",
+            },
+            Family::Image => match self.tgt_info().key {
+                "jpeg" => "Small files for photos — set quality 1–100.",
+                "png" => "Get a lossless copy of every pixel.",
+                _ => "Smaller files at the same quality, transparency included.",
+            },
+        };
+        format!("{base} {hook}")
+    }
+
+    /// OG-card tagline (second line on the 1200×630 card).
+    pub fn og_tagline(&self) -> String {
+        format!(
+            "{} → {} in your browser — free & private, nothing is uploaded.",
+            self.src_name(),
+            self.tgt_name()
+        )
+    }
+
+    /// Deep link opening the parent tool with the target preselected.
+    pub fn cta_url(&self) -> String {
+        match self.src_info().family {
+            Family::Audio => format!("/tools/{}/?format={}", self.parent, self.tgt),
+            Family::Image if self.tgt_info().lossy => {
+                format!("/tools/{}/?format={}&quality=85", self.parent, self.tgt)
+            }
+            // PNG is lossless — the quality param is ignored, so don't teach it.
+            Family::Image => format!("/tools/{}/?format={}", self.parent, self.tgt),
+        }
+    }
+
+    fn direction(&self) -> Direction {
+        match (self.src_info().lossy, self.tgt_info().lossy) {
+            (false, true) => Direction::LosslessToLossy,
+            (true, false) => Direction::LossyToLossless,
+            (true, true) => Direction::LossyToLossy,
+            (false, false) => Direction::LosslessToLossless,
+        }
+    }
+}
+
+/// Enumerate every pair page: sources × targets per family, identity skipped
+/// (compared on canonical format keys, so jpg→jpeg is identity).
+pub fn all_pairs() -> Vec<PairSpec> {
+    let mut out = Vec::new();
+    let families: [(&str, &[&str], &[&str]); 2] = [
+        ("audio-convert", AUDIO_SOURCES, AUDIO_TARGETS),
+        ("image-convert", IMAGE_SOURCES, IMAGE_TARGETS),
+    ];
+    for (parent, sources, targets) in families {
+        for src in sources {
+            for tgt in targets {
+                let same = formats::lookup(src).map(|f| f.key)
+                    == formats::lookup(tgt).map(|f| f.key);
+                if !same {
+                    out.push(PairSpec { parent, src, tgt });
+                }
+            }
+        }
+    }
+    out
+}
+
+/// A "Popular conversions" link on the parent tool's page.
+pub struct PairLink {
+    pub label: String,
+    pub href: String,
+}
+
+/// The parent page's crawlable link list to all its pair pages.
+pub fn pair_links_for_parent(pairs: &[PairSpec], parent_slug: &str) -> Vec<PairLink> {
+    pairs
+        .iter()
+        .filter(|p| p.parent == parent_slug)
+        .map(|p| PairLink {
+            label: format!("{} to {}", p.src_name(), p.tgt_name()),
+            href: format!("/tools/{}/", p.path()),
+        })
+        .collect()
+}
+
+/// `pkg/tools/_pairs.json` — `[{path, title}]`, consumed by
+/// `scripts/gen-seo.sh` to add the pair URLs to the sitemap.
+pub fn pairs_json(pairs: &[&PairSpec]) -> String {
+    let entries: Vec<serde_json::Value> = pairs
+        .iter()
+        .map(|p| serde_json::json!({ "path": p.path(), "title": p.title() }))
+        .collect();
+    serde_json::to_string(&entries).expect("serialize pairs index")
+}
+
+// ---------------------------------------------------------------------------
+// Page content assembly — every fragment below is parameterized by the pair's
+// formats and direction, so the prose is pair-specific by construction.
+// ---------------------------------------------------------------------------
+
+/// Indefinite article for a format's display name, by pronunciation
+/// ("an MP3", "an AIFF" — but "a WAV", "a FLAC").
+fn article(name: &str) -> &'static str {
+    match name {
+        "MP3" | "M4A" | "OGG" | "AAC" | "Opus" | "AIFF" => "an",
+        _ => "a",
+    }
+}
+
+/// Why-this-conversion intro paragraph, direction- and pair-specific.
+fn why_paragraph(pair: &PairSpec) -> String {
+    let src = pair.src_name();
+    let tgt = pair.tgt_name();
+    let tgt_info = pair.tgt_info();
+    match pair.src_info().family {
+        Family::Audio => match pair.direction() {
+            Direction::LosslessToLossy => format!(
+                "Converting {src} to {tgt} trades a sliver of fidelity for a dramatic drop \
+                 in size: {} {src} recording that hogs storage becomes {} {tgt} file you \
+                 can email, message or stream. It's the classic move for sharing voice \
+                 memos, publishing spoken audio and fitting a music library onto a phone.",
+                article(&src),
+                article(&tgt)
+            ),
+            Direction::LossyToLossless => format!(
+                "Converting {src} to {tgt} is about compatibility rather than quality: some \
+                 editors, DAWs and pipelines simply insist on {tgt}. You get a file they \
+                 open natively — but the audio can never get better than the {src} you \
+                 start from."
+            ),
+            Direction::LossyToLossy => format!(
+                "Converting {src} to {tgt} is a compatibility move: both formats are lossy, \
+                 so the goal isn't quality — it's producing a file that fits {}. Expect the \
+                 sound to stay essentially the same, with a small second round of encoding \
+                 loss.",
+                tgt_info.uses
+            ),
+            Direction::LosslessToLossless => match (pair.src_info().key, tgt_info.key) {
+                (_, "flac") => format!(
+                    "Converting {src} to FLAC is a pure win for storage: the copy is \
+                     bit-for-bit identical to the original, at typically 50–70% of the \
+                     {src} size."
+                ),
+                ("flac", _) => format!(
+                    "Converting FLAC to {tgt} unpacks the compressed audio back into raw \
+                     PCM: the file grows several times over, but you get a format every \
+                     editor and OS opens without any codec support."
+                ),
+                _ => format!(
+                    "Converting {src} to {tgt} is essentially a container swap: the raw PCM \
+                     samples are identical and the file size barely changes — you do it \
+                     when a tool or plugin only accepts {tgt}."
+                ),
+            },
+        },
+        Family::Image => match tgt_info.key {
+            "jpeg" => format!(
+                "Converting {src} to {tgt} is almost always about size: JPEG's photo-tuned \
+                 lossy compression produces far smaller files than {src} for photographic \
+                 content, and every app on earth opens the result."
+            ),
+            "webp" => format!(
+                "Converting {src} to WebP usually cuts file size at the same visual \
+                 quality — WebP out-compresses {src} on most images — while keeping alpha \
+                 transparency available."
+            ),
+            // PNG target: the story depends on where you're coming from.
+            _ if pair.src_info().lossy => format!(
+                "Converting {src} to PNG is about compatibility, not quality: PNG stores \
+                 pixels losslessly and is accepted everywhere, so it's the format to reach \
+                 for when an upload form or workflow strictly requires it. The {src}'s \
+                 compression artifacts, though, are already baked into the pixels."
+            ),
+            _ => match pair.src_info().key {
+                "gif" => "Converting GIF to PNG modernizes a still image: PNG keeps every \
+                          pixel, supports proper alpha transparency and has no 256-color \
+                          ceiling for future edits."
+                    .to_string(),
+                "bmp" => "Converting BMP to PNG keeps every pixel and throws away the \
+                          wasted space: PNG's lossless compression routinely shrinks an \
+                          uncompressed bitmap by a large factor."
+                    .to_string(),
+                _ => "Converting TIFF to PNG turns a heavyweight print-and-scan master \
+                      into something browsers and chat apps actually display — losslessly, \
+                      so nothing is thrown away."
+                    .to_string(),
+            },
+        },
+    }
+}
+
+/// The src-vs-tgt comparison table.
+fn comparison_table(pair: &PairSpec) -> Markup {
+    let (src, tgt) = (pair.src_info(), pair.tgt_info());
+    let type_cell = |f: &FormatInfo| {
+        if f.lossy {
+            "lossy — some detail traded for size"
+        } else {
+            "lossless — nothing discarded"
+        }
+    };
+    html! {
+        table {
+            thead {
+                tr {
+                    th {}
+                    th { (pair.src_name()) }
+                    th { (pair.tgt_name()) }
+                }
+            }
+            tbody {
+                tr { th { "Compression" } td { (type_cell(src)) } td { (type_cell(tgt)) } }
+                tr { th { "Codec / container" } td { (src.codec) } td { (tgt.codec) } }
+                tr { th { "Typical file size" } td { (src.size_note) } td { (tgt.size_note) } }
+                tr { th { "Best for" } td { (src.uses) } td { (tgt.uses) } }
+                tr { th { "Strength" } td { (src.strength) } td { (tgt.strength) } }
+                tr { th { "Watch out for" } td { (src.caveat) } td { (tgt.caveat) } }
+                tr { th { "Compatibility" } td { (src.compat) } td { (tgt.compat) } }
+                @if let (Some(s), Some(t)) = (src.transparency, tgt.transparency) {
+                    tr { th { "Transparency" } td { (s) } td { (t) } }
+                }
+                @if let (Some(s), Some(t)) = (src.animation, tgt.animation) {
+                    tr { th { "Animation" } td { (s) } td { (t) } }
+                }
+            }
+        }
+    }
+}
+
+/// The 3-step "How the conversion works" list.
+fn how_it_works(pair: &PairSpec) -> Markup {
+    let src = pair.src_name();
+    let tgt = pair.tgt_name();
+    let audio = pair.src_info().family == Family::Audio;
+    let step1 = if audio {
+        format!(
+            "Choose your {src} file (up to 10 MiB). The button above opens the converter \
+             with {tgt} already selected as the target format."
+        )
+    } else {
+        format!(
+            "Choose your {src} image. The button above opens the converter with {tgt} \
+             already selected as the target format."
+        )
+    };
+    let step2 = match (audio, pair.tgt_info().lossy) {
+        (true, true) => "Pick a bitrate between 32 and 320 kbps — the default 192 kbps is \
+                         transparent for most material, and values outside the range are \
+                         clamped."
+            .to_string(),
+        (true, false) => format!(
+            "There is no bitrate to choose: {tgt} is lossless, so the bitrate field is \
+             simply ignored."
+        ),
+        (false, true) => "Set the quality from 1 to 100 (default 85) — higher keeps more \
+                          detail, lower shrinks the file."
+            .to_string(),
+        (false, false) => "There is no quality to tune: PNG is lossless, so the quality \
+                           setting is ignored."
+            .to_string(),
+    };
+    let step3 = if audio {
+        format!(
+            "Run the conversion and download the result — the output keeps your filename \
+             with a .{} extension. Everything happens locally: the page runs ffmpeg \
+             compiled to WebAssembly, so your audio is never uploaded to a server.",
+            pair.tgt
+        )
+    } else {
+        format!(
+            "Run the conversion and download the {tgt} image. Everything happens locally — \
+             ffmpeg compiled to WebAssembly runs in your browser tab, your image is never \
+             uploaded, and the page keeps working offline once it has loaded."
+        )
+    };
+    html! {
+        ol {
+            li { (step1) }
+            li { (step2) }
+            li { (step3) }
+        }
+    }
+}
+
+/// Direction- and pair-specific "What to expect" paragraphs.
+fn caveats(pair: &PairSpec) -> Vec<Markup> {
+    let src = pair.src_name();
+    let tgt = pair.tgt_name();
+    let mut out = Vec::new();
+    match pair.src_info().family {
+        Family::Audio => {
+            out.push(match pair.direction() {
+                Direction::LossyToLossless => html! {
+                    p {
+                        strong { "No quality is restored. " }
+                        (format!(
+                            "{tgt} preserves exactly what's in your {src} file — detail the \
+                             {src} encoder already discarded is gone for good. Expect a much \
+                             larger file with identical sound; convert because a tool needs \
+                             {tgt}, not to upgrade the audio."
+                        ))
+                    }
+                },
+                Direction::LosslessToLossy => html! {
+                    p {
+                        strong { "This step is lossy. " }
+                        (format!(
+                            "The bitrate decides how much detail the {tgt} keeps: 192 kbps \
+                             (the default) is transparent for most music, 128 kbps suits \
+                             voice recordings, and 256–320 kbps is the choice for archiving. \
+                             Your {src} original keeps every sample, so hold on to it."
+                        ))
+                    }
+                },
+                Direction::LossyToLossy => html! {
+                    p {
+                        strong { "Generation loss stacks. " }
+                        (format!(
+                            "Re-encoding lossy {src} audio with another lossy codec adds a \
+                             second round of loss. Keep the {tgt} bitrate at or above the \
+                             original's and avoid repeated round-trips between formats."
+                        ))
+                    }
+                },
+                Direction::LosslessToLossless => html! {
+                    p {
+                        strong { "Nothing is lost either way. " }
+                        (format!(
+                            "{src} and {tgt} both store audio losslessly, so the samples \
+                             come through bit for bit — only packaging and file size change. \
+                             The bitrate setting doesn't apply to a lossless target."
+                        ))
+                    }
+                },
+            });
+            // The tool always passes -vn: attached-picture streams would break
+            // audio-only muxers, so cover art never survives (parent docs).
+            out.push(html! {
+                p {
+                    (format!(
+                        "Embedded album art is dropped along the way: cover images ride \
+                         along as a video stream, which audio-only outputs like {tgt} can't \
+                         carry."
+                    ))
+                }
+            });
+        }
+        Family::Image => {
+            out.push(match pair.direction() {
+                Direction::LosslessToLossy => html! {
+                    p {
+                        strong { "This step is lossy. " }
+                        (format!(
+                            "{tgt} discards some detail to hit its file sizes — at the \
+                             default quality of 85 that's hard to see on photos, but \
+                             sharp-edged graphics and text show artifacts sooner. Raise the \
+                             quality toward 100 for critical images, and keep the {src} \
+                             original in case you need to re-export."
+                        ))
+                    }
+                },
+                Direction::LossyToLossless => html! {
+                    p {
+                        strong { "No detail is restored. " }
+                        (format!(
+                            "PNG stores pixels losslessly, but your {src}'s compression \
+                             artifacts are already baked into those pixels — expect a \
+                             noticeably larger file with exactly the same visual quality."
+                        ))
+                    }
+                },
+                Direction::LossyToLossy => html! {
+                    p {
+                        strong { "Generation loss stacks. " }
+                        (format!(
+                            "Both {src} and {tgt} are lossy, so each re-encode discards a \
+                             little more. One conversion at quality 85 is rarely visible; \
+                             repeated round-trips are."
+                        ))
+                    }
+                },
+                Direction::LosslessToLossless => html! {
+                    p {
+                        strong { "Nothing is lost. " }
+                        (format!(
+                            "{src} and {tgt} both store the image losslessly, so every \
+                             pixel comes through exactly — and the quality setting doesn't \
+                             even apply to a PNG target."
+                        ))
+                    }
+                },
+            });
+            let src_alpha = matches!(pair.src_info().key, "png" | "webp" | "gif");
+            match pair.tgt_info().key {
+                "jpeg" if src_alpha => out.push(html! {
+                    p {
+                        strong { "Transparency is flattened. " }
+                        (format!(
+                            "JPEG has no alpha channel, so transparent regions of your \
+                             {src} are merged onto a solid background. If you need to keep \
+                             transparency while shrinking the file, convert to WebP instead."
+                        ))
+                    }
+                }),
+                "webp" | "png" if src_alpha => out.push(html! {
+                    p {
+                        (format!(
+                            "Transparency survives: {tgt} supports alpha, so the \
+                             transparent areas of your {src} stay transparent."
+                        ))
+                    }
+                }),
+                _ => {}
+            }
+            if pair.src_info().key == "gif" {
+                out.push(html! {
+                    p {
+                        strong { "Animation doesn't carry over. " }
+                        (format!(
+                            "{tgt} output from this converter is a single still image — the \
+                             tool is built for stills, so an animated GIF won't come out \
+                             animated. Keep the GIF (or convert it to a video format) when \
+                             you need motion."
+                        ))
+                    }
+                });
+            }
+            if pair.src_info().key == "tiff" {
+                out.push(html! {
+                    p {
+                        strong { "Multi-page TIFFs: " }
+                        "TIFF can hold several pages in one file, and this converter is \
+                         designed for single-image files — split multi-page documents \
+                         first."
+                    }
+                });
+            }
+        }
+    }
+    out
+}
+
+/// 2–3 pair-specific FAQs as (question, answer) pairs. Rendered as
+/// `<h2>FAQ</h2>` + `<details>` blocks, which `faq::extract_faqs` picks up so
+/// the page emits matching FAQPage JSON-LD automatically.
+fn faqs(pair: &PairSpec) -> Vec<(String, String)> {
+    let src = pair.src_name();
+    let tgt = pair.tgt_name();
+    let mut out = Vec::new();
+    match pair.src_info().family {
+        Family::Audio => {
+            out.push(match pair.direction() {
+                Direction::LosslessToLossy => (
+                    format!("How much quality do I lose converting {src} to {tgt}?"),
+                    format!(
+                        "At the default 192 kbps, {tgt} is transparent for most listeners \
+                         and most material — you'd struggle to tell it from the {src} \
+                         original. Push the bitrate to 256–320 kbps for archiving, or drop \
+                         to 128 kbps for voice recordings where size matters most."
+                    ),
+                ),
+                Direction::LossyToLossless => (
+                    format!("Does converting {src} to {tgt} improve the audio quality?"),
+                    format!(
+                        "No. {tgt} preserves exactly what's in the source — detail the \
+                         {src} encoder already discarded is gone for good. Convert because \
+                         a tool needs {tgt}, not to upgrade the sound."
+                    ),
+                ),
+                Direction::LossyToLossy => (
+                    format!("Will converting {src} to {tgt} make my audio sound worse?"),
+                    format!(
+                        "Marginally, in principle: both formats are lossy, so the re-encode \
+                         adds a second generation of loss. At 192 kbps or higher it's \
+                         rarely audible, but keep the original {src} and avoid converting \
+                         back and forth."
+                    ),
+                ),
+                Direction::LosslessToLossless => (
+                    format!("Is converting {src} to {tgt} really lossless?"),
+                    "Yes — both formats store the audio losslessly, so the conversion is \
+                     bit-transparent. What changes is packaging and file size, not sound."
+                        .to_string(),
+                ),
+            });
+            out.push(if pair.tgt_info().lossy {
+                (
+                    format!("What bitrate should I pick for the {tgt} file?"),
+                    format!(
+                        "The converter accepts 32–320 kbps and defaults to 192 kbps, which \
+                         is a good balance for music. Use 128 kbps for voice where size \
+                         matters and 256–320 kbps for archiving{}. Values outside the range \
+                         are clamped.",
+                        if pair.src_info().lossy {
+                            format!(
+                                "; when re-encoding from {src}, match or exceed the \
+                                 source's bitrate to limit further loss"
+                            )
+                        } else {
+                            String::new()
+                        }
+                    ),
+                )
+            } else {
+                match (pair.src_info().key, pair.tgt_info().key) {
+                    (s, "flac") if s != "flac" && !pair.src_info().lossy => (
+                        "How much smaller will the FLAC file be?".to_string(),
+                        format!(
+                            "Typically 50–70% of the {src} size — FLAC's compression is \
+                             lossless, so the saving comes free. Exact ratios depend on the \
+                             material: quiet, simple audio shrinks further than dense, loud \
+                             mixes."
+                        ),
+                    ),
+                    ("flac", _) => (
+                        format!("Why is the {tgt} so much bigger than the FLAC?"),
+                        format!(
+                            "{tgt} is raw, uncompressed PCM — roughly 10 MB per minute of \
+                             16-bit stereo — while FLAC stores the same samples compressed. \
+                             Unpacking is the price of universal, codec-free compatibility."
+                        ),
+                    ),
+                    ("aiff", "wav") => (
+                        "What actually changes between AIFF and WAV?".to_string(),
+                        "Only the container. Both hold raw PCM samples, so the audio bytes \
+                         and the file size stay essentially the same — the point is \
+                         compatibility with tools that only read WAV."
+                            .to_string(),
+                    ),
+                    _ => (
+                        format!("Why is the {tgt} file so much larger than my {src}?"),
+                        format!(
+                            "{src} stores heavily compressed audio; {tgt} {} — so the same \
+                             sound takes several times the space. That's normal, and the \
+                             extra bytes don't add quality.",
+                            if pair.tgt_info().key == "wav" {
+                                "expands it to raw PCM (about 10 MB per minute of stereo)"
+                            } else {
+                                "stores a losslessly-compressed copy of the decoded audio"
+                            }
+                        ),
+                    ),
+                }
+            });
+            out.push((
+                format!("Is my {src} file uploaded when converting to {tgt}?"),
+                "No. The page downloads an ffmpeg WebAssembly build once, then converts \
+                 your file locally in the browser tab — the audio never leaves your \
+                 device. Input files up to 10 MiB are supported."
+                    .to_string(),
+            ));
+        }
+        Family::Image => {
+            out.push(match pair.direction() {
+                Direction::LosslessToLossy => (
+                    format!("How much quality do I lose converting {src} to {tgt}?"),
+                    format!(
+                        "At the default quality of 85 the difference is hard to spot on \
+                         photos. Graphics with sharp edges and text show lossy artifacts \
+                         sooner — try quality 90+ there, or stick with a lossless format. \
+                         Your {src} original is untouched either way."
+                    ),
+                ),
+                Direction::LossyToLossless => (
+                    format!("Will converting {src} to PNG make it sharper?"),
+                    format!(
+                        "No. PNG stores the pixels losslessly, but the {src} compression \
+                         artifacts are already baked into those pixels — you get a larger \
+                         file with exactly the same visual quality. Convert when a workflow \
+                         strictly requires PNG."
+                    ),
+                ),
+                Direction::LossyToLossy => (
+                    format!("Will converting {src} to {tgt} lose quality?"),
+                    format!(
+                        "A little, in principle: both {src} and {tgt} are lossy, so the \
+                         re-encode discards a bit more. At the default quality of 85 the \
+                         difference is rarely visible — but keep the original if you expect \
+                         to convert again."
+                    ),
+                ),
+                Direction::LosslessToLossless => (
+                    format!("Is converting {src} to PNG lossless?"),
+                    format!(
+                        "Yes — PNG keeps every pixel of the decoded {src} exactly. {}",
+                        match pair.src_info().key {
+                            "gif" =>
+                                "The GIF's 256-color palette still limits the source \
+                                 detail: PNG can hold more colors, but it can't invent ones \
+                                 the GIF never had.",
+                            "bmp" => "You keep the image and simply drop the uncompressed bulk.",
+                            _ => "For a multi-page TIFF, that applies to the single image \
+                                  being converted.",
+                        }
+                    ),
+                ),
+            });
+            let src_alpha = matches!(pair.src_info().key, "png" | "webp" | "gif");
+            out.push(if pair.src_info().key == "gif" {
+                (
+                    format!("Does an animated GIF stay animated as {tgt}?"),
+                    format!(
+                        "No. {tgt} output from this converter is a single still image — \
+                         the tool is built for stills, so animation is never preserved. \
+                         Keep the GIF, or use a video tool, when you need motion."
+                    ),
+                )
+            } else if pair.tgt_info().key == "jpeg" && src_alpha {
+                (
+                    format!("What happens to transparency when I convert {src} to JPEG?"),
+                    format!(
+                        "It's lost — JPEG has no alpha channel, so transparent regions of \
+                         the {src} get flattened onto a solid background. If you need to \
+                         keep transparency while shrinking the file, convert to WebP \
+                         instead."
+                    ),
+                )
+            } else if matches!(pair.src_info().key, "bmp" | "tiff") {
+                (
+                    format!("How much smaller will the {tgt} be than my {src}?"),
+                    if pair.tgt_info().lossy {
+                        format!(
+                            "Usually dramatically smaller: {src} files carry little to no \
+                             compression, while {tgt} at the default quality of 85 \
+                             compresses photographic content to a small fraction of that."
+                        )
+                    } else {
+                        format!(
+                            "Usually much smaller: PNG compresses losslessly, so you keep \
+                             every pixel while shedding most of the {src}'s bulk — with no \
+                             quality change at all."
+                        )
+                    },
+                )
+            } else if pair.tgt_info().key == "png" {
+                (
+                    format!("Why is the PNG bigger than my {src}?"),
+                    format!(
+                        "{src} stores the image as heavily compressed lossy data; PNG \
+                         re-stores the decoded pixels losslessly, which simply takes more \
+                         bytes. Same look, bigger file — worth it only when PNG is \
+                         required."
+                    ),
+                )
+            } else {
+                (
+                    "How does the quality setting work for WebP?".to_string(),
+                    "Quality runs from 1 to 100 (default 85) and is mapped onto ffmpeg's \
+                     encoder scale. Higher values keep more detail and grow the file; for \
+                     most images 80–90 is the sweet spot. It only applies to lossy targets \
+                     — PNG ignores it."
+                        .to_string(),
+                )
+            });
+            out.push((
+                format!("Is my {src} image uploaded when converting to {tgt}?"),
+                "No. The conversion runs entirely in your browser with ffmpeg compiled to \
+                 WebAssembly — your image never leaves your device, and the page keeps \
+                 working offline once it has loaded."
+                    .to_string(),
+            ));
+        }
+    }
+    out
+}
+
+/// The page's prose content (everything inside `<section class="tool-content">`),
+/// as an HTML string — also what the ≥250-word guard measures and what
+/// `faq::extract_faqs` reads for the FAQPage JSON-LD.
+pub fn content_html(pair: &PairSpec) -> String {
+    let markup = html! {
+        p { (pair.src_info().blurb) }
+        p { (pair.tgt_info().blurb) }
+        p { (why_paragraph(pair)) }
+        h2 { (format!("{} vs {}", pair.src_name(), pair.tgt_name())) }
+        (comparison_table(pair))
+        h2 { "How the conversion works" }
+        (how_it_works(pair))
+        h2 { "What to expect" }
+        @for para in caveats(pair) { (para) }
+        h2 { "FAQ" }
+        @for (q, a) in faqs(pair) {
+            details {
+                summary { (q) }
+                p { (a) }
+            }
+        }
+    };
+    markup.into_string()
+}
+
+/// Sibling-links section: the other targets for the same source, the reverse
+/// direction when it exists, and the parent converter.
+fn siblings_section(parent: &ToolMeta, pair: &PairSpec, all: &[PairSpec]) -> Markup {
+    let others: Vec<&PairSpec> = all
+        .iter()
+        .filter(|p| p.parent == pair.parent && p.src == pair.src && p.tgt != pair.tgt)
+        .collect();
+    let reverse = all
+        .iter()
+        .find(|p| p.parent == pair.parent && p.src_info().key == pair.tgt_info().key
+            && p.tgt_info().key == pair.src_info().key);
+    html! {
+        section class="pair-siblings" {
+            h2 { (format!("More {} conversions", pair.src_name())) }
+            ul class="pair-siblings-list" {
+                @for o in &others {
+                    li { a href=(format!("/tools/{}/", o.path())) { (format!("{} to {}", o.src_name(), o.tgt_name())) } }
+                }
+                @if let Some(r) = reverse {
+                    li { a href=(format!("/tools/{}/", r.path())) { (format!("{} to {} (reverse)", r.src_name(), r.tgt_name())) } }
+                }
+                li { a href=(format!("/tools/{}/", pair.parent)) { (format!("All formats — {}", parent.h1)) } }
+            }
+        }
+    }
+}
+
+/// Inline styles for the pair-page hero, CTA and sibling chips. Everything
+/// else (prose, tables, FAQ details) reuses `.tool-content` from the parent's
+/// `tool.css`, which the page links relatively (`../tool.css`).
+const PAIR_CSS: &str = r#"
+.pair-hero { max-width: 720px; margin: 8px auto 0; text-align: center; padding: 12px 0 8px; }
+.pair-hero h1 { font-size: clamp(24px, 5vw, 34px); font-weight: 800; margin: 10px 0 6px; }
+.pair-breadcrumb { font-size: .85rem; color: var(--tool-muted, #6b7280); margin: 0; }
+.pair-breadcrumb a { color: inherit; text-decoration: none; }
+.pair-breadcrumb a:hover { text-decoration: underline; }
+.pair-sub { color: var(--tool-muted, #6b7280); max-width: 560px; margin: 0 auto; line-height: 1.55; }
+.pair-cta { display: inline-block; margin: 18px auto 4px; padding: 13px 26px; background: var(--tool-accent, #4f46e5); color: #fff; font-weight: 650; border-radius: 10px; text-decoration: none; box-shadow: 0 4px 14px rgba(79,70,229,.35); }
+.pair-cta:hover, .pair-cta:focus-visible { background: #4338ca; }
+.pair-cta-note { font-size: .85rem; color: var(--tool-muted, #6b7280); margin: 6px 0 0; }
+.pair-siblings { max-width: 720px; margin: 40px auto 64px; }
+.pair-siblings h2 { font-size: 1.3rem; margin: 0 0 12px; color: var(--tool-ink, #0f172a); border-bottom: 1px solid #e2e8f0; padding-bottom: 8px; }
+.pair-siblings-list { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 8px; }
+.pair-siblings-list a { display: inline-block; padding: 7px 14px; border: 1px solid #e2e8f0; border-radius: 999px; background: #fff; color: var(--tool-accent, #4f46e5); font-size: .9rem; text-decoration: none; }
+.pair-siblings-list a:hover, .pair-siblings-list a:focus-visible { border-color: var(--tool-accent, #4f46e5); text-decoration: underline; }
+"#;
+
+/// Render the full HTML document for one pair page. Chrome assets are linked
+/// from the PARENT tool's directory (`../tool.css`, `../header.js`, …) — the
+/// parent page always ships them, so pair pages add no per-page asset copies.
+pub fn render_pair_page(parent: &ToolMeta, pair: &PairSpec, all: &[PairSpec]) -> String {
+    let canonical = pair.canonical();
+    let title = pair.title();
+    let description = pair.description();
+    let h1 = pair.h1();
+    let og_image = format!("https://gizza.ai/tools/{}/og.png", pair.path());
+    let parent_url = format!("https://gizza.ai/tools/{}/", parent.slug);
+    let pair_label = format!("{} to {}", pair.src_name(), pair.tgt_name());
+    let breadcrumbs_ld = breadcrumbs_json_ld(&[
+        ("Home", "https://gizza.ai/"),
+        ("Tools", "https://gizza.ai/tools/"),
+        (&parent.h1, &parent_url),
+        (&pair_label, &canonical),
+    ]);
+    let content = content_html(pair);
+    // FAQPage JSON-LD mirrors the visible FAQ <details> blocks — same
+    // extraction path as the tool pages (one source of truth, no drift).
+    let faq_entries = crate::faq::extract_faqs(&content);
+    let faq_ld = (!faq_entries.is_empty()).then(|| {
+        serde_json::json!({
+            "@context": "https://schema.org",
+            "@type": "FAQPage",
+            "mainEntity": faq_entries.iter().map(|f| serde_json::json!({
+                "@type": "Question",
+                "name": f.question,
+                "acceptedAnswer": { "@type": "Answer", "text": f.answer_html },
+            })).collect::<Vec<_>>(),
+        })
+        .to_string()
+        .replace("</", "<\\/")
+    });
+
+    let markup = html! {
+        (DOCTYPE)
+        html lang="en" {
+            head {
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width, initial-scale=1";
+                title { (title) }
+                meta name="description" content=(description);
+                link rel="canonical" href=(canonical);
+                link rel="alternate" type="text/markdown" href="index.md";
+                meta property="og:type" content="website";
+                meta property="og:title" content=(title);
+                meta property="og:description" content=(description);
+                meta property="og:url" content=(canonical);
+                meta property="og:image" content=(og_image);
+                meta property="og:image:width" content="1200";
+                meta property="og:image:height" content="630";
+                meta property="og:image:alt" content=(title);
+                meta name="twitter:card" content="summary_large_image";
+                meta name="twitter:title" content=(title);
+                meta name="twitter:description" content=(description);
+                meta name="twitter:image" content=(og_image);
+                link rel="stylesheet" href="https://site-kit.suppers.ai/dist/design-system.css";
+                link rel="stylesheet" href="../tool.css";
+                link rel="stylesheet" href="../header.css";
+                link rel="icon" href="https://gizza.ai/favicon-32.png" sizes="32x32";
+                style { (PreEscaped(PAIR_CSS)) }
+                script type="application/ld+json" { (PreEscaped(breadcrumbs_ld)) }
+                @if let Some(faq_ld) = &faq_ld {
+                    script type="application/ld+json" { (PreEscaped(faq_ld)) }
+                }
+                script type="module" src="../header.js" {}
+            }
+            body {
+                (chrome_header(brand_link(), Active::Tool))
+                main class="tool-main" {
+                    section class="pair-hero" {
+                        p class="pair-breadcrumb" {
+                            a href="/" { "Home" }
+                            " › "
+                            a href="/tools/" { "Tools" }
+                            " › "
+                            a href=(format!("/tools/{}/", parent.slug)) { (parent.h1) }
+                            " › "
+                            span { (pair_label) }
+                        }
+                        h1 { (h1) }
+                        p class="pair-sub" { (description) }
+                        a class="pair-cta" href=(pair.cta_url()) {
+                            (format!("Convert {} to {} →", pair.src_name(), pair.tgt_name()))
+                        }
+                        p class="pair-cta-note" {
+                            "Free · Private — runs in your browser, nothing is uploaded"
+                        }
+                    }
+                    section class="tool-content" {
+                        (PreEscaped(content))
+                    }
+                    (siblings_section(parent, pair, all))
+                }
+                (chrome_footer())
+            }
+        }
+    };
+    markup.into_string()
+}
+
+/// Markdown twin of a pair page: what/why, the deep-link CTA, a runnable CLI
+/// example and a pointer at the parent tool's full docs.
+pub fn pair_markdown(parent: &ToolMeta, pair: &PairSpec) -> String {
+    let cli = match pair.src_info().family {
+        Family::Audio => format!(
+            "gizza tool {} 'url=https://example.com/input.{}' 'format={}'",
+            parent.slug, pair.src, pair.tgt
+        ),
+        Family::Image if pair.tgt_info().lossy => format!(
+            "gizza tool {} 'url=https://example.com/input.{}' 'format={}' 'quality=85'",
+            parent.slug, pair.src, pair.tgt
+        ),
+        Family::Image => format!(
+            "gizza tool {} 'url=https://example.com/input.{}' 'format={}'",
+            parent.slug, pair.src, pair.tgt
+        ),
+    };
+    format!(
+        "# {h1}\n\n{desc}\n\n{src_blurb}\n\n{tgt_blurb}\n\n{why}\n\n## Run it\n\n\
+         - **Web ({tgt} preselected):** https://gizza.ai{cta}\n\
+         - **CLI:** `{cli}`\n\
+         - **Parent tool docs:** https://gizza.ai/tools/{parent_slug}/index.md\n",
+        h1 = pair.h1(),
+        desc = pair.description(),
+        src_blurb = pair.src_info().blurb,
+        tgt_blurb = pair.tgt_info().blurb,
+        why = why_paragraph(pair),
+        tgt = pair.tgt_name(),
+        cta = pair.cta_url(),
+        cli = cli,
+        parent_slug = parent.slug,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn audio_meta() -> ToolMeta {
+        ToolMeta::from_toml(
+            r#"
+slug          = "audio-convert"
+title         = "Convert Audio Online — gizza.ai"
+description   = "d"
+h1            = "Convert an Audio File"
+hero_subtitle = "s"
+wasm          = "w"
+export        = "build_argv"
+runtime       = "ffmpeg"
+output_label  = "o"
+format        = "audio"
+"#,
+        )
+        .unwrap()
+    }
+
+    fn image_meta() -> ToolMeta {
+        ToolMeta::from_toml(
+            r#"
+slug          = "image-convert"
+title         = "Convert an Image Online — gizza.ai"
+description   = "d"
+h1            = "Convert an Image"
+hero_subtitle = "s"
+wasm          = "w"
+export        = "build_argv"
+runtime       = "ffmpeg"
+output_label  = "o"
+format        = "image"
+"#,
+        )
+        .unwrap()
+    }
+
+    fn find<'a>(pairs: &'a [PairSpec], src: &str, tgt: &str) -> &'a PairSpec {
+        pairs
+            .iter()
+            .find(|p| p.src == src && p.tgt == tgt)
+            .unwrap_or_else(|| panic!("pair {src}-to-{tgt} missing"))
+    }
+
+    /// Visible text of an HTML fragment: tags stripped, whitespace collapsed.
+    fn strip_tags(html: &str) -> String {
+        let mut out = String::new();
+        let mut in_tag = false;
+        for c in html.chars() {
+            match c {
+                '<' => {
+                    in_tag = true;
+                    out.push(' ');
+                }
+                '>' => in_tag = false,
+                c if !in_tag => out.push(c),
+                _ => {}
+            }
+        }
+        out.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    #[test]
+    fn enumerates_35_audio_and_15_image_pairs_without_identity() {
+        let pairs = all_pairs();
+        let audio: Vec<_> = pairs.iter().filter(|p| p.parent == "audio-convert").collect();
+        let image: Vec<_> = pairs.iter().filter(|p| p.parent == "image-convert").collect();
+        assert_eq!(audio.len(), 35, "8 sources × 5 targets − 5 identity");
+        assert_eq!(image.len(), 15, "6 sources × 3 targets − 3 identity");
+        assert_eq!(pairs.len(), 50);
+        // no identity pairs — jpg→jpeg counts as identity (same format)
+        assert!(!pairs.iter().any(|p| p.src == p.tgt));
+        assert!(!pairs.iter().any(|p| p.src == "jpg" && p.tgt == "jpeg"));
+        // slugs and titles are unique across the whole set
+        let mut slugs: Vec<String> = pairs.iter().map(|p| p.path()).collect();
+        slugs.sort();
+        slugs.dedup();
+        assert_eq!(slugs.len(), 50, "pair paths unique");
+        let mut titles: Vec<String> = pairs.iter().map(|p| p.title()).collect();
+        titles.sort();
+        titles.dedup();
+        assert_eq!(titles.len(), 50, "pair titles unique");
+    }
+
+    #[test]
+    fn wav_to_mp3_page_has_seo_head_breadcrumbs_cta_and_faq_ld() {
+        let pairs = all_pairs();
+        let pair = find(&pairs, "wav", "mp3");
+        let html = render_pair_page(&audio_meta(), pair, &pairs);
+        assert!(html.contains("<title>Convert WAV to MP3 Online — Free &amp; Private — gizza.ai</title>"));
+        assert!(html.contains(
+            r#"<link rel="canonical" href="https://gizza.ai/tools/audio-convert/wav-to-mp3/">"#
+        ));
+        assert!(html.contains("<h1>Convert WAV to MP3</h1>"));
+        // og card is the per-pair image
+        assert!(html.contains(
+            r#"content="https://gizza.ai/tools/audio-convert/wav-to-mp3/og.png""#
+        ));
+        // 4-level breadcrumb trail: Home › Tools › parent h1 › pair
+        assert!(html.contains(r#""@type":"BreadcrumbList""#));
+        assert!(html.contains(r#""item":"https://gizza.ai/tools/audio-convert/","name":"Convert an Audio File""#));
+        assert!(html.contains(r#""name":"WAV to MP3""#));
+        // prominent CTA deep-links the parent with the target preselected
+        assert!(html.contains(r#"<a class="pair-cta" href="/tools/audio-convert/?format=mp3">"#));
+        // FAQPage JSON-LD extracted from the visible <details> FAQ
+        assert!(html.contains(r#""@type":"FAQPage""#), "FAQPage JSON-LD present");
+        assert!(html.contains("<h2>FAQ</h2>"), "visible FAQ section");
+        // markdown twin discovery link
+        assert!(html.contains(r#"<link rel="alternate" type="text/markdown" href="index.md">"#));
+        // chrome assets come from the parent directory
+        assert!(html.contains(r#"href="../tool.css""#));
+        assert!(html.contains(r#"src="../header.js""#));
+        // audio pages state the documented 10 MiB input limit
+        assert!(html.contains("10 MiB"));
+    }
+
+    #[test]
+    fn png_to_webp_page_deep_links_quality_and_keeps_transparency_claims() {
+        let pairs = all_pairs();
+        let pair = find(&pairs, "png", "webp");
+        let html = render_pair_page(&image_meta(), pair, &pairs);
+        assert!(html.contains(r#"href="/tools/image-convert/?format=webp&amp;quality=85""#));
+        assert!(html.contains("<h1>Convert PNG to WebP</h1>"));
+        // alpha survives png→webp — the page must say so, not warn about flattening
+        assert!(html.contains("Transparency survives"));
+        assert!(!html.contains("Transparency is flattened"));
+        // image pages must NOT inherit the audio-only 10 MiB claim
+        assert!(!html.contains("10 MiB"));
+        // png target CTA (lossless) never teaches the ignored quality param
+        let png_tgt = find(&pairs, "jpg", "png");
+        assert_eq!(png_tgt.cta_url(), "/tools/image-convert/?format=png");
+    }
+
+    #[test]
+    fn png_to_jpeg_warns_transparency_but_jpg_to_png_does_not() {
+        let pairs = all_pairs();
+        let warn = render_pair_page(&image_meta(), find(&pairs, "png", "jpeg"), &pairs);
+        assert!(warn.contains("Transparency is flattened"));
+        let no_warn = render_pair_page(&image_meta(), find(&pairs, "jpg", "png"), &pairs);
+        assert!(!no_warn.contains("Transparency is flattened"));
+        // gif sources warn about animation instead
+        let gif = render_pair_page(&image_meta(), find(&pairs, "gif", "png"), &pairs);
+        assert!(gif.contains("Animation doesn't carry over"));
+    }
+
+    #[test]
+    fn every_pair_page_has_at_least_250_words_of_visible_prose() {
+        for pair in all_pairs() {
+            let text = strip_tags(&content_html(&pair));
+            let words = text.split_whitespace().count();
+            assert!(
+                words >= 250,
+                "{} has only {words} words of visible prose",
+                pair.path()
+            );
+        }
+    }
+
+    #[test]
+    fn every_pair_page_emits_faq_details_for_json_ld() {
+        for pair in all_pairs() {
+            let content = content_html(&pair);
+            let faqs = crate::faq::extract_faqs(&content);
+            assert!(
+                (2..=3).contains(&faqs.len()),
+                "{} has {} FAQs (want 2–3)",
+                pair.path(),
+                faqs.len()
+            );
+        }
+    }
+
+    #[test]
+    fn sibling_links_cover_other_targets_reverse_and_parent() {
+        let pairs = all_pairs();
+        let html = render_pair_page(&audio_meta(), find(&pairs, "wav", "mp3"), &pairs);
+        // other targets for the same source
+        for sib in ["wav-to-ogg", "wav-to-flac", "wav-to-m4a"] {
+            assert!(
+                html.contains(&format!(r#"href="/tools/audio-convert/{sib}/""#)),
+                "sibling {sib} linked"
+            );
+        }
+        // the reverse direction exists (mp3 is a valid source, wav a valid target)
+        assert!(html.contains(r#"href="/tools/audio-convert/mp3-to-wav/""#));
+        // and the parent converter
+        assert!(html.contains(r#"href="/tools/audio-convert/""#));
+        // a source-only format (opus) has no reverse page to link
+        let opus = render_pair_page(&audio_meta(), find(&pairs, "opus", "mp3"), &pairs);
+        assert!(!opus.contains("mp3-to-opus"));
+    }
+
+    #[test]
+    fn direction_copy_matches_the_parent_tools_documented_behavior() {
+        let pairs = all_pairs();
+        // lossy→lossless cannot restore quality
+        let mp3_flac = content_html(find(&pairs, "mp3", "flac"));
+        assert!(mp3_flac.contains("No quality is restored"));
+        // lossless→lossy explains the bitrate choice
+        let wav_mp3 = content_html(find(&pairs, "wav", "mp3"));
+        assert!(wav_mp3.contains("32 and 320 kbps"));
+        assert!(wav_mp3.contains("192 kbps"));
+        // lossless targets: no bitrate to choose
+        let wav_flac = content_html(find(&pairs, "wav", "flac"));
+        assert!(wav_flac.contains("no bitrate to choose"));
+        // every audio pair mentions the dropped album art (the tool passes -vn)
+        for pair in pairs.iter().filter(|p| p.parent == "audio-convert") {
+            assert!(
+                content_html(pair).contains("album art is dropped"),
+                "{} album-art caveat",
+                pair.path()
+            );
+        }
+    }
+
+    #[test]
+    fn pairs_json_lists_path_and_title() {
+        let pairs = all_pairs();
+        let refs: Vec<&PairSpec> = pairs.iter().collect();
+        let v: serde_json::Value = serde_json::from_str(&pairs_json(&refs)).unwrap();
+        let arr = v.as_array().unwrap();
+        assert_eq!(arr.len(), 50);
+        let wav_mp3 = arr
+            .iter()
+            .find(|e| e["path"] == "audio-convert/wav-to-mp3")
+            .expect("wav-to-mp3 entry");
+        assert_eq!(
+            wav_mp3["title"],
+            "Convert WAV to MP3 Online — Free & Private — gizza.ai"
+        );
+        assert!(arr.iter().any(|e| e["path"] == "image-convert/png-to-webp"));
+        // every path is parent-slash-pair shaped
+        for e in arr {
+            let path = e["path"].as_str().unwrap();
+            assert!(
+                path.starts_with("audio-convert/") || path.starts_with("image-convert/"),
+                "{path}"
+            );
+            assert!(path.contains("-to-"), "{path}");
+        }
+    }
+
+    #[test]
+    fn pair_markdown_has_cta_cli_and_parent_docs_link() {
+        let pairs = all_pairs();
+        let md = pair_markdown(&audio_meta(), find(&pairs, "wav", "mp3"));
+        assert!(md.starts_with("# Convert WAV to MP3\n"));
+        assert!(md.contains("https://gizza.ai/tools/audio-convert/?format=mp3"));
+        assert!(md.contains(
+            "`gizza tool audio-convert 'url=https://example.com/input.wav' 'format=mp3'`"
+        ));
+        assert!(md.contains("https://gizza.ai/tools/audio-convert/index.md"));
+
+        let md = pair_markdown(&image_meta(), find(&pairs, "png", "webp"));
+        assert!(md.contains(
+            "`gizza tool image-convert 'url=https://example.com/input.png' 'format=webp' 'quality=85'`"
+        ));
+    }
+
+    #[test]
+    fn pair_links_for_parent_builds_the_popular_conversions_list() {
+        let pairs = all_pairs();
+        let links = pair_links_for_parent(&pairs, "audio-convert");
+        assert_eq!(links.len(), 35);
+        assert!(links
+            .iter()
+            .any(|l| l.label == "WAV to MP3" && l.href == "/tools/audio-convert/wav-to-mp3/"));
+        let links = pair_links_for_parent(&pairs, "image-convert");
+        assert_eq!(links.len(), 15);
+        assert!(links
+            .iter()
+            .any(|l| l.label == "JPG to WebP" && l.href == "/tools/image-convert/jpg-to-webp/"));
+        assert!(pair_links_for_parent(&pairs, "calculator").is_empty());
+    }
+}

--- a/tools/generator/src/template.rs
+++ b/tools/generator/src/template.rs
@@ -5,11 +5,13 @@ use crate::categories::Hub;
 use crate::control::{fmt_num, Control, ParamSchema};
 use crate::markdown::{cli_example as shared_cli_example, example_deeplink};
 use crate::meta::ToolMeta;
+use crate::pairs::PairLink;
 use gizza_chrome::{header as chrome_header, footer as chrome_footer, Active};
 use maud::{html, Markup, PreEscaped, DOCTYPE};
 
-/// The shared header's brand block — identical on every generated page.
-fn brand_link() -> Markup {
+/// The shared header's brand block — identical on every generated page
+/// (`pub(crate)` so the pair pages in `pairs.rs` render the same chrome).
+pub(crate) fn brand_link() -> Markup {
     html! {
         a.tool-brand href="https://gizza.ai" {
             img src="/logo.webp" alt="gizza.ai logo";
@@ -23,7 +25,10 @@ fn brand_link() -> Markup {
 /// ships a `page/custom.js`/`page/custom.css` (copied next to the page by
 /// main.rs) — the escape hatch for bespoke UI that the declarative meta.toml
 /// controls can't express. `related` is the tag-ranked top-5 from
-/// `related::related_tools`, rendered as internal links.
+/// `related::related_tools`, rendered as internal links. `pairs` is the
+/// tool's "X to Y" conversion pages (`pairs::pair_links_for_parent`) —
+/// non-empty only for the converter tools, rendered as a crawlable "Popular
+/// conversions" section right after the content.
 pub fn render_page(
     meta: &ToolMeta,
     content_html: &str,
@@ -31,6 +36,7 @@ pub fn render_page(
     custom_js: bool,
     custom_css: bool,
     related: &[&ToolMeta],
+    pairs: &[PairLink],
 ) -> String {
     let canonical = format!("https://gizza.ai/tools/{}/", meta.slug);
     // Both JSON blobs below are emitted raw inside <script> via PreEscaped, so a
@@ -116,6 +122,9 @@ pub fn render_page(
                 style { (PreEscaped(TOOL_CLI_CSS)) }
                 @if !related.is_empty() {
                     style { (PreEscaped(TOOL_RELATED_CSS)) }
+                }
+                @if !pairs.is_empty() {
+                    style { (PreEscaped(TOOL_PAIRS_CSS)) }
                 }
                 script type="application/ld+json" { (PreEscaped(json_ld)) }
                 script type="application/ld+json" { (PreEscaped(breadcrumbs_ld)) }
@@ -306,6 +315,18 @@ pub fn render_page(
                     section class="tool-content" {
                         (PreEscaped(content_html))
                     }
+                    // Crawlable "X to Y" landing-page links for the converter
+                    // tools — each chip is a pair page nested under this tool.
+                    @if !pairs.is_empty() {
+                        section class="tool-pairs" {
+                            h2 { "Popular conversions" }
+                            ul class="tool-pairs-list" {
+                                @for p in pairs {
+                                    li { a class="tool-pairs-link" href=(p.href) { (p.label) } }
+                                }
+                            }
+                        }
+                    }
                     // Internal links to the tag-nearest tools — crawlable
                     // `<a href>`s that spread link equity across the catalog
                     // and give readers a next step.
@@ -386,8 +407,9 @@ pub fn render_page(
 }
 
 /// BreadcrumbList JSON-LD for an ordered (name, url) trail, `</`-neutralized
-/// like the other JSON-LD blobs.
-fn breadcrumbs_json_ld(trail: &[(&str, &str)]) -> String {
+/// like the other JSON-LD blobs (`pub(crate)` — the pair pages emit the same
+/// trail with one extra level).
+pub(crate) fn breadcrumbs_json_ld(trail: &[(&str, &str)]) -> String {
     serde_json::json!({
         "@context": "https://schema.org",
         "@type": "BreadcrumbList",
@@ -436,6 +458,17 @@ const TOOL_RELATED_CSS: &str = r#"
 .tool-related-link { font-weight: 650; color: var(--tool-accent, #4f46e5); text-decoration: none; }
 .tool-related-link:hover, .tool-related-link:focus-visible { text-decoration: underline; }
 .tool-related-desc { margin: 4px 0 0; font-size: .9rem; color: var(--tool-muted, #6b7280); line-height: 1.45; }
+"#;
+
+/// Inline styles for the "Popular conversions" chip list on the converter
+/// tools' pages (same section idiom as the related-tools block; only emitted
+/// when the tool has pair pages).
+const TOOL_PAIRS_CSS: &str = r#"
+.tool-pairs { max-width: 720px; margin: 48px auto 0; }
+.tool-pairs h2 { font-size: 1.3rem; margin: 0 0 12px; color: var(--tool-ink, #0f172a); border-bottom: 1px solid #e2e8f0; padding-bottom: 8px; }
+.tool-pairs-list { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 8px; }
+.tool-pairs-link { display: inline-block; padding: 7px 14px; border: 1px solid #e2e8f0; border-radius: 999px; background: #fff; color: var(--tool-accent, #4f46e5); font-size: .9rem; text-decoration: none; }
+.tool-pairs-link:hover, .tool-pairs-link:focus-visible { border-color: var(--tool-accent, #4f46e5); text-decoration: underline; }
 "#;
 
 /// Inline styles for the `/tools/` landing grid (uses the `--tool-*` tokens
@@ -726,7 +759,7 @@ source      = "field"
 
     #[test]
     fn includes_seo_head_and_widget() {
-        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
+        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[], &[]);
         assert!(html.contains("<title>Free Online Calculator — gizza.ai</title>"));
         assert!(html.contains(r#"<link rel="canonical" href="https://gizza.ai/tools/calculator/">"#));
         assert!(
@@ -742,7 +775,7 @@ source      = "field"
 
     #[test]
     fn emits_per_tool_og_image_and_breadcrumbs() {
-        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
+        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[], &[]);
         assert!(
             html.contains(r#"content="https://gizza.ai/tools/calculator/og.png""#),
             "og:image + twitter:image point at the per-tool card"
@@ -761,11 +794,11 @@ source      = "field"
     fn faq_json_ld_mirrors_content_faq_section() {
         let with_faq = "<h2>FAQ</h2>\
             <details><summary>Is it private?</summary><p>Yes — runs locally.</p></details>";
-        let html = render_page(&sample(), with_faq, &ParamSchema::empty(), false, false, &[]);
+        let html = render_page(&sample(), with_faq, &ParamSchema::empty(), false, false, &[], &[]);
         assert!(html.contains(r#""@type":"FAQPage""#), "FAQPage JSON-LD present");
         assert!(html.contains(r#""name":"Is it private?""#));
 
-        let without = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
+        let without = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[], &[]);
         assert!(
             !without.contains("FAQPage"),
             "no FAQPage block when the page has no FAQ section"
@@ -774,7 +807,7 @@ source      = "field"
 
     #[test]
     fn links_machine_readable_descriptor_in_head_and_dev_section() {
-        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
+        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[], &[]);
         assert!(
             html.contains(r#"<link rel="alternate" type="application/json" href="tool.json">"#),
             "tool.json discovery link in the head",
@@ -792,7 +825,7 @@ source      = "field"
 
     #[test]
     fn page_documents_query_param_deep_link() {
-        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
+        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[], &[]);
         assert!(html.contains("Open it by URL"), "deep-link section present");
         assert!(
             html.contains("https://gizza.ai/tools/calculator/?expr="),
@@ -802,7 +835,7 @@ source      = "field"
 
     #[test]
     fn includes_shared_chrome_header_and_footer() {
-        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
+        let html = render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[], &[]);
         // Shared header markers from gizza-chrome
         assert!(
             html.contains(r#"id="explore-search""#),
@@ -931,7 +964,7 @@ format        = "text"
         .unwrap();
         let related = vec![&related_meta];
         let html =
-            render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &related);
+            render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &related, &[]);
         assert!(html.contains(r#"<section class="tool-related">"#), "related section present");
         assert!(html.contains("<h2>Related tools</h2>"));
         assert!(
@@ -951,8 +984,35 @@ format        = "text"
 
         // no related tools → neither the section nor its CSS
         let html =
-            render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
+            render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[], &[]);
         assert!(!html.contains("tool-related"), "no empty related section");
+    }
+
+    #[test]
+    fn popular_conversions_section_renders_after_content() {
+        let pairs = vec![
+            PairLink { label: "WAV to MP3".to_string(), href: "/tools/audio-convert/wav-to-mp3/".to_string() },
+            PairLink { label: "WAV to FLAC".to_string(), href: "/tools/audio-convert/wav-to-flac/".to_string() },
+        ];
+        let html =
+            render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[], &pairs);
+        assert!(html.contains(r#"<section class="tool-pairs">"#), "pairs section present");
+        assert!(html.contains("<h2>Popular conversions</h2>"));
+        assert!(
+            html.contains(r#"<a class="tool-pairs-link" href="/tools/audio-convert/wav-to-mp3/">WAV to MP3</a>"#),
+            "crawlable pair link"
+        );
+        assert!(html.contains(".tool-pairs-list"), "pairs CSS emitted");
+        // placement: content → popular conversions → Developer & Automation Access
+        let content = html.find(r#"class="tool-content""#).unwrap();
+        let pairs_at = html.find(r#"class="tool-pairs""#).unwrap();
+        let dev = html.find("Developer &amp; Automation Access").unwrap();
+        assert!(content < pairs_at && pairs_at < dev, "pairs sit between content and dev access");
+
+        // no pairs → neither the section nor its CSS
+        let html =
+            render_page(&sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[], &[]);
+        assert!(!html.contains("tool-pairs"), "no empty pairs section");
     }
 
     fn ffmpeg_sample() -> ToolMeta {
@@ -1028,7 +1088,7 @@ params = { birthdate = "1990-04-15" }
 
     #[test]
     fn renders_declarative_controls_examples_and_widget_chrome() {
-        let html = render_page(&declarative_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
+        let html = render_page(&declarative_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[], &[]);
         // meta kind="date" → native picker, no per-tool JS type-swapping
         assert!(html.contains(r#"id="in-birthdate" class="tool-input" type="date""#), "date picker rendered");
         // meta options="timezones" → datalist autocomplete
@@ -1093,7 +1153,7 @@ label       = "Gain"
             "semitones": { "type": "number", "minimum": -24, "maximum": 24 },
             "gain": { "type": "number", "minimum": -60, "maximum": 60 }
         }));
-        let html = render_page(&meta, "<h2>About</h2>", &schema, false, false, &[]);
+        let html = render_page(&meta, "<h2>About</h2>", &schema, false, false, &[], &[]);
         // kind="slider" → a range input mirroring the canonical number box
         assert!(html.contains(r#"id="in-semitones-slider""#), "slider rendered");
         assert!(html.contains(r#"data-for="in-semitones""#), "slider targets its number box");
@@ -1153,7 +1213,7 @@ kind        = "color"
             "color": { "type": "string", "default": "#4f46e5" },
             "background": { "type": "string" }
         }));
-        let html = render_page(&meta, "<h2>About</h2>", &schema, false, false, &[]);
+        let html = render_page(&meta, "<h2>About</h2>", &schema, false, false, &[], &[]);
         // kind="color" → a native swatch mirroring the canonical TEXT input
         assert!(html.contains(r##"id="in-color-swatch""##), "swatch rendered");
         assert!(html.contains(r##"data-for="in-color""##), "swatch targets its text input");
@@ -1203,7 +1263,7 @@ labels = { "9:16" = "9:16 — Reels / Shorts / TikTok (1080×1920)", "1:1" = "1:
         let schema = ParamSchema::from_props_for_tests(serde_json::json!({
             "aspect": { "type": "string", "enum": ["9:16", "1:1", "16:9"], "default": "9:16" }
         }));
-        let html = render_page(&meta, "<h2>About</h2>", &schema, false, false, &[]);
+        let html = render_page(&meta, "<h2>About</h2>", &schema, false, false, &[], &[]);
         // labeled options: canonical value attr + enriched visible text
         assert!(
             html.contains(r#"<option value="9:16" selected>9:16 — Reels / Shorts / TikTok (1080×1920)</option>"#),
@@ -1219,7 +1279,7 @@ labels = { "9:16" = "9:16 — Reels / Shorts / TikTok (1080×1920)", "1:1" = "1:
 
     #[test]
     fn media_tools_get_reset_but_not_copy_result() {
-        let html = render_page(&ffmpeg_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
+        let html = render_page(&ffmpeg_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[], &[]);
         assert!(html.contains(r#"id="tool-reset""#), "reset present (has fields)");
         assert!(!html.contains(r#"id="tool-copy-output""#), "no copy-result on media output");
     }
@@ -1229,7 +1289,7 @@ labels = { "9:16" = "9:16 — Reels / Shorts / TikTok (1080×1920)", "1:1" = "1:
         // ffmpeg_sample() is format="image" → the Copy-image button is rendered
         // (hidden, next to the download link), so a result can be copied to the
         // clipboard as PNG by tool.js.
-        let image_html = render_page(&ffmpeg_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
+        let image_html = render_page(&ffmpeg_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[], &[]);
         assert!(
             image_html.contains(r#"id="tool-copy-image""#),
             "image-output page renders the Copy-image button"
@@ -1261,7 +1321,7 @@ accept = "video/*"
 "#,
         )
         .unwrap();
-        let video_html = render_page(&video_meta, "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
+        let video_html = render_page(&video_meta, "<h2>About</h2>", &ParamSchema::empty(), false, false, &[], &[]);
         assert!(
             !video_html.contains(r#"id="tool-copy-image""#),
             "video-output page must not render the Copy-image button"
@@ -1288,14 +1348,14 @@ accept = "audio/*"
 "#,
         )
         .unwrap();
-        let audio_html = render_page(&audio_meta, "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
+        let audio_html = render_page(&audio_meta, "<h2>About</h2>", &ParamSchema::empty(), false, false, &[], &[]);
         assert!(
             !audio_html.contains(r#"id="tool-copy-image""#),
             "audio-output page must not render the Copy-image button"
         );
 
         // Text output (declarative_sample is format="text") must NOT get it.
-        let text_html = render_page(&declarative_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
+        let text_html = render_page(&declarative_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[], &[]);
         assert!(
             !text_html.contains(r#"id="tool-copy-image""#),
             "text-output page must not render the Copy-image button"
@@ -1304,7 +1364,7 @@ accept = "audio/*"
 
     #[test]
     fn renders_file_input_and_media_output() {
-        let html = render_page(&ffmpeg_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[]);
+        let html = render_page(&ffmpeg_sample(), "<h2>About</h2>", &ParamSchema::empty(), false, false, &[], &[]);
         assert!(html.contains(r#"type="file""#), "file input present");
         assert!(html.contains(r#"id="in-image""#), "file input id");
         assert!(html.contains(r#"accept="image/*""#), "accept attr");


### PR DESCRIPTION
## What

PR 5 of the stacked SEO program (base: `seo/feeds-indexnow`, PR #182). Adds **50 programmatic "X to Y" converter landing pages** nested under the two real converter tools — the queries people actually type ("wav to mp3", "png to webp"):

- **Audio (35):** sources mp3, wav, ogg, flac, m4a, aac, opus, aiff × targets mp3, wav, ogg, flac, m4a, identity skipped → `pkg/tools/audio-convert/<src>-to-<tgt>/`
- **Image (15):** sources png, jpg, webp, gif, bmp, tiff × targets jpeg, png, webp, with jpg→jpeg treated as identity → `pkg/tools/image-convert/…`

Each page ships `index.html` + `index.md` twin + per-pair `og.png` (via `OgRenderer`), and gets:

- Unique `<title>` ("Convert WAV to MP3 Online — Free & Private — gizza.ai"), meta description, canonical, og/twitter tags pointing at the pair card
- Visible breadcrumb + 4-level BreadcrumbList JSON-LD (Home › Tools › parent h1 › SRC to TGT)
- Prominent CTA deep-linking the parent with the target preselected (`/tools/audio-convert/?format=mp3`; image lossy targets add `&quality=85`, PNG targets omit the ignored param)
- A src-vs-tgt comparison table (compression, codec, size, uses, strengths, caveats, compatibility, + transparency/animation for images), a 3-step how-it-works, direction-specific caveats and 2–3 pair-specific FAQs (`<h2>FAQ</h2>` + `<details>` → FAQPage JSON-LD emits via the existing extractor)
- Sibling links: other targets for the same source, the reverse direction when it exists, and the parent converter

## Thin-content guard

Everything is assembled from a new per-format fact table (`src/formats.rs`) plus direction copy keyed on (lossy, lossless) — so intro, table, steps, caveats and FAQs all vary by pair. A test enforces **≥250 words of visible prose on every one of the 50 pages** (actual: 450+); all claims were checked against the parent tools' `content.md` (bitrate 32–320 clamped, album art dropped via `-vn`, 10 MiB audio limit, quality 1–100 JPEG/WebP-only, JPEG transparency flattened, GIF animation never carried over — phrased as "still images only", since the parent docs don't promise first-frame extraction).

Sample (wav-to-mp3 intro): *"WAV stores raw, uncompressed PCM samples — the audio equivalent of a bitmap. Files are huge, but every editor, DAW and operating system opens them without a second thought. MP3 is the most widely supported audio format there is — a lossy codec that shrinks audio to a fraction of its uncompressed size and plays on virtually anything with a speaker. Converting WAV to MP3 trades a sliver of fidelity for a dramatic drop in size: a WAV recording that hogs storage becomes an MP3 file you can email, message or stream."*

## Plumbing

- Parent converter pages gain a crawlable **"Popular conversions"** chip section right after the content section (`render_page` grew a `pairs` param — no `content.md` edits)
- `pkg/tools/_pairs.json` (`[{path, title}]`) → consumed by `scripts/gen-seo.sh` to add pair URLs to the sitemap (same pattern as `_hubs.json`), lastmod = `git_lastmod blocks/<parent>/page`, graceful when missing
- Pair pages link chrome assets from the parent dir (`../tool.css`, `../header.js`) — zero per-pair asset copies; `main.rs` fails loudly if a pair dir would shadow a parent file

## Tested

- `cargo test` (tools/generator): **105 passed** (88 → 105; new: formats lookups, 35+15 enumeration counts, pair markup incl. canonical/breadcrumbs/CTA/FAQ JSON-LD, ≥250-word guard on all 50, direction-copy consistency incl. per-pair transparency/animation claims, `_pairs.json` shape, popular-conversions placement)
- `cargo clippy --all-targets`: no new warnings vs base (only the pre-existing `empty` dead_code note)
- Full release run from repo root: 324 tool pages + 13 hubs + **50 pair pages** render; spot-read `audio-convert/wav-to-mp3` and `image-convert/png-to-webp` plus mp3-to-ogg / flac-to-wav / aiff-to-wav / gif-to-jpeg / tiff-to-png / jpg-to-png end-to-end for prose sanity
- `GIZZA=gizza scripts/gen-seo.sh`: sitemap now 390 URLs (+50 pair URLs), XML-valid; `gen-seo.test.sh` extended with a `_pairs.json` fixture and passes; shellcheck: no new findings
- No pair directory collides with any file in the parents' output dirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)