### PR TITLE
feat(seo): redirect gizza-ai.pages.dev mirror to canonical gizza.ai

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -165,8 +165,9 @@ jobs:
 
       - name: Deploy to Cloudflare Pages
         # workingDirectory is gizza-ai so wrangler finds the sibling `functions/`
-        # directory (the Pages Functions middleware that does the *.gizza.ai
-        # subdomain rewrite) next to the deployed `pkg/` assets.
+        # directory (the Pages Functions middleware that 301-redirects the
+        # gizza-ai.pages.dev project subdomain to the canonical gizza.ai
+        # domain) next to the deployed `pkg/` assets.
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,0 +1,23 @@
+// Pages Functions middleware: 301-redirect the Cloudflare project subdomain
+// (gizza-ai.pages.dev) to the canonical apex domain. The mirror serves the
+// exact same deployment as gizza.ai, so without this it can be crawled,
+// indexed, or cited by AI agents in place of the real domain — the pages
+// already carry <link rel="canonical" href="https://gizza.ai/..."> but that
+// is only a hint, and this makes it a hard redirect.
+//
+// Only the production subdomain is matched. Preview deploys
+// (<hash>.gizza-ai.pages.dev) and the real domain fall through untouched, so
+// previews stay usable. Path and query string are preserved.
+//
+// Runs on every request; on the production domain it is a single hostname
+// comparison then next(), so the cost is negligible.
+export async function onRequest(context) {
+  const url = new URL(context.request.url);
+  if (url.hostname === "gizza-ai.pages.dev") {
+    url.protocol = "https:";
+    url.hostname = "gizza.ai";
+    url.port = "";
+    return Response.redirect(url.toString(), 301);
+  }
+  return context.next();
+}


### PR DESCRIPTION
## Why

Cloudflare Pages always keeps the project subdomain **`gizza-ai.pages.dev`** live, serving the byte-identical deployment as `gizza.ai`. Every page already emits `<link rel="canonical" href="https://gizza.ai/...">`, which consolidates ranking signals — but canonical is a *hint*, not a directive. The mirror can still be indexed occasionally and, more importantly for this repo's SEO/AI-readability focus, **cited by AI crawlers under the wrong domain**.

A path-based `_redirects` file can't fix this: Cloudflare Pages `_redirects` matches on path only and is served identically to *both* hosts, so it would loop on the real domain. The redirect has to be host-aware.

## What

- **`functions/_middleware.js`** — a Pages Functions middleware that 301-redirects the production `gizza-ai.pages.dev` host to `https://gizza.ai`, preserving path + query. The real domain and preview deploys (`<hash>.gizza-ai.pages.dev`) fall through untouched, so previews stay usable.
- **`deploy.yml` comment fix** — the deploy step already set `workingDirectory: gizza-ai` "so wrangler finds the sibling `functions/` directory," but that dir never existed and the comment described a non-existent `*.gizza.ai` rewrite. Corrected to describe the actual redirect. This PR finally supplies the `functions/` dir the workflow was already expecting.

## Verification

`node --check` passes; simulated the redirect logic against representative hosts:

| Request | Result |
|---|---|
| `https://gizza-ai.pages.dev/tools/calculator/?expr=1%2B1` | → `https://gizza.ai/tools/calculator/?expr=1%2B1` (301) |
| `https://gizza-ai.pages.dev/` | → `https://gizza.ai/` (301) |
| `https://gizza.ai/tools/calculator/` | pass through |
| `https://abc123.gizza-ai.pages.dev/tools/calculator/` (preview) | pass through |

Full end-to-end confirmation happens on the first deploy after merge (the middleware only runs on the live Pages edge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)