### PR TITLE
ci: run repo-level tests + changed-tool Playwright on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -318,7 +318,7 @@ jobs:
             echo "No changed tool-page specs; skipping Playwright."
             exit 0
           fi
-          npm ci
+          npm install --no-audit --no-fund
           npx playwright install --with-deps chromium
           npx playwright test "${specs[@]}"
 
@@ -330,6 +330,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          npm ci
+          npm install --no-audit --no-fund
           npx playwright install --with-deps chromium
           npx playwright test landing-chooser.spec.ts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -259,7 +259,12 @@ jobs:
           node-version: '20'
 
       - name: JS tests
+        # The sw-bypass tests need the solobase-built pkg/sw.js: on main
+        # pushes (pkg built above) REQUIRE_BUILT_PKG makes a missing artifact
+        # a failure; on PRs (no app build) those two tests self-skip.
         working-directory: gizza-ai
+        env:
+          REQUIRE_BUILT_PKG: ${{ github.event_name != 'pull_request' && '1' || '' }}
         run: |
           npm install --no-audit --no-fund
           npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -205,7 +205,8 @@ jobs:
           done <<< "${{ steps.changed.outputs.blocks }}"
 
       - name: Cargo tests
-        if: github.event_name != 'pull_request'
+        # Root crate tests (lazy_skill lifecycle, skills_embed, agent, …) run
+        # on PRs too: repo-level regressions used to surface only after merge.
         working-directory: gizza-ai
         run: cargo test
 
@@ -229,7 +230,6 @@ jobs:
           fi
 
       - name: CLI tests
-        if: github.event_name != 'pull_request'
         working-directory: gizza-ai
         run: cargo test --manifest-path cli/Cargo.toml
 
@@ -246,7 +246,6 @@ jobs:
         run: bash scripts/check-tool-hygiene.test.sh
 
       - name: Chrome crate tests
-        if: github.event_name != 'pull_request'
         working-directory: gizza-ai
         run: cargo test --manifest-path chrome/Cargo.toml
 
@@ -260,8 +259,72 @@ jobs:
           node-version: '20'
 
       - name: JS tests
-        if: github.event_name != 'pull_request'
         working-directory: gizza-ai
         run: |
           npm install --no-audit --no-fund
           npm test
+
+      - name: Build changed tool pages
+        # Standalone tool pages are self-contained under pkg/tools/<slug>/
+        # (web wasm + generator output) — no app/solobase build needed. The
+        # generator regenerates all pages but only warns for tools whose
+        # web/pkg is absent (it copies wasm only for the ones built here).
+        if: github.event_name == 'pull_request'
+        working-directory: gizza-ai
+        shell: bash
+        run: |
+          set -euo pipefail
+          built=0
+          while IFS= read -r block; do
+            [ -n "$block" ] || continue
+            if [ ! -d "blocks/$block/web" ]; then
+              echo "blocks/$block has no web/ crate — skipping"
+              continue
+            fi
+            echo "Building web wasm for $block"
+            wasm-pack build "blocks/$block/web" --target web --release --out-dir pkg
+            built=$((built + 1))
+          done <<< "${{ steps.changed.outputs.blocks }}"
+          if [ "$built" -eq 0 ]; then
+            echo "No changed tool web crates; skipping page generation."
+            exit 0
+          fi
+          cargo run --manifest-path tools/generator/Cargo.toml -- .
+
+      - name: Changed tool-page Playwright tests
+        # Playwright runs headless (the fixtures only go headed under HEADED=1
+        # for WebLLM/WebGPU specs, which are not in this set). The webServer in
+        # playwright.config.ts serves ../pkg on :8001 automatically.
+        if: github.event_name == 'pull_request'
+        working-directory: gizza-ai/tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          specs=()
+          while IFS= read -r block; do
+            [ -n "$block" ] || continue
+            if [ -f "tool-page-$block.spec.ts" ]; then
+              specs+=("tool-page-$block.spec.ts")
+            else
+              echo "No Playwright spec for changed block '$block'"
+            fi
+          done <<< "${{ steps.changed.outputs.blocks }}"
+          if [ "${#specs[@]}" -eq 0 ]; then
+            echo "No changed tool-page specs; skipping Playwright."
+            exit 0
+          fi
+          npm ci
+          npx playwright install --with-deps chromium
+          npx playwright test "${specs[@]}"
+
+      - name: Landing-chooser Playwright smoke
+        # Guards the static chooser page in the pkg/ that "Build skill wasms
+        # (full)" produced above — main-push only (PRs don't build the app pkg).
+        if: github.event_name != 'pull_request'
+        working-directory: gizza-ai/tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm ci
+          npx playwright install --with-deps chromium
+          npx playwright test landing-chooser.spec.ts

--- a/js/sw-bypass.test.js
+++ b/js/sw-bypass.test.js
@@ -7,10 +7,18 @@ import { fileURLToPath } from 'node:url';
 // lightweight standalone pages that must be served as static assets, never
 // booted through the wafer/solobase runtime. solobase injects this bypass from
 // solobase.toml [assets].extra_bypass_prefix into sw.js via __EXTRA_BYPASS__.
-// Requires `solobase build` to have produced pkg/sw.js (CI builds before tests).
+//
+// pkg/sw.js is a `solobase build` artifact, so these are post-build
+// integration tests: lanes without a built pkg/ (PR CI, fresh clones) skip
+// them, and lanes that build pkg/ set REQUIRE_BUILT_PKG=1 so a missing
+// artifact fails loudly instead of skipping.
 const swPath = fileURLToPath(new URL('../pkg/sw.js', import.meta.url));
+const skip =
+  !existsSync(swPath) && !process.env.REQUIRE_BUILT_PKG
+    ? 'pkg/sw.js not built — run `solobase build` (REQUIRE_BUILT_PKG=1 makes this a failure)'
+    : false;
 
-test('sw.js bypasses /tools/ so tool pages stay static', () => {
+test('sw.js bypasses /tools/ so tool pages stay static', { skip }, () => {
   assert.ok(existsSync(swPath), 'pkg/sw.js missing — run `solobase build` first');
   const src = readFileSync(swPath, 'utf8');
   assert.match(
@@ -20,7 +28,7 @@ test('sw.js bypasses /tools/ so tool pages stay static', () => {
   );
 });
 
-test('sw.js bypasses /ffmpeg-engine.js and /ffmpeg.js so the chat ffmpeg bridge loads statically', () => {
+test('sw.js bypasses /ffmpeg-engine.js and /ffmpeg.js so the chat ffmpeg bridge loads statically', { skip }, () => {
   assert.ok(existsSync(swPath), 'pkg/sw.js missing — run `solobase build` first');
   const src = readFileSync(swPath, 'utf8');
   assert.match(


### PR DESCRIPTION
Closes the PR-CI gap noted in the 07-09 saga: root `cargo test`, CLI, chrome, and JS tests were main-push-only, and Playwright was not wired into CI at all — repo-level regressions and broken tool pages surfaced only after merge.

## What

- **Root/CLI/chrome/JS test steps now run on PRs** (dropped the `!= 'pull_request'` conditions).
- **Changed-tool Playwright on PRs**: for each changed block (same detection as the per-changed-block cargo tests), wasm-pack its web crate, run the page generator, and run its `tool-page-<slug>.spec.ts` headless. Tool pages are self-contained under `pkg/tools/<slug>/`, so no app/solobase build is needed; the generator warns-and-skips tools whose web/pkg isn't built. The config's built-in `serve_pkg.py` webServer serves `pkg/` automatically. Both steps early-exit cleanly when a PR touches no blocks.
- **Landing-chooser smoke on main pushes**, guarding the static chooser in the `pkg/` produced by "Build skill wasms (full)" — including the mascot idle-video regression class from #190.

Full-suite Playwright (342 specs) stays out of CI deliberately — per-PR it's changed-tools-only, mirroring the existing per-block philosophy.

## Verification

- Local, exercising the exact new paths: slugify web wasm + generator + its spec — 5 passed headless (1.8s); landing-chooser — 4 passed (12s); chrome crate — 9 passed; JS — 0 fail; root + cli suites green earlier today on identical Rust code.
- This PR's own CI exercises the PR lanes with zero changed blocks (early-exit paths).
- A throwaway draft PR touching one block will exercise the full changed-tool Playwright lane in real CI before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)