### PR TITLE
fix(ci): render /tools/ hubs before the landing-chooser smoke on main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -322,6 +322,14 @@ jobs:
           npx playwright install --with-deps chromium
           npx playwright test "${specs[@]}"
 
+      - name: Generate tool pages (full)
+        # Renders the /tools/ hub pages into pkg/tools/ — the landing-chooser
+        # smoke below asserts the chooser's Tools button lands on a real hub.
+        # (The generator only warns for tools without a built web/pkg.)
+        if: github.event_name != 'pull_request'
+        working-directory: gizza-ai
+        run: cargo run --manifest-path tools/generator/Cargo.toml -- .
+
       - name: Landing-chooser Playwright smoke
         # Guards the static chooser page in the pkg/ that "Build skill wasms
         # (full)" produced above — main-push only (PRs don't build the app pkg).


### PR DESCRIPTION
Fix-forward for the red main test run (29066355351): the new landing-chooser smoke's /tools/ test 404'd because the main-push lane never ran the tool-page generator — `solobase build` doesn't render `pkg/tools/`. Adds a "Generate tool pages (full)" step (main-push only, reuses the generator binary already compiled by the generator-tests step) before the smoke.

Verified locally: `rm -rf pkg/tools` reproduces the exact CI failure (3 passed / 1 failed on the /tools/ title); after the generator runs, 4 passed (12s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)