### PR TITLE
fix(pages): 404 unknown /tools/ slugs instead of soft-404 homepage shell

### DIFF
--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -1,16 +1,74 @@
-// Pages Functions middleware: 301-redirect the Cloudflare project subdomain
-// (gizza-ai.pages.dev) to the canonical apex domain. The mirror serves the
-// exact same deployment as gizza.ai, so without this it can be crawled,
-// indexed, or cited by AI agents in place of the real domain — the pages
-// already carry <link rel="canonical" href="https://gizza.ai/..."> but that
-// is only a hint, and this makes it a hard redirect.
+// Pages Functions middleware, two jobs:
 //
-// Only the production subdomain is matched. Preview deploys
-// (<hash>.gizza-ai.pages.dev) and the real domain fall through untouched, so
-// previews stay usable. Path and query string are preserved.
+// 1. 301-redirect the Cloudflare project subdomain (gizza-ai.pages.dev) to
+//    the canonical apex domain. The mirror serves the exact same deployment
+//    as gizza.ai, so without this it can be crawled, indexed, or cited by AI
+//    agents in place of the real domain — the pages already carry
+//    <link rel="canonical" href="https://gizza.ai/..."> but that is only a
+//    hint, and this makes it a hard redirect. Only the production subdomain
+//    is matched; preview deploys (<hash>.gizza-ai.pages.dev) and the real
+//    domain fall through untouched, so previews stay usable. Path and query
+//    string are preserved.
 //
-// Runs on every request; on the production domain it is a single hostname
-// comparison then next(), so the cost is negligible.
+// 2. 404 unknown /tools/ pages. The deployment ships no 404.html, so
+//    Cloudflare Pages serves the SPA fallback (the homepage shell) with a
+//    200 for any unmatched path — and /tools/ requests always take that
+//    route because the service worker deliberately bypasses them (sw.js).
+//    That soft-404 lets crawlers index arbitrary /tools/<garbage>/ URLs.
+//    The guard checks the requested slug against the generated manifests
+//    (`/tools/_index.json`, `_hubs.json`, `_pairs.json` — written by
+//    tools/generator next to the pages themselves, so they cannot drift
+//    from what is actually deployed) and answers a real 404 for unknown
+//    slugs. Decision logic lives in js/tools-guard.js (covered by
+//    `node --test`); manifests are fetched once per isolate and cached.
+
+import { buildManifestSets, classifyToolsPath } from "../js/tools-guard.js";
+
+let manifestSetsPromise = null;
+
+async function loadManifestSets(context, origin) {
+  const fetchJson = async (path) => {
+    try {
+      const res = await context.env.ASSETS.fetch(new URL(path, origin));
+      if (!res.ok) return [];
+      return await res.json();
+    } catch {
+      return []; // fail open — classifyToolsPath treats empty tools as "pass all"
+    }
+  };
+  const [tools, hubs, pairs] = await Promise.all([
+    fetchJson("/tools/_index.json"),
+    fetchJson("/tools/_hubs.json"),
+    fetchJson("/tools/_pairs.json"),
+  ]);
+  return buildManifestSets({ tools, hubs, pairs });
+}
+
+const NOT_FOUND_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Tool not found — gizza.ai</title>
+<style>
+  body{font-family:system-ui,sans-serif;display:grid;place-items:center;min-height:100vh;margin:0;background:#fafafa;color:#111}
+  main{text-align:center;padding:2rem}
+  h1{font-size:1.4rem;margin-bottom:.5rem}
+  a{color:#2563eb}
+  @media (prefers-color-scheme:dark){body{background:#111;color:#eee}a{color:#7ab7ff}}
+</style>
+</head>
+<body>
+<main>
+  <h1>404 — no such tool</h1>
+  <p>This tool doesn't exist (or isn't built yet).</p>
+  <p><a href="/tools/">Browse all tools</a></p>
+</main>
+</body>
+</html>
+`;
+
 export async function onRequest(context) {
   const url = new URL(context.request.url);
   if (url.hostname === "gizza-ai.pages.dev") {
@@ -19,5 +77,20 @@ export async function onRequest(context) {
     url.port = "";
     return Response.redirect(url.toString(), 301);
   }
+
+  const method = context.request.method;
+  if ((method === "GET" || method === "HEAD") && url.pathname.startsWith("/tools/")) {
+    if (!manifestSetsPromise) {
+      manifestSetsPromise = loadManifestSets(context, url.origin);
+    }
+    const manifests = await manifestSetsPromise;
+    if (classifyToolsPath(url.pathname, manifests) === "not-found") {
+      return new Response(method === "HEAD" ? null : NOT_FOUND_HTML, {
+        status: 404,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
+  }
+
   return context.next();
 }

--- a/js/tools-guard.js
+++ b/js/tools-guard.js
@@ -1,0 +1,68 @@
+// Decide whether a /tools/ request maps to a page this deployment actually
+// ships, so the Pages middleware can 404 unknown slugs instead of letting
+// Cloudflare's SPA fallback serve the homepage shell with a 200 (soft-404 —
+// crawlers index garbage tool URLs).
+//
+// Pure module: the middleware feeds it the generated manifests
+// (`pkg/tools/_index.json`, `_hubs.json`, `_pairs.json` — written by
+// tools/generator alongside the pages themselves, so they cannot drift from
+// what was deployed) and a pathname; it answers 'pass' or 'not-found'.
+// Kept free of Workers APIs so `node --test` covers it directly.
+
+/**
+ * Build fast lookup sets from the three parsed manifest arrays.
+ * Missing/failed manifests should be passed as empty arrays.
+ */
+export function buildManifestSets({ tools = [], hubs = [], pairs = [] }) {
+  return {
+    tools: new Set(tools.map((t) => t.slug)),
+    hubs: new Set(hubs.map((h) => h.slug)),
+    pairs: new Set(pairs.map((p) => p.path)),
+  };
+}
+
+/**
+ * Classify a request pathname against the deployed tool/hub/pair manifests.
+ *
+ * Returns 'pass' (let the asset server handle it) or 'not-found' (the
+ * middleware should answer 404).
+ *
+ * Rules:
+ * - Only `/tools/…` paths are ever guarded; everything else passes.
+ * - `/tools/` and `/tools/index.html` (the hub) pass.
+ * - A first segment containing a dot is a file directly under /tools/
+ *   (the `_*.json` manifests, feed fragments) — pass.
+ * - A first segment found in the tool or hub manifests passes at any depth.
+ * - Under a known hub, a second *page* segment must be a known pair path
+ *   (`hub/pair`); files (dotted) under a known hub pass.
+ * - Anything else is 'not-found'.
+ * - Fail open when the tool manifest is empty: a deployment with zero tools
+ *   is not a real state, so an empty set means the manifests could not be
+ *   loaded — availability wins over strictness.
+ */
+export function classifyToolsPath(pathname, manifests) {
+  if (!pathname.startsWith('/tools/')) return 'pass';
+  if (manifests.tools.size === 0) return 'pass';
+
+  let decoded;
+  try {
+    decoded = decodeURIComponent(pathname);
+  } catch {
+    return 'not-found';
+  }
+
+  const segments = decoded.slice('/tools/'.length).split('/').filter(Boolean);
+  if (segments.length === 0) return 'pass'; // /tools/ itself
+
+  const [first, second] = segments;
+  if (first === 'index.html') return 'pass';
+  if (first.includes('.')) return 'pass'; // _index.json etc.
+
+  if (manifests.tools.has(first)) return 'pass';
+  if (manifests.hubs.has(first)) {
+    if (segments.length === 1) return 'pass';
+    if (second.includes('.')) return 'pass'; // file under a hub page
+    return manifests.pairs.has(`${first}/${second}`) ? 'pass' : 'not-found';
+  }
+  return 'not-found';
+}

--- a/js/tools-guard.test.js
+++ b/js/tools-guard.test.js
@@ -1,0 +1,67 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildManifestSets, classifyToolsPath } from './tools-guard.js';
+
+const manifests = buildManifestSets({
+  tools: [{ slug: 'calculator' }, { slug: 'word-count' }],
+  hubs: [{ slug: 'audio' }, { slug: 'audio-convert' }],
+  pairs: [{ path: 'audio-convert/mp3-to-wav' }],
+});
+
+test('non-tools paths are never guarded', () => {
+  assert.equal(classifyToolsPath('/', manifests), 'pass');
+  assert.equal(classifyToolsPath('/chat', manifests), 'pass');
+  assert.equal(classifyToolsPath('/toolsy/thing/', manifests), 'pass');
+});
+
+test('the tools hub itself passes', () => {
+  assert.equal(classifyToolsPath('/tools/', manifests), 'pass');
+  assert.equal(classifyToolsPath('/tools/index.html', manifests), 'pass');
+});
+
+test('known tool slugs pass at any depth', () => {
+  assert.equal(classifyToolsPath('/tools/calculator/', manifests), 'pass');
+  assert.equal(classifyToolsPath('/tools/calculator', manifests), 'pass');
+  assert.equal(classifyToolsPath('/tools/calculator/tool.json', manifests), 'pass');
+  assert.equal(classifyToolsPath('/tools/calculator/index.md', manifests), 'pass');
+});
+
+test('known category hubs pass', () => {
+  assert.equal(classifyToolsPath('/tools/audio/', manifests), 'pass');
+});
+
+test('known pair pages under a hub pass', () => {
+  assert.equal(classifyToolsPath('/tools/audio-convert/mp3-to-wav/', manifests), 'pass');
+  assert.equal(
+    classifyToolsPath('/tools/audio-convert/mp3-to-wav/index.md', manifests),
+    'pass'
+  );
+});
+
+test('unknown pair pages under a known hub 404', () => {
+  assert.equal(
+    classifyToolsPath('/tools/audio-convert/flac-to-midi/', manifests),
+    'not-found'
+  );
+});
+
+test('unknown slugs 404', () => {
+  assert.equal(classifyToolsPath('/tools/definitely-not-a-tool-xyz/', manifests), 'not-found');
+  assert.equal(classifyToolsPath('/tools/word-counter/', manifests), 'not-found');
+});
+
+test('manifest files and dotted files under /tools/ pass', () => {
+  assert.equal(classifyToolsPath('/tools/_index.json', manifests), 'pass');
+  assert.equal(classifyToolsPath('/tools/_hubs.json', manifests), 'pass');
+  assert.equal(classifyToolsPath('/tools/_pairs.json', manifests), 'pass');
+});
+
+test('percent-encoded segments are decoded before matching', () => {
+  assert.equal(classifyToolsPath('/tools/word%2Dcount/', manifests), 'pass');
+  assert.equal(classifyToolsPath('/tools/nope%20nope/', manifests), 'not-found');
+});
+
+test('empty manifests fail open (deploy-ordering safety)', () => {
+  const empty = buildManifestSets({ tools: [], hubs: [], pairs: [] });
+  assert.equal(classifyToolsPath('/tools/anything-at-all/', empty), 'pass');
+});


### PR DESCRIPTION
Found by the live browser smoke (2026-07-10): `https://gizza.ai/tools/definitely-not-a-tool-xyz/` returned **200 with the homepage shell** — Pages' SPA fallback, reached because the deploy has no `404.html` and `sw.js` bypasses `/tools/` so the wasm router's 404 never runs there. Crawlers can index garbage tool URLs.

Fix: the existing Pages middleware now guards `GET/HEAD /tools/*` against the generated slug manifests (`_index.json` / `_hubs.json` / `_pairs.json`) and returns a real 404 (`noindex`) for unknown slugs/pairs. Pure decision logic in `js/tools-guard.js` with `node --test` coverage (literal-match rules, pair pages, dotted files pass, fail-open on missing manifests).

Scoped to `/tools/` on purpose — a top-level `404.html` would flip ALL unmatched paths out of SPA mode and break first-load client routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)