### PR TITLE
refactor: de-brand block pages; branding now injected via site config

### DIFF
--- a/blocks/action-item-extractor/page/meta.toml
+++ b/blocks/action-item-extractor/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "action-item-extractor"
-title         = "Action Item Extractor — Turn Meeting Notes into Tasks — gizza.ai"
+title         = "Action Item Extractor — Turn Meeting Notes into Tasks"
 description   = "Extract action items, owners, and decisions from meeting notes or daily notes with deterministic rules. Markdown checklist or JSON, private in-browser."
 tags          = ["action items", "meeting notes", "task extractor", "decision log", "todo list", "meeting summary", "owner extraction", "daily notes"]
 h1            = "Extract Action Items from Meeting Notes"

--- a/blocks/add-line-numbers/page/meta.toml
+++ b/blocks/add-line-numbers/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "add-line-numbers"
-title         = "Add Line Numbers — number every line of text — gizza.ai"
+title         = "Add Line Numbers — number every line of text"
 description   = "Add line numbers to every line of text online, like nl or cat -n — custom start, step, separator, and alignment. Free and private, runs in your browser."
 tags          = ["add line numbers", "number lines", "line numbering", "nl", "cat -n", "prefix line numbers"]
 h1            = "Add Line Numbers"

--- a/blocks/adjacency-matrix-converter/page/meta.toml
+++ b/blocks/adjacency-matrix-converter/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "adjacency-matrix-converter"
-title         = "Adjacency Matrix Converter — Edge List ⇄ Matrix — gizza.ai"
+title         = "Adjacency Matrix Converter — Edge List ⇄ Matrix"
 description   = "Convert a graph between edge list, adjacency matrix, and incidence matrix — directed or undirected, weighted or not. Free, private, runs in your browser."
 tags          = ["adjacency matrix", "incidence matrix", "edge list", "graph converter", "directed graph", "weighted graph", "graph theory", "matrix"]
 h1            = "Adjacency Matrix Converter"

--- a/blocks/aes-cipher/page/meta.toml
+++ b/blocks/aes-cipher/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "aes-cipher"
-title         = "AES Cipher — Encrypt/decrypt with AES (CBC/CTR/GCM/ECB) — gizza.ai"
+title         = "AES Cipher — Encrypt/decrypt with AES (CBC/CTR/GCM/ECB)"
 description   = "Encrypt or decrypt text with AES in CBC, CTR, GCM or ECB mode and 128/192/256-bit keys, with hex/base64 I/O — in your browser. Nothing is uploaded."
 tags          = ["aes", "aes encrypt", "aes decrypt", "cbc", "ctr", "gcm", "cipher"]
 h1            = "AES cipher"

--- a/blocks/aes-key-wrap/page/meta.toml
+++ b/blocks/aes-key-wrap/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "aes-key-wrap"
-title         = "AES Key Wrap — Wrap & unwrap keys (RFC 3394 / RFC 5649) — gizza.ai"
+title         = "AES Key Wrap — Wrap & unwrap keys (RFC 3394 / RFC 5649)"
 description   = "Wrap and unwrap cryptographic keys with AES Key Wrap (KW / RFC 3394, KWP / RFC 5649) using a 128/192/256-bit KEK — hex or base64, free and in-browser."
 tags          = ["aes key wrap", "key wrap", "rfc 3394", "rfc 5649", "kwp", "kek", "wrap key"]
 h1            = "AES Key Wrap"

--- a/blocks/age-calculator/page/meta.toml
+++ b/blocks/age-calculator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "age-calculator"
-title         = "Age Calculator — Exact Age in Years, Months & Days from Date of Birth — gizza.ai"
+title         = "Age Calculator — Exact Age in Years, Months & Days from Date of Birth"
 description   = "Calculate your exact age from your date of birth — years, months and days, next birthday countdown and total days lived. Free, private, in-browser."
 tags          = ["age calculator", "how old am i", "date of birth", "age in years months days", "birthday countdown", "age in days", "chronological age", "zodiac sign", "day of week born"]
 h1            = "Age Calculator"

--- a/blocks/amazon-order-analyzer/page/meta.toml
+++ b/blocks/amazon-order-analyzer/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "amazon-order-analyzer"
-title         = "Amazon Order Analyzer — Spending by Month, Item, Category — gizza.ai"
+title         = "Amazon Order Analyzer — Spending by Month, Item, Category"
 description   = "Paste an Amazon order-history CSV export to summarize total spend by month, top items, and category breakdowns. Browser-only, private, with Markdown or JSON output."
 tags          = ["amazon orders", "order history", "csv analyzer", "spending summary", "monthly spend", "top items", "category breakdown", "personal finance", "shopping"]
 h1            = "Amazon Order Analyzer"

--- a/blocks/argon2-hash/page/meta.toml
+++ b/blocks/argon2-hash/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "argon2-hash"
-title         = "Argon2 Hash — Argon2id password hashing & verify — gizza.ai"
+title         = "Argon2 Hash — Argon2id password hashing & verify"
 description   = "Hash a password with Argon2id (configurable memory, iterations, parallelism) and get a PHC string, or verify a password — in your browser. Nothing is uploaded."
 tags          = ["argon2", "argon2id", "password hash", "phc", "password hashing", "verify password"]
 h1            = "Argon2 hash"

--- a/blocks/asn1-parser/page/meta.toml
+++ b/blocks/asn1-parser/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "asn1-parser"
-title         = "ASN.1 / DER Parser — decode DER hex to a readable tree — gizza.ai"
+title         = "ASN.1 / DER Parser — decode DER hex to a readable tree"
 description   = "Parse an ASN.1 / DER hex string into a readable tree of tags, lengths, OIDs and values — free, in your browser. Inspect X.509 certificates, keys and CSRs."
 tags          = ["asn.1 parser", "asn1 decoder", "der decoder", "der parser", "der to text", "x.509 parser", "oid decoder", "asn1 hex", "certificate decoder"]
 h1            = "ASN.1 / DER parser"

--- a/blocks/audio-compress/page/meta.toml
+++ b/blocks/audio-compress/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "audio-compress"
-title         = "Compress Audio Online — gizza.ai"
+title         = "Compress Audio Online"
 description   = "Shrink MP3, WAV, M4A or any audio file right in your browser — pick a target bitrate (96 kbps default) and format. Nothing is uploaded, free."
 tags          = ["audio", "compress", "shrink", "mp3", "bitrate", "smaller", "reduce", "size"]
 h1            = "Compress an Audio File"

--- a/blocks/audio-convert/page/meta.toml
+++ b/blocks/audio-convert/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "audio-convert"
-title         = "Convert Audio Online — gizza.ai"
+title         = "Convert Audio Online"
 description   = "Convert any audio file to MP3, WAV, OGG, FLAC or M4A right in your browser — pick a bitrate for lossy formats. Runs locally, nothing is uploaded, free."
 tags          = ["audio", "convert", "mp3", "wav", "ogg", "flac", "m4a", "bitrate"]
 h1            = "Convert an Audio File"

--- a/blocks/audio-eq/page/meta.toml
+++ b/blocks/audio-eq/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "audio-eq"
-title         = "Audio Equalizer Online — gizza.ai"
+title         = "Audio Equalizer Online"
 description   = "Equalize any audio file right in your browser — boost or cut bass, mid and treble in dB, then save as MP3, WAV and more. Nothing is uploaded, free."
 tags          = ["audio", "equalizer", "eq", "bass", "treble", "mid", "boost", "tone"]
 h1            = "Equalize an Audio File"

--- a/blocks/audio-fade/page/meta.toml
+++ b/blocks/audio-fade/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "audio-fade"
-title         = "Add Fade In & Fade Out to Audio Online — gizza.ai"
+title         = "Add Fade In & Fade Out to Audio Online"
 description   = "Add a smooth fade-in and fade-out to any audio file right in your browser — pick the lengths in seconds. Nothing is uploaded, free."
 tags          = ["audio", "fade", "fade-in", "fade-out", "smooth", "intro", "outro"]
 h1            = "Fade an Audio File In and Out"

--- a/blocks/audio-loop/page/meta.toml
+++ b/blocks/audio-loop/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "audio-loop"
-title         = "Loop Audio Online — Repeat a Sound to Any Length — gizza.ai"
+title         = "Loop Audio Online — Repeat a Sound to Any Length"
 description   = "Loop any audio file right in your browser — repeat a short sound to a target duration or a number of plays, saved as MP3, WAV and more. Free."
 tags          = ["audio", "loop", "repeat", "seamless", "extend", "background", "ambience"]
 h1            = "Loop an Audio File"

--- a/blocks/audio-metadata-stripper/page/content.md
+++ b/blocks/audio-metadata-stripper/page/content.md
@@ -57,6 +57,6 @@ it.
 
 No. The standalone page runs ffmpeg in WebAssembly inside your browser tab. The
 CLI/chat tool resolves its own provided URL or attachment reference, but the page
-does not upload your file to gizza.ai.
+does not upload your file anywhere.
 
 </details>

--- a/blocks/audio-metadata-stripper/page/meta.toml
+++ b/blocks/audio-metadata-stripper/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "audio-metadata-stripper"
-title         = "Strip Audio Metadata Online — gizza.ai"
+title         = "Strip Audio Metadata Online"
 description   = "Remove ID3 tags, comments, chapters, and cover art from MP3, FLAC, OGG, M4A, WAV, and other audio files in your browser. Stream-copy audio, no upload."
 tags          = ["audio", "metadata", "id3", "privacy", "cover art", "tags", "mp3", "flac"]
 h1            = "Strip Audio Metadata"

--- a/blocks/audio-noise-reduce/page/meta.toml
+++ b/blocks/audio-noise-reduce/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "audio-noise-reduce"
-title         = "Reduce Audio Background Noise Online — gizza.ai"
+title         = "Reduce Audio Background Noise Online"
 description   = "Remove steady background hiss and hum from an audio file right in your browser — pick a strength, choose a denoiser, download. Runs locally, nothing is uploaded, free."
 tags          = ["audio", "noise", "denoise", "hiss", "hum", "background-noise", "cleanup", "afftdn"]
 h1            = "Reduce Audio Background Noise"

--- a/blocks/audio-normalize/page/meta.toml
+++ b/blocks/audio-normalize/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "audio-normalize"
-title         = "Normalize Audio Loudness Online — gizza.ai"
+title         = "Normalize Audio Loudness Online"
 description   = "Level any audio file to a standard loudness (LUFS) right in your browser — -14 for Spotify/YouTube, -16 for podcasts. Runs locally, nothing is uploaded, free."
 tags          = ["audio", "normalize", "loudness", "lufs", "volume", "level", "podcast", "spotify"]
 h1            = "Normalize Audio Loudness"

--- a/blocks/audio-pitch-shift/page/meta.toml
+++ b/blocks/audio-pitch-shift/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "audio-pitch-shift"
-title         = "Change Audio Pitch Online — gizza.ai"
+title         = "Change Audio Pitch Online"
 description   = "Free online pitch changer — shift any audio up or down by semitones without changing its speed. Transpose songs, fix tuning, deepen voices in your browser."
 tags          = ["audio", "pitch", "semitones", "transpose", "key", "shift", "changer", "voice", "chipmunk", "432 hz", "karaoke", "cents"]
 h1            = "Change Audio Pitch"

--- a/blocks/audio-silence-remove/page/meta.toml
+++ b/blocks/audio-silence-remove/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "audio-silence-remove"
-title         = "Remove Silence from Audio Online — gizza.ai"
+title         = "Remove Silence from Audio Online"
 description   = "Strip dead air and long pauses out of any recording right in your browser — set a silence threshold and minimum gap. Runs locally, nothing is uploaded, free."
 tags          = ["audio", "silence", "remove", "dead air", "podcast", "trim", "pauses", "gaps"]
 h1            = "Remove Silence from Audio"

--- a/blocks/audio-to-mono/page/meta.toml
+++ b/blocks/audio-to-mono/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "audio-to-mono"
-title         = "Convert Stereo to Mono Online — gizza.ai"
+title         = "Convert Stereo to Mono Online"
 description   = "Downmix any stereo or surround audio file to mono right in your browser — blend all channels or keep just the left/right side. Nothing is uploaded, free."
 tags          = ["audio", "mono", "stereo", "downmix", "channel", "convert", "left", "right"]
 h1            = "Convert Audio to Mono"

--- a/blocks/audio-volume-adjust/page/meta.toml
+++ b/blocks/audio-volume-adjust/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "audio-volume-adjust"
-title         = "Change Audio Volume Online — gizza.ai"
+title         = "Change Audio Volume Online"
 description   = "Boost or cut any audio file's volume right in your browser — by decibels or a factor, with a clipping-safe peak limiter. Nothing is uploaded, free."
 tags          = ["audio", "volume", "boost", "louder", "gain", "db", "quieter", "amplify"]
 h1            = "Change Audio Volume"

--- a/blocks/audio-waveform-video/page/meta.toml
+++ b/blocks/audio-waveform-video/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "audio-waveform-video"
-title         = "Audio Waveform Video Generator — gizza.ai"
+title         = "Audio Waveform Video Generator"
 description   = "Turn audio into an animated waveform MP4 in your browser. Pick mirror, bars or wave styles, colors, gradient, size and fps. Nothing uploaded."
 tags          = ["audio", "waveform", "video", "visualizer", "audiogram", "soundwave", "mp4", "music", "podcast", "mirror", "gradient", "social"]
 h1            = "Audio Waveform Video Generator"

--- a/blocks/avro-to-json/page/meta.toml
+++ b/blocks/avro-to-json/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "avro-to-json"
-title         = "Avro to JSON — Decode Apache Avro (.avro / OCF) to JSON | gizza.ai"
+title         = "Avro to JSON — Decode Apache Avro (.avro / OCF) to JSON"
 description   = "Decode Apache Avro Object Container Files (.avro / OCF) to JSON, NDJSON, or the embedded schema — no .avsc needed, free and private in your browser."
 tags          = ["avro", "avro to json", "apache avro", "avro decoder", "ocf", "avro container file", "deserialize avro", "avro viewer"]
 h1            = "Avro to JSON Converter"

--- a/blocks/base32-codec/page/meta.toml
+++ b/blocks/base32-codec/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "base32-codec"
-title         = "Base32 Encoder & Decoder (RFC 4648) — gizza.ai"
+title         = "Base32 Encoder & Decoder (RFC 4648)"
 description   = "Free Base32 encoder and decoder in your browser — RFC 4648, base32hex, Crockford and z-base-32 variants, hex byte I/O, optional padding. Private, no sign-up."
 tags          = ["base32", "base32 encode", "base32 decode", "rfc 4648", "base32hex", "crockford base32", "z-base-32", "encoder", "decoder", "hex"]
 h1            = "Base32 Encoder / Decoder"

--- a/blocks/base58-codec/page/meta.toml
+++ b/blocks/base58-codec/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "base58-codec"
-title         = "Base58 Encoder & Decoder (Bitcoin / IPFS) — gizza.ai"
+title         = "Base58 Encoder & Decoder (Bitcoin / IPFS)"
 description   = "Encode text or bytes to Base58 and decode Base58 back in your browser — Bitcoin/IPFS, Ripple (XRP) and Flickr alphabets, hex I/O. Free, private, no sign-up."
 tags          = ["base58", "base58 encode", "base58 decode", "bitcoin base58", "ipfs base58", "ripple base58", "xrp", "flickr base58", "encoder", "decoder", "hex"]
 h1            = "Base58 Encoder / Decoder"

--- a/blocks/base62-codec/page/meta.toml
+++ b/blocks/base62-codec/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "base62-codec"
-title         = "Base62 Encoder & Decoder (Short IDs / URL Slugs) — gizza.ai"
+title         = "Base62 Encoder & Decoder (Short IDs / URL Slugs)"
 description   = "Encode text, hex bytes, or numbers to Base62 (0-9A-Za-z) and decode back — URL-safe, no padding, arbitrary-precision numbers. Free, private, in your browser."
 tags          = ["base62", "base62 encode", "base62 decode", "base62 encoder", "base62 decoder", "short id", "url slug", "number to base62", "base62 converter", "hex", "encoder", "decoder"]
 h1            = "Base62 Encoder / Decoder"

--- a/blocks/base85-codec/page/meta.toml
+++ b/blocks/base85-codec/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "base85-codec"
-title         = "Base85 Encoder & Decoder (Ascii85, Z85, RFC 1924) — gizza.ai"
+title         = "Base85 Encoder & Decoder (Ascii85, Z85, RFC 1924)"
 description   = "Encode text or hex bytes to Base85 and decode Base85 back. Supports Ascii85, ZeroMQ Z85, and RFC 1924 variants with optional Adobe framing. Free, private, browser-local."
 tags          = ["base85", "ascii85", "z85", "rfc1924", "base85 encoder", "base85 decoder", "adobe ascii85", "zeromq z85", "binary encoder", "url safe"]
 h1            = "Base85 Encoder / Decoder"

--- a/blocks/bcrypt-hash/page/meta.toml
+++ b/blocks/bcrypt-hash/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "bcrypt-hash"
-title         = "Bcrypt Hash — bcrypt password hashing & verify — gizza.ai"
+title         = "Bcrypt Hash — bcrypt password hashing & verify"
 description   = "Hash a password with bcrypt at a chosen cost and get a $2b$ hash string, or verify a password against an existing bcrypt hash — in your browser. Nothing is uploaded."
 tags          = ["bcrypt", "password hash", "bcrypt generator", "bcrypt verify", "password hashing", "$2b$"]
 h1            = "Bcrypt hash"

--- a/blocks/bech32-codec/page/meta.toml
+++ b/blocks/bech32-codec/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "bech32-codec"
-title         = "Bech32 & Bech32m Encoder / Decoder (BIP 173 / BIP 350) — gizza.ai"
+title         = "Bech32 & Bech32m Encoder / Decoder (BIP 173 / BIP 350)"
 description   = "Encode and decode checksummed Bech32 and Bech32m strings (HRP + data) as used by SegWit, Taproot, Lightning and Nostr. Free, private, browser-local."
 tags          = ["bech32", "bech32m", "bech32 encoder", "bech32 decoder", "bip173", "bip350", "segwit address", "taproot", "lightning invoice", "nostr npub"]
 h1            = "Bech32 / Bech32m Encoder & Decoder"

--- a/blocks/bencode-decoder/page/meta.toml
+++ b/blocks/bencode-decoder/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "bencode-decoder"
-title         = "Bencode Decoder — bencode ⇄ JSON converter — gizza.ai"
+title         = "Bencode Decoder — bencode ⇄ JSON converter"
 description   = "Decode bencode (the BitTorrent / .torrent serialization format) into readable JSON, and re-encode JSON back into canonical bencode — in your browser. Nothing is uploaded."
 tags          = ["bencode", "bencode decoder", "bencode to json", "torrent", "torrent decoder", "bencode encoder", "bittorrent"]
 h1            = "Bencode decoder"

--- a/blocks/bibtex-format/page/meta.toml
+++ b/blocks/bibtex-format/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "bibtex-format"
-title         = "BibTeX Formatter & Validator — gizza.ai"
+title         = "BibTeX Formatter & Validator"
 description   = "Free BibTeX formatter and validator — pretty-print, sort and align .bib bibliography entries in your browser. Consistent indentation, no sign-up, no upload."
 tags          = ["bibtex", "bibtex formatter", "bibtex validator", "bib file", "bibliography", "latex", "citation", "sort bibtex", "pretty print"]
 h1            = "BibTeX Formatter & Validator"

--- a/blocks/binary-codec/page/meta.toml
+++ b/blocks/binary-codec/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "binary-codec"
-title         = "Binary Encoder & Decoder — Text to Binary & Binary to Text — gizza.ai"
+title         = "Binary Encoder & Decoder — Text to Binary & Binary to Text"
 description   = "Convert text to binary and decode binary back to text instantly — byte delimiters, 0b prefix, hex byte view. Free, private, runs entirely in your browser."
 tags          = ["binary", "binary encode", "binary decode", "text to binary", "binary to text", "binary translator", "encoder", "decoder", "binary converter", "bits"]
 h1            = "Binary Encoder / Decoder"

--- a/blocks/bip39-mnemonic-generator/page/meta.toml
+++ b/blocks/bip39-mnemonic-generator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "bip39-mnemonic-generator"
-title         = "BIP39 Mnemonic Seed Phrase Generator — gizza.ai"
+title         = "BIP39 Mnemonic Seed Phrase Generator"
 description   = "Generate a BIP39 mnemonic seed phrase (12–24 words) with checksum and derived 512-bit seed, entirely in your browser. Optional passphrase. Free and private."
 tags          = ["bip39", "mnemonic", "seed phrase", "recovery phrase", "crypto wallet", "bitcoin", "hd wallet", "bip32", "bip44", "entropy"]
 h1            = "BIP39 Mnemonic Seed Phrase Generator"

--- a/blocks/bip39-seed-derive/page/meta.toml
+++ b/blocks/bip39-seed-derive/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "bip39-seed-derive"
-title         = "BIP39 Seed Derive — Mnemonic to 512-bit Seed — gizza.ai"
+title         = "BIP39 Seed Derive — Mnemonic to 512-bit Seed"
 description   = "Derive the 512-bit BIP39 seed from an existing mnemonic recovery phrase and optional passphrase, in your browser. Validates the wordlist and checksum. Free and private."
 tags          = ["bip39", "seed derive", "mnemonic to seed", "recovery phrase", "bip39 seed", "crypto wallet", "bitcoin", "hd wallet", "bip32", "bip44"]
 h1            = "BIP39 Seed Derivation"

--- a/blocks/bitwise-calculator/page/meta.toml
+++ b/blocks/bitwise-calculator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "bitwise-calculator"
-title         = "Bitwise Calculator — AND, OR, XOR, NOT, Shifts, Rotates & Popcount — gizza.ai"
+title         = "Bitwise Calculator — AND, OR, XOR, NOT, Shifts, Rotates & Popcount"
 description   = "Bitwise calculator: AND, OR, XOR, NOT, shifts, rotates and popcount on 8–64-bit integers in binary, hex, octal or decimal. Free, private, in your browser."
 tags          = ["bitwise calculator", "bitwise and", "bitwise or", "xor calculator", "bitwise not", "bit shift calculator", "rotate bits", "popcount", "set bits", "twos complement", "binary calculator", "hex calculator", "bitmask"]
 h1            = "Bitwise Calculator"

--- a/blocks/blowfish-cipher/page/meta.toml
+++ b/blocks/blowfish-cipher/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "blowfish-cipher"
-title         = "Blowfish Cipher — Encrypt/decrypt with Blowfish (ECB/CBC) — gizza.ai"
+title         = "Blowfish Cipher — Encrypt/decrypt with Blowfish (ECB/CBC)"
 description   = "Encrypt or decrypt data with the Blowfish cipher in ECB or CBC mode, with hex/base64 I/O — in your browser. Variable 4–56 byte key. Nothing is uploaded."
 tags          = ["blowfish", "blowfish encrypt", "blowfish decrypt", "block cipher", "ecb", "cbc"]
 h1            = "Blowfish cipher"

--- a/blocks/bollinger-bands/page/meta.toml
+++ b/blocks/bollinger-bands/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "bollinger-bands"
-title         = "Bollinger Bands Calculator — moving average ± standard deviations — gizza.ai"
+title         = "Bollinger Bands Calculator — moving average ± standard deviations"
 description   = "Compute Bollinger Bands (SMA plus/minus standard deviations) for a price series, plus %B and bandwidth, in your browser. Free, private, no upload."
 tags          = ["bollinger bands", "technical analysis", "moving average", "standard deviation", "percent b", "bandwidth", "trading indicator"]
 h1            = "Bollinger Bands calculator"

--- a/blocks/byte-drop/page/meta.toml
+++ b/blocks/byte-drop/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "byte-drop"
-title         = "Byte Drop — Remove a Byte Range from Text, Hex or Base64 — gizza.ai"
+title         = "Byte Drop — Remove a Byte Range from Text, Hex or Base64"
 description   = "Delete a range of bytes from text, hex, or Base64 by start offset and length, and view the remainder in any format. Free, private, runs in your browser."
 tags          = ["byte drop", "remove bytes", "delete byte range", "byte editor", "hex", "base64", "trim bytes", "byte splice", "binary editor", "offset length"]
 h1            = "Byte Drop — Remove a Byte Range"

--- a/blocks/byte-take/page/meta.toml
+++ b/blocks/byte-take/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "byte-take"
-title         = "Byte Take — Extract a Byte Range from Text, Hex or Base64 — gizza.ai"
+title         = "Byte Take — Extract a Byte Range from Text, Hex or Base64"
 description   = "Extract a byte range from text, hex, or Base64 by start offset and length, output as text, hex, or Base64 — free byte slice tool, runs in your browser."
 tags          = ["byte take", "extract bytes", "byte slice", "byte range", "byte substring", "hex", "base64", "slice bytes", "binary slice", "offset length"]
 h1            = "Byte Take — Extract a Byte Range"

--- a/blocks/calculator/page/meta.toml
+++ b/blocks/calculator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "calculator"
-title         = "Free Online Calculator — gizza.ai"
+title         = "Free Online Calculator"
 description   = "Evaluate any arithmetic expression instantly in your browser. Supports +, −, ×, ÷, parentheses and functions. No sign-up, runs offline."
 tags          = ["math", "maths", "arithmetic", "sum", "percentage"]
 h1            = "Free Online Calculator"

--- a/blocks/cartesian-product/page/meta.toml
+++ b/blocks/cartesian-product/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "cartesian-product"
-title         = "Cartesian Product Generator — Every Combination of 2–4 Lists — gizza.ai"
+title         = "Cartesian Product Generator — Every Combination of 2–4 Lists"
 description   = "Generate every combination across 2-4 lists (sizes x colors x materials) — or just count them. Paste spreadsheet cells, pick any separator, output lines, CSV, JSON."
 tags          = ["cartesian product", "combination generator", "combine lists", "all combinations", "product variants generator", "seo keyword combiner", "cross join lists", "tuple generator", "word combiner", "keyword mixer", "merge word lists", "combination counter"]
 h1            = "Cartesian Product Generator"

--- a/blocks/censor-text/page/meta.toml
+++ b/blocks/censor-text/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "censor-text"
-title         = "Censor Text — Redact Words Online — gizza.ai"
+title         = "Censor Text — Redact Words Online"
 description   = "Redact a list of words (or common profanity) in any text by masking them — case-insensitive, whole-word or substring. Runs in your browser, nothing is uploaded, free."
 tags          = ["censor text", "redact words", "profanity filter", "mask words", "text redaction"]
 h1            = "Censor Text"

--- a/blocks/chacha20-cipher/page/meta.toml
+++ b/blocks/chacha20-cipher/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "chacha20-cipher"
-title         = "ChaCha20 Cipher — Encrypt/decrypt with ChaCha20 & ChaCha20-Poly1305 — gizza.ai"
+title         = "ChaCha20 Cipher — Encrypt/decrypt with ChaCha20 & ChaCha20-Poly1305"
 description   = "Encrypt or decrypt text with ChaCha20 or ChaCha20-Poly1305 AEAD (RFC 8439) in your browser — 32-byte key, 12-byte nonce, hex/base64 I/O. Nothing is uploaded."
 tags          = ["chacha20", "chacha20-poly1305", "chacha20 encrypt", "chacha20 decrypt", "aead", "rfc 8439", "stream cipher", "poly1305"]
 h1            = "ChaCha20 cipher"

--- a/blocks/change-case/page/meta.toml
+++ b/blocks/change-case/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "change-case"
-title         = "Change Case — Convert Text to UPPER, lower, Title, camelCase & more — gizza.ai"
+title         = "Change Case — Convert Text to UPPER, lower, Title, camelCase & more"
 description   = "Free online case converter — switch text between UPPERCASE, lowercase, Title Case, camelCase, PascalCase, snake_case, kebab-case and more, right in your browser."
 tags          = ["change case", "uppercase", "lowercase", "title case", "sentence case", "swap case", "camelcase", "snake case", "kebab case", "constant case", "pascalcase", "text case converter"]
 h1            = "Change Case"

--- a/blocks/change-speed/page/meta.toml
+++ b/blocks/change-speed/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "change-speed"
-title         = "Change Video Speed Online — gizza.ai"
+title         = "Change Video Speed Online"
 description   = "Speed up or slow down a video right in your browser, keeping audio in sync — pick a speed factor (0.25x–4x). Re-encodes locally with ffmpeg, nothing is uploaded, free."
 tags          = ["video speed", "slow motion", "fast forward", "speed up video", "slow down video", "ffmpeg"]
 h1            = "Change Video Speed"

--- a/blocks/charset-transcode/page/meta.toml
+++ b/blocks/charset-transcode/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "charset-transcode"
-title         = "Mojibake Fixer & Charset Transcoder — gizza.ai"
+title         = "Mojibake Fixer & Charset Transcoder"
 description   = "Fix mojibake and re-decode legacy charsets (Windows-1252, Latin-1, Shift_JIS, GBK, Big5, KOI8-R) into clean UTF-8 — free, private, in your browser."
 tags          = ["mojibake", "charset", "encoding", "utf-8", "windows-1252", "iso-8859-1", "latin1", "shift_jis", "transcode", "fix garbled text"]
 h1            = "Mojibake Fixer / Charset Transcoder"

--- a/blocks/chi-square-test/page/meta.toml
+++ b/blocks/chi-square-test/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "chi-square-test"
-title         = "Chi-Square Test — goodness-of-fit & contingency table — gizza.ai"
+title         = "Chi-Square Test — goodness-of-fit & contingency table"
 description   = "Run Pearson's chi-square test online: goodness-of-fit or contingency-table independence with statistic, df, p-value and Cramér's V. Free, in-browser, no upload."
 tags          = ["chi-square test", "chi square calculator", "goodness of fit", "contingency table", "test of independence", "p-value", "cramers v"]
 h1            = "Chi-square test"

--- a/blocks/cidr-calculator/page/meta.toml
+++ b/blocks/cidr-calculator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "cidr-calculator"
-title         = "CIDR Calculator — Subnet, Netmask, Broadcast & Host Range (IPv4 & IPv6) | gizza.ai"
+title         = "CIDR Calculator — Subnet, Netmask, Broadcast & Host Range (IPv4 & IPv6)"
 description   = "CIDR calculator: get network address, broadcast, netmask, wildcard, usable host range and host count for any IPv4 or IPv6 prefix. Free, private, in-browser."
 tags          = ["cidr calculator", "subnet calculator", "ip subnet calculator", "netmask calculator", "broadcast address", "wildcard mask", "host range", "ipv4", "ipv6", "cidr to netmask"]
 h1            = "CIDR Calculator"

--- a/blocks/ciphersaber2/page/meta.toml
+++ b/blocks/ciphersaber2/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "ciphersaber2"
-title         = "CipherSaber-2 — Encrypt/decrypt with CipherSaber (RC4 + random IV) — gizza.ai"
+title         = "CipherSaber-2 — Encrypt/decrypt with CipherSaber (RC4 + random IV)"
 description   = "Encrypt and decrypt CipherSaber-2 (RC4 with a 10-byte IV and repeated key setup) in your browser — hex or base64 output. Free, private, nothing uploaded."
 tags          = ["ciphersaber", "ciphersaber-2", "ciphersaber2", "rc4", "arcfour", "stream cipher", "cipher", "encrypt", "decrypt"]
 h1            = "CipherSaber-2 cipher"

--- a/blocks/citation-generator/page/meta.toml
+++ b/blocks/citation-generator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "citation-generator"
-title         = "Citation Generator — APA, MLA, Chicago & Harvard — gizza.ai"
+title         = "Citation Generator — APA, MLA, Chicago & Harvard"
 description   = "Free APA 7, MLA 9, Chicago and Harvard citation generator — format author, title, year, journal and URL into a correct reference right in your browser."
 tags          = ["citation generator", "apa citation", "mla citation", "chicago citation", "harvard citation", "reference generator", "bibliography", "works cited", "cite a source"]
 h1            = "Citation Generator"

--- a/blocks/classical-cipher-tool/page/meta.toml
+++ b/blocks/classical-cipher-tool/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "classical-cipher-tool"
-title         = "Classical Cipher Tool — Caesar, Vigenère, Atbash & Rail-Fence — gizza.ai"
+title         = "Classical Cipher Tool — Caesar, Vigenère, Atbash & Rail-Fence"
 description   = "Encrypt and decrypt Caesar, Vigenère, Atbash, and rail-fence ciphers in your browser, with a Caesar brute-force listing all 26 shifts. Free and private."
 tags          = ["caesar cipher", "vigenere cipher", "atbash", "rail fence cipher", "classical cipher", "cipher encrypt decrypt", "caesar brute force", "rot", "cryptogram"]
 h1            = "Classical Cipher Tool"

--- a/blocks/clock/page/meta.toml
+++ b/blocks/clock/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "clock"
-title         = "Current UTC Time — gizza.ai"
+title         = "Current UTC Time"
 description   = "See the current UTC date and time, updating live in your browser. No sign-up, runs offline."
 tags          = ["time", "timezone", "utc", "date"]
 h1            = "Current UTC Time"

--- a/blocks/cmac-generate/page/meta.toml
+++ b/blocks/cmac-generate/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "cmac-generate"
-title         = "AES-CMAC Generator — AES-128/192/256 CMAC (RFC 4493) | gizza.ai"
+title         = "AES-CMAC Generator — AES-128/192/256 CMAC (RFC 4493)"
 description   = "Generate an AES-CMAC (NIST SP 800-38B / RFC 4493) of any message and key in your browser — AES-128/192/256 by key length, hex or base64 output. Free and private."
 tags          = ["cmac", "aes-cmac", "aes", "aes-128", "aes-256", "mac", "block-cipher-mac", "message-authentication", "rfc-4493", "nist-sp-800-38b", "hex", "base64", "cryptography"]
 h1            = "AES-CMAC Generator"

--- a/blocks/color-contrast-checker/page/meta.toml
+++ b/blocks/color-contrast-checker/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "color-contrast-checker"
-title         = "Color Contrast Checker (WCAG AA / AAA) — gizza.ai"
+title         = "Color Contrast Checker (WCAG AA / AAA)"
 description   = "WCAG colour contrast checker — get the contrast ratio and AA / AAA pass-fail for any text and background colour, plus an accessible suggestion. Free, in-browser."
 tags          = ["color contrast checker", "wcag contrast", "contrast ratio", "accessibility", "aa", "aaa", "a11y", "hex", "rgb", "hsl", "accessible color"]
 h1            = "Color Contrast Checker"

--- a/blocks/color-format-convert/page/meta.toml
+++ b/blocks/color-format-convert/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "color-format-convert"
-title         = "Color Converter — HEX, RGB, HSL, HSV, CMYK — gizza.ai"
+title         = "Color Converter — HEX, RGB, HSL, HSV, CMYK"
 description   = "Convert a color between HEX, RGB(A), HSL, HSV and CMYK, in your browser. Paste any notation and get them all. Nothing is uploaded."
 tags          = ["color converter", "hex to rgb", "rgb to hex", "hsl", "cmyk", "color format"]
 h1            = "Color converter"

--- a/blocks/color-palette-generator/page/meta.toml
+++ b/blocks/color-palette-generator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "color-palette-generator"
-title         = "Color Palette Generator — Harmonious Schemes from a Base Color — gizza.ai"
+title         = "Color Palette Generator — Harmonious Schemes from a Base Color"
 description   = "Generate a color palette from any base color — complementary, analogous, triadic, tetradic, monochromatic, shades and tints. Free, runs in your browser."
 tags          = ["color palette generator", "color scheme", "complementary colors", "analogous", "triadic", "monochromatic", "color theory"]
 h1            = "Color palette generator"

--- a/blocks/color-shades-generator/page/meta.toml
+++ b/blocks/color-shades-generator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "color-shades-generator"
-title         = "Color Shades Generator — Tints, Shades, Tones & Tailwind 50-950 Scale — gizza.ai"
+title         = "Color Shades Generator — Tints, Shades, Tones & Tailwind 50-950 Scale"
 description   = "Generate a ramp of tints, shades and tones from any base color, including a Tailwind-style 50-900 scale, in HEX, RGB and HSL. Runs in your browser, nothing is uploaded."
 tags          = ["color shades generator", "tints and shades", "tailwind color scale", "color ramp", "color tints", "color tones", "50 to 900 colors"]
 h1            = "Color shades generator"

--- a/blocks/column-math/page/meta.toml
+++ b/blocks/column-math/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "column-math"
-title         = "Column Math — Add, Subtract, Multiply & Divide Two Number Lists | gizza.ai"
+title         = "Column Math — Add, Subtract, Multiply & Divide Two Number Lists"
 description   = "Element-wise math on two columns of numbers — add, subtract, multiply, or divide two lists row by row in your browser. Free, private, no sign-up."
 tags          = ["column math", "element-wise", "add columns", "subtract columns", "multiply columns", "divide columns", "vector math", "number list calculator", "spreadsheet math", "batch arithmetic"]
 h1            = "Column Math"

--- a/blocks/contact-info-extractor/page/meta.toml
+++ b/blocks/contact-info-extractor/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "contact-info-extractor"
-title         = "Contact Info Extractor — Pull Emails & Phone Numbers from Text — gizza.ai"
+title         = "Contact Info Extractor — Pull Emails & Phone Numbers from Text"
 description   = "Extract emails and phone numbers from pasted text. Deduplicated, counted, sorted, and private in your browser with no upload."
 tags          = ["contact extractor", "email extractor", "phone number extractor", "extract emails", "extract phone numbers", "text scraper", "deduplicate contacts", "contact list"]
 h1            = "Extract Emails & Phone Numbers from Text"

--- a/blocks/context-trimmer/page/meta.toml
+++ b/blocks/context-trimmer/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "context-trimmer"
-title         = "Context Trimmer — Fit Text to a Token Budget | gizza.ai"
+title         = "Context Trimmer — Fit Text to a Token Budget"
 description   = "Trim text to an approximate token budget for LLM prompts, keeping the head, tail, middle, or both ends. Runs locally in your browser."
 tags          = ["llm", "prompt", "tokens", "text", "context"]
 h1            = "Context Trimmer"

--- a/blocks/count-line-frequency/page/meta.toml
+++ b/blocks/count-line-frequency/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "count-line-frequency"
-title         = "Count Line Frequency — Rank lines by occurrence — gizza.ai"
+title         = "Count Line Frequency — Rank lines by occurrence"
 description   = "Count how often each line or value occurs and rank them most to least frequent, in your browser. Like sort | uniq -c | sort -rn. Nothing is uploaded."
 tags          = ["count lines", "uniq -c", "frequency count", "tally", "duplicate counter", "rank lines"]
 h1            = "Count line frequency"

--- a/blocks/cron-next-runs/page/meta.toml
+++ b/blocks/cron-next-runs/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "cron-next-runs"
-title         = "Cron Expression Next Run Times — Crontab Schedule Preview (UTC) | gizza.ai"
+title         = "Cron Expression Next Run Times — Crontab Schedule Preview (UTC)"
 description   = "Cron expression parser and next-run calculator — see upcoming run times in UTC with plain-English schedules, free and entirely in your browser."
 tags          = ["cron expression", "crontab", "next run time", "cron schedule", "cron preview", "crontab tester", "cron next runs", "cron parser", "cron calculator"]
 h1            = "Cron Next Run Times"

--- a/blocks/css-autoprefixer/page/meta.toml
+++ b/blocks/css-autoprefixer/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "css-autoprefixer"
-title         = "CSS Autoprefixer — Add Vendor Prefixes Online — gizza.ai"
+title         = "CSS Autoprefixer — Add Vendor Prefixes Online"
 description   = "Free online CSS autoprefixer — paste CSS and add the -webkit-, -moz-, -ms-, -o- vendor prefixes browsers still need. Runs entirely in your browser."
 tags          = ["css autoprefixer", "vendor prefixes", "-webkit-", "-moz-", "-ms-", "browser compatibility", "user-select", "flexbox prefixes", "position sticky", "css tool"]
 h1            = "CSS Autoprefixer"

--- a/blocks/css-gradient-generator/page/meta.toml
+++ b/blocks/css-gradient-generator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "css-gradient-generator"
-title         = "CSS Gradient Generator — gizza.ai"
+title         = "CSS Gradient Generator"
 description   = "Generate CSS linear, radial and conic gradients — pick type, angle and color stops, then copy a ready-to-paste background-image. Free, in-browser."
 tags          = ["css gradient", "gradient generator", "linear gradient", "radial gradient", "conic gradient", "background-image", "color stops", "css generator", "web design"]
 h1            = "CSS Gradient Generator"

--- a/blocks/csv-find-incomplete-rows/page/meta.toml
+++ b/blocks/csv-find-incomplete-rows/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "csv-find-incomplete-rows"
-title         = "Find Incomplete CSV Rows — Flag rows with wrong field count or blank cells — gizza.ai"
+title         = "Find Incomplete CSV Rows — Flag rows with wrong field count or blank cells"
 description   = "Scan a CSV for malformed rows: too few or too many fields, or blank cells in required columns. Runs in your browser. Free, private, no upload."
 tags          = ["csv validation", "incomplete csv rows", "malformed csv", "csv field count", "csv missing values"]
 h1            = "Find incomplete CSV rows"

--- a/blocks/csv-json-convert/page/meta.toml
+++ b/blocks/csv-json-convert/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "csv-json-convert"
-title         = "CSV to JSON & JSON to CSV Converter — gizza.ai"
+title         = "CSV to JSON & JSON to CSV Converter"
 description   = "Convert CSV to JSON or JSON to CSV in your browser — auto-detects direction, infers types, handles quoted fields and custom delimiters. Free, no upload."
 tags          = ["csv to json", "json to csv", "csv converter", "json converter", "csv parser", "tabular data", "tsv", "data conversion"]
 h1            = "CSV ⇄ JSON Converter"

--- a/blocks/csv-pii-redactor/page/meta.toml
+++ b/blocks/csv-pii-redactor/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "csv-pii-redactor"
-title         = "CSV PII Redactor — Mask, Salted-Hash & Redact Columns — gizza.ai"
+title         = "CSV PII Redactor — Mask, Salted-Hash & Redact Columns"
 description   = "Mask, salted-hash, or redact the values in chosen CSV columns for safe sharing — pick columns by name or index, in your browser. Free, private, no upload."
 tags          = ["csv pii redactor", "anonymize csv columns", "mask csv", "hash csv column", "salted hash pii", "redact csv", "data masking", "csv anonymizer"]
 h1            = "CSV PII redactor"

--- a/blocks/csv-reorder-columns/page/meta.toml
+++ b/blocks/csv-reorder-columns/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "csv-reorder-columns"
-title         = "CSV Reorder Columns — Reorder, swap & drop columns — gizza.ai"
+title         = "CSV Reorder Columns — Reorder, swap & drop columns"
 description   = "Reorder, swap, or drop CSV columns by name or index to a target order, in your browser. Free, private, no upload."
 tags          = ["csv reorder columns", "rearrange csv", "drop csv columns", "swap columns", "select columns"]
 h1            = "CSV reorder columns"

--- a/blocks/csv-stats/page/meta.toml
+++ b/blocks/csv-stats/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "csv-stats"
-title         = "CSV Stats — Per-column summary statistics — gizza.ai"
+title         = "CSV Stats — Per-column summary statistics"
 description   = "Compute per-column count, distinct, min, max, mean and sum for a CSV, in your browser. Free, private, no upload."
 tags          = ["csv stats", "csv summary", "column statistics", "csv describe", "csv mean min max"]
 h1            = "CSV stats"

--- a/blocks/csv-to-table/page/meta.toml
+++ b/blocks/csv-to-table/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "csv-to-table"
-title         = "CSV to Table — Markdown & HTML table generator — gizza.ai"
+title         = "CSV to Table — Markdown & HTML table generator"
 description   = "Convert CSV data into a Markdown or HTML table, in your browser. Free, private, no upload."
 tags          = ["csv to markdown", "csv to html table", "markdown table", "html table generator", "csv table"]
 h1            = "CSV to table"

--- a/blocks/csv-to-vcard/page/meta.toml
+++ b/blocks/csv-to-vcard/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "csv-to-vcard"
-title         = "CSV to vCard Converter — Make .VCF Contact Files — gizza.ai"
+title         = "CSV to vCard Converter — Make .VCF Contact Files"
 description   = "Convert CSV or JSON contact lists into a single .vcf vCard file for iPhone, Android, Google Contacts, Outlook, and CRM imports."
 tags          = ["csv to vcard", "csv to vcf", "contacts converter", "vcard generator", "vcf file", "google contacts", "outlook contacts", "iphone contacts", "android contacts", "json to vcard"]
 h1            = "CSV to vCard Converter"

--- a/blocks/csv-to-xlsx/page/meta.toml
+++ b/blocks/csv-to-xlsx/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "csv-to-xlsx"
-title         = "CSV to Excel (XLSX) Converter — gizza.ai"
+title         = "CSV to Excel (XLSX) Converter"
 description   = "Convert CSV, TSV or JSON into a real Excel .xlsx workbook — typed number/boolean columns, a bold frozen header, auto-fit widths. In-browser, nothing uploaded."
 tags          = ["csv to xlsx", "csv to excel", "json to excel", "xlsx converter", "spreadsheet", "tsv to excel"]
 h1            = "CSV to Excel (.xlsx)"

--- a/blocks/csv-to-xml/page/meta.toml
+++ b/blocks/csv-to-xml/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "csv-to-xml"
-title         = "CSV to XML — Convert CSV to XML records — gizza.ai"
+title         = "CSV to XML — Convert CSV to XML records"
 description   = "Convert a CSV table into XML records using the header names as element tags, in your browser. Free, private, no upload."
 tags          = ["csv to xml", "csv xml converter", "convert csv", "xml records", "tabular to xml"]
 h1            = "CSV to XML"

--- a/blocks/csv-to-yaml/page/meta.toml
+++ b/blocks/csv-to-yaml/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "csv-to-yaml"
-title         = "CSV to YAML — Convert CSV to a YAML list — gizza.ai"
+title         = "CSV to YAML — Convert CSV to a YAML list"
 description   = "Convert a CSV table into a YAML list of objects keyed by the header row, in your browser. Free, private, no upload."
 tags          = ["csv to yaml", "csv yaml converter", "yaml list", "tabular to yaml", "convert csv"]
 h1            = "CSV to YAML"

--- a/blocks/csv-transpose/page/meta.toml
+++ b/blocks/csv-transpose/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "csv-transpose"
-title         = "CSV Transpose — Swap rows and columns — gizza.ai"
+title         = "CSV Transpose — Swap rows and columns"
 description   = "Transpose a CSV — swap rows and columns so the header becomes the first column — in your browser. Free, private, no upload."
 tags          = ["csv transpose", "swap rows columns", "pivot csv", "rotate csv", "transpose table"]
 h1            = "CSV transpose"

--- a/blocks/cumulative-sum/page/meta.toml
+++ b/blocks/cumulative-sum/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "cumulative-sum"
-title         = "Cumulative Sum Calculator — Running Total of a List of Numbers | gizza.ai"
+title         = "Cumulative Sum Calculator — Running Total of a List of Numbers"
 description   = "Get the running total (prefix sum) of a list of numbers in your browser, with optional running average, min, and max at each step. Free, private, no sign-up."
 tags          = ["cumulative sum", "running total", "prefix sum", "running average", "running minimum", "running maximum", "number list calculator", "accumulate", "partial sums", "running balance"]
 h1            = "Cumulative Sum Calculator"

--- a/blocks/curl-command-parser/page/meta.toml
+++ b/blocks/curl-command-parser/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "curl-command-parser"
-title         = "cURL Command Parser — decode a curl command into a structured request — gizza.ai"
+title         = "cURL Command Parser — decode a curl command into a structured request"
 description   = "Paste a curl command to see its method, URL, query params, headers, body, auth, cookies and flags — or rebuild clean curl. Browser-only."
 tags          = ["curl command parser", "parse curl command", "curl parser", "decode curl", "curl to structured request", "curl headers parser", "curl command reader", "rebuild curl command"]
 h1            = "cURL Command Parser"

--- a/blocks/data-format-converter/page/meta.toml
+++ b/blocks/data-format-converter/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "data-format-converter"
-title         = "Data Format Converter — CSV, TSV, JSON & NDJSON — gizza.ai"
+title         = "Data Format Converter — CSV, TSV, JSON & NDJSON"
 description   = "Convert data between CSV, TSV, JSON, and NDJSON (JSONL) in any direction — auto-detects the source, infers types, unions keys. Free, in-browser, no upload."
 tags          = ["data format converter", "csv to json", "json to csv", "csv to ndjson", "json to ndjson", "ndjson to csv", "jsonl converter", "tsv to json", "json to jsonl", "ndjson converter", "tabular data converter"]
 h1            = "Data Format Converter"

--- a/blocks/data-uri-decode/page/meta.toml
+++ b/blocks/data-uri-decode/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "data-uri-decode"
-title         = "Data URI Decoder — decode a data: URI into its MIME type & payload — gizza.ai"
+title         = "Data URI Decoder — decode a data: URI into its MIME type & payload"
 description   = "Decode a data: URI into its MIME type, charset and payload — text decoded inline, binaries with detected type and hex preview, all in your browser."
 tags          = ["data uri decoder", "data url decoder", "decode data uri", "data uri parser", "base64 data uri", "rfc 2397", "mime type", "data uri to text", "decode base64 data url"]
 h1            = "Data URI Decoder"

--- a/blocks/data-uri-encode/page/meta.toml
+++ b/blocks/data-uri-encode/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "data-uri-encode"
-title         = "Data URI Encoder — Text to data: URI — gizza.ai"
+title         = "Data URI Encoder — Text to data: URI"
 description   = "Turn text into a self-contained data: URI with a chosen MIME type and Base64 or percent encoding. No sign-up, runs offline in your browser."
 tags          = ["data-uri", "base64", "encode", "mime", "css", "svg"]
 h1            = "Data URI Encoder"

--- a/blocks/date-diff/page/meta.toml
+++ b/blocks/date-diff/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "date-diff"
-title         = "Date Difference Calculator — Days, Weeks, Months & Years Between Dates — gizza.ai"
+title         = "Date Difference Calculator — Days, Weeks, Months & Years Between Dates"
 description   = "Calculate the exact duration between two dates: years, months, days, hours, minutes and seconds, with leap years handled. Free, private, in-browser."
 tags          = ["date difference", "days between dates", "date calculator", "duration calculator", "date diff", "time between dates", "weeks between dates", "months between dates", "age in days"]
 h1            = "Date Difference Calculator"

--- a/blocks/des-cipher/page/meta.toml
+++ b/blocks/des-cipher/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "des-cipher"
-title         = "DES Cipher — Encrypt/decrypt with DES (ECB/CBC) — gizza.ai"
+title         = "DES Cipher — Encrypt/decrypt with DES (ECB/CBC)"
 description   = "Encrypt or decrypt data with single DES in ECB or CBC mode, with hex/base64 I/O — in your browser. For legacy interop. Nothing is uploaded."
 tags          = ["des", "des encrypt", "des decrypt", "legacy cipher", "ecb", "cbc"]
 h1            = "DES cipher"

--- a/blocks/descriptive-stats/page/meta.toml
+++ b/blocks/descriptive-stats/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "descriptive-stats"
-title         = "Descriptive Statistics — Mean, median, std dev, quartiles — gizza.ai"
+title         = "Descriptive Statistics — Mean, median, std dev, quartiles"
 description   = "Compute mean, median, mode, variance, standard deviation, quartiles, min and max for a list of numbers, in your browser. Free, private, no upload."
 tags          = ["descriptive statistics", "mean median mode", "standard deviation", "variance", "quartiles", "stats calculator"]
 h1            = "Descriptive statistics"

--- a/blocks/disposable-email-detector/page/meta.toml
+++ b/blocks/disposable-email-detector/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "disposable-email-detector"
-title         = "Disposable Email Detector — Check for Temporary / Throwaway Inboxes | gizza.ai"
+title         = "Disposable Email Detector — Check for Temporary / Throwaway Inboxes"
 description   = "Check if an email address or domain is a disposable or throwaway inbox (Mailinator, Guerrilla Mail, YOPmail and more) — free, private, right in your browser."
 tags          = ["disposable email detector", "temporary email checker", "throwaway email", "fake email detector", "burner email check", "mailinator", "guerrilla mail", "10 minute mail", "block disposable email"]
 h1            = "Disposable Email Detector"

--- a/blocks/dns-message-parser/page/meta.toml
+++ b/blocks/dns-message-parser/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "dns-message-parser"
-title         = "DNS Message Parser — decode a DNS query/response from hex or base64url — gizza.ai"
+title         = "DNS Message Parser — decode a DNS query/response from hex or base64url"
 description   = "Decode a DNS wire-format message from hex or base64url — header flags, RCODE, question and answer records, name decompression. Free, in your browser."
 tags          = ["dns message parser", "decode dns packet", "dns wire format", "dns over https", "dns header flags", "rcode", "dns resource records", "name compression", "edns0", "dns hex decoder"]
 h1            = "DNS Message Parser"

--- a/blocks/document-splitter/page/meta.toml
+++ b/blocks/document-splitter/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "document-splitter"
-title         = "Document Splitter — split Markdown or HTML by section — gizza.ai"
+title         = "Document Splitter — split Markdown or HTML by section"
 description   = "Split a long Markdown or HTML document into separate files, one per top-level heading. Runs entirely in your browser, no upload, no sign-up."
 tags          = ["document splitter", "split markdown", "split html", "by heading", "sections", "chunk document"]
 h1            = "Document Splitter"

--- a/blocks/dot-to-svg/page/meta.toml
+++ b/blocks/dot-to-svg/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "dot-to-svg"
-title         = "DOT to SVG — render Graphviz diagrams online — gizza.ai"
+title         = "DOT to SVG — render Graphviz diagrams online"
 description   = "Render Graphviz DOT source to a clean, scalable SVG in your browser — no Graphviz install. Directed and undirected graphs, labels, dark mode. No upload."
 tags          = ["dot to svg", "graphviz online", "dot renderer", "render graphviz", "dot diagram", "graphviz svg"]
 h1            = "DOT to SVG"

--- a/blocks/ecdsa-sign/page/meta.toml
+++ b/blocks/ecdsa-sign/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "ecdsa-sign"
-title         = "ECDSA Sign — sign a message with a P-256/P-384 key — gizza.ai"
+title         = "ECDSA Sign — sign a message with a P-256/P-384 key"
 description   = "Sign a message with an ECDSA private key (NIST P-256 or P-384) and get a DER or raw r||s signature in base64 and hex, in your browser. Nothing is uploaded."
 tags          = ["ecdsa sign", "ecdsa signature", "p256", "p384", "secp256r1", "digital signature", "rfc6979", "crypto"]
 h1            = "ECDSA sign"

--- a/blocks/ed25519-sign-verify/page/meta.toml
+++ b/blocks/ed25519-sign-verify/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "ed25519-sign-verify"
-title         = "Ed25519 Sign & Verify — sign a message or check a signature — gizza.ai"
+title         = "Ed25519 Sign & Verify — sign a message or check a signature"
 description   = "Sign a message with an Ed25519 private key, or verify a signature with the public key — hex, base64, or PEM keys, entirely in your browser."
 tags          = ["ed25519 sign", "ed25519 verify", "eddsa", "curve25519", "digital signature", "rfc8032", "verify signature", "crypto"]
 h1            = "Ed25519 sign & verify"

--- a/blocks/email-normalizer/page/meta.toml
+++ b/blocks/email-normalizer/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "email-normalizer"
-title         = "Email Normalizer — Canonicalize Email Addresses | gizza.ai"
+title         = "Email Normalizer — Canonicalize Email Addresses"
 description   = "Normalize email addresses to canonical form — strip Gmail dots and +tags, fold googlemail.com, dedupe-ready output, free and private in your browser."
 tags          = ["email normalizer", "canonical email", "gmail dots", "plus addressing", "sub-address", "email deduplication", "normalize email", "googlemail"]
 h1            = "Email Normalizer"

--- a/blocks/email-obfuscator/page/meta.toml
+++ b/blocks/email-obfuscator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "email-obfuscator"
-title         = "Email Obfuscator — Hide Your Email From Spam Bots (HTML Entities, JS, CSS) — gizza.ai"
+title         = "Email Obfuscator — Hide Your Email From Spam Bots (HTML Entities, JS, CSS)"
 description   = "Email obfuscator — encode your address as HTML entities, a JavaScript writer, CSS reversal, or a ROT13 mailto so spam bots can't harvest it. Free, in-browser."
 tags          = ["email obfuscator", "hide email from bots", "anti spam email", "email entity encoder", "mailto obfuscation", "html entity email", "scraper protection", "email harvester block", "rot13 email", "css email obfuscation"]
 h1            = "Email Obfuscator"

--- a/blocks/email-reply-cleaner/page/meta.toml
+++ b/blocks/email-reply-cleaner/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "email-reply-cleaner"
-title         = "Email Reply Cleaner — Strip Quotes, Reply Chains & Signatures | gizza.ai"
+title         = "Email Reply Cleaner — Strip Quotes, Reply Chains & Signatures"
 description   = "Paste a replied or forwarded email and get just the fresh message — quoted lines, the reply chain, and signatures removed. Toggle each pass. Runs in your browser."
 tags          = ["email", "reply", "quote", "signature", "text"]
 h1            = "Email Reply Cleaner"

--- a/blocks/email-validator/page/meta.toml
+++ b/blocks/email-validator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "email-validator"
-title         = "Email Validator — Check Email Address Syntax | gizza.ai"
+title         = "Email Validator — Check Email Address Syntax"
 description   = "Validate an email address against RFC 5321/5322 syntax in your browser — flags bad domains, illegal characters and typos like gmial.com. Free, no DNS lookup."
 tags          = ["email validator", "validate email", "email syntax check", "rfc 5322", "email checker", "verify email format", "email typo", "did you mean"]
 h1            = "Email Validator"

--- a/blocks/eml-parse/page/meta.toml
+++ b/blocks/eml-parse/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "eml-parse"
-title         = "EML Parser — read a raw .eml email message — gizza.ai"
+title         = "EML Parser — read a raw .eml email message"
 description   = "Parse a raw .eml / RFC 822 email into headers, decoded text and HTML bodies, and an attachment list — in your browser. Nothing is uploaded."
 tags          = ["eml parser", "parse email", "rfc822", "rfc5322", "mime parser", "read eml", "email headers", "attachments"]
 h1            = "EML Parser"

--- a/blocks/emoji-search/page/meta.toml
+++ b/blocks/emoji-search/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "emoji-search"
-title         = "Emoji Search — Find Emoji by Keyword or Shortcode — gizza.ai"
+title         = "Emoji Search — Find Emoji by Keyword or Shortcode"
 description   = "Search emoji by keyword, :shortcode: or category and copy the glyphs instantly — happy, love, fire, rocket and more. Free, private, runs in your browser."
 tags          = ["emoji search", "find emoji", "emoji by keyword", "emoji shortcode", "emoji finder", "emoji picker", "emoji lookup", "copy emoji"]
 h1            = "Emoji Search"

--- a/blocks/evp-derive/page/meta.toml
+++ b/blocks/evp-derive/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "evp-derive"
-title         = "EVP_BytesToKey — OpenSSL key/IV derivation from a password — gizza.ai"
+title         = "EVP_BytesToKey — OpenSSL key/IV derivation from a password"
 description   = "Reproduce OpenSSL's EVP_BytesToKey key and IV derivation from a password and salt (MD5, SHA-1, SHA-256, SHA-512) — free and entirely in your browser."
 tags          = ["evp_bytestokey", "openssl key derivation", "openssl iv", "derive key from password", "openssl enc", "md5 key derivation", "legacy kdf", "openssl decrypt"]
 h1            = "EVP_BytesToKey — OpenSSL key & IV derivation"

--- a/blocks/extract-audio-from-video/page/meta.toml
+++ b/blocks/extract-audio-from-video/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "extract-audio-from-video"
-title         = "Extract Audio from Video Online — gizza.ai"
+title         = "Extract Audio from Video Online"
 description   = "Pull the audio track out of any video as MP3 or WAV, right in your browser — pick a format and bitrate. Runs locally with ffmpeg, nothing is uploaded, free."
 tags          = ["audio", "video", "extract", "mp3", "wav", "convert", "rip", "soundtrack"]
 h1            = "Extract Audio from a Video"

--- a/blocks/extract-dates/page/meta.toml
+++ b/blocks/extract-dates/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "extract-dates"
-title         = "Extract Dates — find & normalize dates in text — gizza.ai"
+title         = "Extract Dates — find & normalize dates in text"
 description   = "Scan any text for dates and times and list them normalized to ISO 8601 — in your browser. Handles ISO, numeric, month-name, and clock formats. No upload."
 tags          = ["extract dates", "find dates", "date parser", "iso 8601", "normalize dates", "date extraction", "datetime"]
 h1            = "Extract Dates"

--- a/blocks/extract-decode-base64/page/meta.toml
+++ b/blocks/extract-decode-base64/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "extract-decode-base64"
-title         = "Find & Decode Base64 in Text — gizza.ai"
+title         = "Find & Decode Base64 in Text"
 description   = "Scan any text for embedded Base64 blobs and decode them — showing decoded text, or a file-type + hex preview for binaries. Runs in your browser, nothing uploaded."
 tags          = ["decode base64", "find base64", "base64 extractor", "base64 in text", "url-safe base64", "decode blob"]
 h1            = "Find & Decode Base64"

--- a/blocks/extract-domains/page/meta.toml
+++ b/blocks/extract-domains/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "extract-domains"
-title         = "Extract Domains from Text — gizza.ai"
+title         = "Extract Domains from Text"
 description   = "Extract domains from text, URLs, and emails — hostnames or registrable eTLD+1, validated against the Public Suffix List. Free, private, in your browser."
 tags          = ["extract domains", "domain extractor", "find domains", "registrable domain", "etld+1", "public suffix list", "parse hostnames"]
 h1            = "Extract Domains"

--- a/blocks/extract-email-addresses/page/meta.toml
+++ b/blocks/extract-email-addresses/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "extract-email-addresses"
-title         = "Extract Email Addresses from Text — gizza.ai"
+title         = "Extract Email Addresses from Text"
 description   = "Pull all email addresses out of any text, deduplicated and optionally grouped by domain — in your browser. Nothing is uploaded."
 tags          = ["extract emails", "email extractor", "find email addresses", "scrape emails", "dedupe emails", "group by domain"]
 h1            = "Extract Email Addresses"

--- a/blocks/extract-frames/page/meta.toml
+++ b/blocks/extract-frames/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "extract-frames"
-title         = "Extract Frames from a Video — Contact Sheet / Thumbnail Grid — gizza.ai"
+title         = "Extract Frames from a Video — Contact Sheet / Thumbnail Grid"
 description   = "Sample frames from a video by interval, fps or scene change and tile them into one contact-sheet image. Free, in your browser with ffmpeg, nothing is uploaded."
 tags          = ["extract frames", "video contact sheet", "thumbnail grid", "storyboard", "scene detection", "video thumbnails", "frames per second", "ffmpeg"]
 h1            = "Extract Video Frames to a Contact Sheet"

--- a/blocks/extract-hashes/page/meta.toml
+++ b/blocks/extract-hashes/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "extract-hashes"
-title         = "Extract Hashes from Text — gizza.ai"
+title         = "Extract Hashes from Text"
 description   = "Pull every MD5, SHA-1, SHA-256 and SHA-512 hash out of any text, grouped by algorithm and deduplicated — in your browser. Nothing is uploaded."
 tags          = ["extract hashes", "hash extractor", "find md5", "find sha256", "ioc hashes", "checksum extractor"]
 h1            = "Extract Hashes"

--- a/blocks/extract-ip-addresses/page/meta.toml
+++ b/blocks/extract-ip-addresses/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "extract-ip-addresses"
-title         = "Extract IP Addresses from Text or Logs — gizza.ai"
+title         = "Extract IP Addresses from Text or Logs"
 description   = "Find, validate and deduplicate all IPv4 and IPv6 addresses in pasted text or a log — in your browser. Nothing is uploaded."
 tags          = ["extract ip", "ip address finder", "ipv4", "ipv6", "parse logs", "find ip addresses", "dedupe ips"]
 h1            = "Extract IP Addresses"

--- a/blocks/extract-mac-addresses/page/meta.toml
+++ b/blocks/extract-mac-addresses/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "extract-mac-addresses"
-title         = "Extract MAC Addresses from Text or Logs — gizza.ai"
+title         = "Extract MAC Addresses from Text or Logs"
 description   = "Find every MAC address in pasted text or logs and normalize to colon, hyphen, Cisco dotted, or bare hex. Deduplicated, private, runs in your browser."
 tags          = ["extract mac", "mac address finder", "mac normalizer", "eui-48", "eui-64", "cisco mac format", "parse logs", "dedupe mac"]
 h1            = "Extract MAC Addresses"

--- a/blocks/extract-substring/page/meta.toml
+++ b/blocks/extract-substring/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "extract-substring"
-title         = "Extract Substring — by index or between delimiters — gizza.ai"
+title         = "Extract Substring — by index or between delimiters"
 description   = "Pull out a portion of text by start/end character index, or everything between two delimiters — in your browser. Nothing is uploaded."
 tags          = ["substring", "extract text", "between delimiters", "slice string", "cut text", "string index"]
 h1            = "Extract Substring"

--- a/blocks/extract-urls/page/meta.toml
+++ b/blocks/extract-urls/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "extract-urls"
-title         = "Extract URLs from Text — gizza.ai"
+title         = "Extract URLs from Text"
 description   = "Pull all http/https URLs out of any text, deduplicated, with an optional scheme/host/path component split — in your browser. Nothing is uploaded."
 tags          = ["extract urls", "url extractor", "find links", "parse urls", "dedupe urls", "url components"]
 h1            = "Extract URLs"

--- a/blocks/fake-data-generator/page/meta.toml
+++ b/blocks/fake-data-generator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "fake-data-generator"
-title         = "Fake Data Generator — CSV & JSON Test Records — gizza.ai"
+title         = "Fake Data Generator — CSV & JSON Test Records"
 description   = "Generate fake test data — names, emails, addresses, UUIDs and more — as CSV, JSON, SQL or XML. Up to 1000 rows, seedable. Free, in your browser."
 tags          = ["fake data", "test data", "mock data", "sample data", "csv generator", "json generator", "dummy data", "seed data", "placeholder data"]
 h1            = "Fake Data Generator"

--- a/blocks/fernet-token/page/meta.toml
+++ b/blocks/fernet-token/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "fernet-token"
-title         = "Fernet Token Generator — create & decrypt Fernet tokens online — gizza.ai"
+title         = "Fernet Token Generator — create & decrypt Fernet tokens online"
 description   = "Create and read Fernet tokens (AES-128-CBC + HMAC-SHA256) in your browser: generate a key, encrypt to a url-safe token, decrypt with optional TTL. No upload."
 tags          = ["fernet", "fernet token", "symmetric encryption", "aes-128-cbc", "hmac-sha256", "token", "ttl", "privacy"]
 h1            = "Fernet token tool"

--- a/blocks/file-tree-generator/page/meta.toml
+++ b/blocks/file-tree-generator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "file-tree-generator"
-title         = "File Tree Generator — ASCII Directory Tree | gizza.ai"
+title         = "File Tree Generator — ASCII Directory Tree"
 description   = "Turn a list of file paths or an indented outline into an ASCII tree for READMEs and docs. Unicode or ASCII connectors, optional sorting. Free, in-browser."
 tags          = ["file tree generator", "ascii tree", "directory tree", "folder structure diagram", "tree command", "readme tree", "ascii folder structure", "project structure generator"]
 h1            = "File Tree Generator"

--- a/blocks/files-to-prompt/page/meta.toml
+++ b/blocks/files-to-prompt/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "files-to-prompt"
-title         = "Files to Prompt — Bundle Files into One LLM Prompt — gizza.ai"
+title         = "Files to Prompt — Bundle Files into One LLM Prompt"
 description   = "Bundle multiple files into one LLM-ready prompt: a directory tree, fenced file contents, and a token estimate. Free, in your browser, nothing uploaded."
 tags          = ["files to prompt", "code to prompt", "concatenate files for llm", "repo to text", "codebase to prompt", "llm context bundler", "claude xml documents", "directory tree", "token estimate"]
 h1            = "Files to Prompt"

--- a/blocks/filter-lines/page/meta.toml
+++ b/blocks/filter-lines/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "filter-lines"
-title         = "Filter Lines — keep or drop lines by substring/regex — gizza.ai"
+title         = "Filter Lines — keep or drop lines by substring/regex"
 description   = "Keep or drop lines of text matching a substring or regular expression — a friendly grep in your browser. Nothing is uploaded."
 tags          = ["filter lines", "grep", "keep lines", "drop lines", "regex filter", "search lines"]
 h1            = "Filter Lines"

--- a/blocks/find-duplicate-lines/page/meta.toml
+++ b/blocks/find-duplicate-lines/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "find-duplicate-lines"
-title         = "Find Duplicate Lines — with counts — gizza.ai"
+title         = "Find Duplicate Lines — with counts"
 description   = "List the lines that appear more than once in pasted text, with their counts — in your browser. Optional case-insensitive and trim matching. Nothing is uploaded."
 tags          = ["find duplicate lines", "duplicate finder", "count duplicates", "repeated lines", "dedupe check"]
 h1            = "Find Duplicate Lines"

--- a/blocks/find-replace/page/meta.toml
+++ b/blocks/find-replace/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "find-replace"
-title         = "Find and Replace Text Online — gizza.ai"
+title         = "Find and Replace Text Online"
 description   = "Find and replace text with literal or regex matching, case-sensitive or not, all matches or just the first. Runs in your browser, nothing is uploaded, free."
 tags          = ["find and replace", "search replace", "regex replace", "text replace", "bulk replace"]
 h1            = "Find and Replace Text"

--- a/blocks/find-unique-lines/page/meta.toml
+++ b/blocks/find-unique-lines/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "find-unique-lines"
-title         = "Find Unique Lines — keep only one-off lines — gizza.ai"
+title         = "Find Unique Lines — keep only one-off lines"
 description   = "Return only the lines that appear exactly once in pasted text (like uniq -u) — in your browser. Optional case-insensitive and trim matching. Nothing is uploaded."
 tags          = ["find unique lines", "uniq -u", "lines appearing once", "non-repeated lines", "unique line filter"]
 h1            = "Find Unique Lines"

--- a/blocks/flask-session-decode/page/meta.toml
+++ b/blocks/flask-session-decode/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "flask-session-decode"
-title         = "Flask Session Cookie Decoder — Decode itsdangerous Sessions — gizza.ai"
+title         = "Flask Session Cookie Decoder — Decode itsdangerous Sessions"
 description   = "Decode a Flask session cookie (itsdangerous) into readable JSON without the secret key — base64url, zlib payloads, signature timestamp. Free, in your browser."
 tags          = ["flask session decoder", "itsdangerous", "session cookie", "decode flask cookie", "flask cookie decoder", "base64url", "session debugging", "python flask"]
 h1            = "Flask Session Cookie Decoder"

--- a/blocks/frequency-distribution/page/meta.toml
+++ b/blocks/frequency-distribution/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "frequency-distribution"
-title         = "Frequency Distribution — Character, byte & n-gram frequency table — gizza.ai"
+title         = "Frequency Distribution — Character, byte & n-gram frequency table"
 description   = "Build a character, byte, or n-gram frequency table from text or hex, with counts and percentages, ranked most to least frequent — in your browser. Nothing is uploaded."
 tags          = ["frequency distribution", "character frequency", "letter frequency", "byte frequency", "n-gram frequency", "frequency analysis", "frequency table", "bigram counter"]
 h1            = "Frequency distribution"

--- a/blocks/fuzzy-doc-search/page/meta.toml
+++ b/blocks/fuzzy-doc-search/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "fuzzy-doc-search"
-title         = "Fuzzy Text Search — find ranked matching snippets — gizza.ai"
+title         = "Fuzzy Text Search — find ranked matching snippets"
 description   = "Paste text and fuzzy-search it — find the best-matching lines even with typos, ranked by relevance with the matches highlighted. Runs in your browser, no upload."
 tags          = ["fuzzy search", "full text search", "search in text", "find in document", "typo tolerant search", "ranked snippets", "search markdown", "grep online"]
 h1            = "Fuzzy Text Search"

--- a/blocks/generate-hotp/page/meta.toml
+++ b/blocks/generate-hotp/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "generate-hotp"
-title         = "HOTP Generator — counter-based one-time codes — gizza.ai"
+title         = "HOTP Generator — counter-based one-time codes"
 description   = "Generate counter-based one-time (HOTP, RFC 4226) codes from a base32 secret and a counter, in your browser. The secret never leaves your device."
 tags          = ["hotp", "rfc4226", "one-time password", "otp", "2fa", "counter", "authenticator"]
 h1            = "HOTP generator"

--- a/blocks/generate-uuid/page/meta.toml
+++ b/blocks/generate-uuid/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "generate-uuid"
-title         = "UUID Generator — gizza.ai"
+title         = "UUID Generator"
 description   = "Generate UUIDs / GUIDs online: v4 (random), v7 (time-ordered), v1, and v5/v3 (namespace), one or in bulk. Runs entirely in your browser — nothing uploaded, free."
 tags          = ["uuid generator", "guid generator", "uuid v4", "uuid v7", "bulk uuid generator"]
 h1            = "UUID Generator"

--- a/blocks/geojson-to-svg/page/meta.toml
+++ b/blocks/geojson-to-svg/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "geojson-to-svg"
-title         = "GeoJSON to SVG — render a GeoJSON map online — gizza.ai"
+title         = "GeoJSON to SVG — render a GeoJSON map online"
 description   = "Render GeoJSON to a scalable SVG map in your browser — polygons, lines and points, Web-Mercator or raw lon/lat, custom colours. No tile server, no upload."
 tags          = ["geojson to svg", "geojson map", "render geojson", "geojson viewer", "geojson svg", "geojson visualizer"]
 h1            = "GeoJSON to SVG"

--- a/blocks/geometry-calculator/page/meta.toml
+++ b/blocks/geometry-calculator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "geometry-calculator"
-title         = "Geometry Calculator — Area, Perimeter, Surface Area & Volume — gizza.ai"
+title         = "Geometry Calculator — Area, Perimeter, Surface Area & Volume"
 description   = "Geometry calculator for area, perimeter, surface area and volume — squares, triangles, circles, spheres, cylinders, cones and more. Free, private, in-browser."
 tags          = ["geometry calculator", "area calculator", "perimeter calculator", "volume calculator", "surface area calculator", "circle area", "cylinder volume", "sphere volume", "triangle area"]
 h1            = "Geometry Calculator"

--- a/blocks/gif-to-mp4/page/meta.toml
+++ b/blocks/gif-to-mp4/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "gif-to-mp4"
-title         = "GIF to MP4 / WebM Converter — gizza.ai"
+title         = "GIF to MP4 / WebM Converter"
 description   = "Convert an animated GIF into a much smaller MP4 or WebM video, right in your browser. Re-encodes locally with ffmpeg (H.264 / VP9), nothing is uploaded, free."
 tags          = ["gif to mp4", "gif to webm", "gif converter", "animated gif", "compress gif", "ffmpeg"]
 h1            = "GIF to MP4 / WebM"

--- a/blocks/gmail-takeout-parser/page/meta.toml
+++ b/blocks/gmail-takeout-parser/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "gmail-takeout-parser"
-title         = "Gmail Takeout Parser — mbox to CSV / JSON with Labels — gizza.ai"
+title         = "Gmail Takeout Parser — mbox to CSV / JSON with Labels"
 description   = "Turn a Google Takeout Gmail .mbox export into CSV or JSON — one row per message with date, from/to/cc, subject and Gmail labels. In-browser, no upload."
 tags          = ["gmail takeout parser", "mbox to csv", "mbox to json", "gmail labels export", "google takeout gmail", "mbox converter", "email to spreadsheet", "x-gmail-labels"]
 h1            = "Gmail Takeout mbox → CSV / JSON"

--- a/blocks/gost-kuznyechik-cipher/page/meta.toml
+++ b/blocks/gost-kuznyechik-cipher/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "gost-kuznyechik-cipher"
-title         = "GOST Kuznyechik Cipher — Encrypt/decrypt (GOST R 34.12-2015) — gizza.ai"
+title         = "GOST Kuznyechik Cipher — Encrypt/decrypt (GOST R 34.12-2015)"
 description   = "Encrypt or decrypt text with the GOST Kuznyechik cipher (GOST R 34.12-2015) in CBC, CTR, CFB, OFB or ECB mode — 256-bit key, hex/base64 I/O, in your browser."
 tags          = ["kuznyechik", "gost", "gost r 34.12-2015", "gost encrypt", "gost decrypt", "cbc", "ctr", "cfb", "ofb", "cipher"]
 h1            = "GOST Kuznyechik cipher"

--- a/blocks/gost-magma-cipher/page/meta.toml
+++ b/blocks/gost-magma-cipher/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "gost-magma-cipher"
-title         = "GOST Magma Cipher — Encrypt/decrypt (GOST 28147-89) — gizza.ai"
+title         = "GOST Magma Cipher — Encrypt/decrypt (GOST 28147-89)"
 description   = "Encrypt or decrypt text with the GOST 28147-89 Magma 64-bit block cipher — ECB or CBC, 256-bit key, hex or base64 — free and entirely in your browser."
 tags          = ["magma", "gost", "gost 28147-89", "gost r 34.12-2015", "gost encrypt", "gost decrypt", "cbc", "ecb", "block cipher", "cipher"]
 h1            = "GOST Magma cipher"

--- a/blocks/gpx-analyzer/page/meta.toml
+++ b/blocks/gpx-analyzer/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "gpx-analyzer"
-title         = "GPX Analyzer — distance, elevation, pace & speed from a GPX track — gizza.ai"
+title         = "GPX Analyzer — distance, elevation, pace & speed from a GPX track"
 description   = "Paste a GPX file to get total distance (km and miles), elevation gain/loss, duration, average speed and pace — in your browser. Nothing is uploaded."
 tags          = ["gpx analyzer", "gpx stats", "gps track", "distance calculator", "elevation gain", "running pace", "gpx viewer", "haversine"]
 h1            = "GPX Analyzer"

--- a/blocks/gpx-privacy-scrubber/page/meta.toml
+++ b/blocks/gpx-privacy-scrubber/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "gpx-privacy-scrubber"
-title         = "GPX Privacy Scrubber — Remove Start/End Points, Timestamps & Sensor Data | gizza.ai"
+title         = "GPX Privacy Scrubber — Remove Start/End Points, Timestamps & Sensor Data"
 description   = "Scrub a GPX file before sharing it: remove or fuzz start/end locations, rewrite timestamps, and strip sensor extensions. Runs locally in your browser."
 tags          = ["gpx", "privacy", "location", "gps", "fitness"]
 h1            = "GPX Privacy Scrubber"

--- a/blocks/graph-algorithms/page/meta.toml
+++ b/blocks/graph-algorithms/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "graph-algorithms"
-title         = "Graph Algorithms — BFS, DFS, Shortest Path, Topological Sort & Cycle Detection — gizza.ai"
+title         = "Graph Algorithms — BFS, DFS, Shortest Path, Topological Sort & Cycle Detection"
 description   = "Run graph algorithms on your own edge list — BFS, DFS, Dijkstra shortest path, topological sort, and cycle detection. Free, private, in your browser."
 tags          = ["graph algorithms", "bfs", "dfs", "shortest path", "dijkstra", "topological sort", "cycle detection", "edge list", "directed graph", "weighted graph"]
 h1            = "Graph Algorithms"

--- a/blocks/gzip-size-estimator/page/meta.toml
+++ b/blocks/gzip-size-estimator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "gzip-size-estimator"
-title         = "Gzip & Brotli Size Estimator — Measure Compressed Transfer Size | gizza.ai"
+title         = "Gzip & Brotli Size Estimator — Measure Compressed Transfer Size"
 description   = "See the gzip and brotli compressed size of any code or text — raw bytes, bytes saved, percent reduction and ratio. Free, private, runs in your browser."
 tags          = ["gzip size", "brotli size", "compressed size", "transfer size", "bundle size", "gzip estimator", "compression ratio", "minify", "page weight", "content-encoding"]
 h1            = "Gzip & Brotli Size Estimator"

--- a/blocks/hash-all/page/meta.toml
+++ b/blocks/hash-all/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "hash-all"
-title         = "Hash All — MD5, SHA, SHA-3, RIPEMD, BLAKE3, Whirlpool, CRC-32 | gizza.ai"
+title         = "Hash All — MD5, SHA, SHA-3, RIPEMD, BLAKE3, Whirlpool, CRC-32"
 description   = "Hash text with every common algorithm at once — MD5, SHA-1, SHA-256/512, SHA-3, BLAKE3, RIPEMD-160, CRC-32 and more — free and private in your browser."
 tags          = ["hash", "md5", "sha1", "sha256", "sha512", "sha3", "ripemd", "blake2", "blake3", "whirlpool", "crc32", "checksum", "digest", "hex", "base64", "cryptography"]
 h1            = "Hash All Generator"

--- a/blocks/hash-identifier/page/meta.toml
+++ b/blocks/hash-identifier/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "hash-identifier"
-title         = "Hash Identifier — Detect Hash Type Online | gizza.ai"
+title         = "Hash Identifier — Detect Hash Type Online"
 description   = "Paste a hash and instantly identify its likely algorithm — bcrypt, Argon2, MD5, SHA-1/256/512, NTLM, sha512crypt, PHPass and more. Runs entirely in your browser."
 tags          = ["hash", "security", "identifier", "bcrypt", "argon2", "md5", "sha256", "ntlm", "password"]
 h1            = "Hash Identifier"

--- a/blocks/hash-text/page/meta.toml
+++ b/blocks/hash-text/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "hash-text"
-title         = "Text Hash Generator — MD5, SHA-256, SHA-3, BLAKE3 | gizza.ai"
+title         = "Text Hash Generator — MD5, SHA-256, SHA-3, BLAKE3"
 description   = "Generate MD5, SHA-1, SHA-256/512, SHA-3, BLAKE2 or BLAKE3 hashes of any text in your browser, with hex or base64 output. Free, private, nothing uploaded."
 tags          = ["hash", "md5", "sha1", "sha256", "sha512", "sha3", "blake2", "blake3", "checksum", "digest", "hex", "base64", "cryptography"]
 h1            = "Text Hash Generator"

--- a/blocks/hd-key-derive/page/meta.toml
+++ b/blocks/hd-key-derive/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "hd-key-derive"
-title         = "HD Key Derive — BIP32 xprv/xpub and Bitcoin Address — gizza.ai"
+title         = "HD Key Derive — BIP32 xprv/xpub and Bitcoin Address"
 description   = "Derive BIP32 child private keys, xpubs, WIF keys, and Bitcoin mainnet/testnet P2PKH or SegWit addresses from a seed or xprv. Private and offline in your browser."
 tags          = ["bip32", "hd wallet", "xprv", "xpub", "bitcoin", "wallet", "derivation path", "p2pkh", "segwit", "wif"]
 h1            = "BIP32 HD Key Derivation"

--- a/blocks/head-lines/page/meta.toml
+++ b/blocks/head-lines/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "head-lines"
-title         = "Head — Get the First N Lines of Text | gizza.ai"
+title         = "Head — Get the First N Lines of Text"
 description   = "Get the first N lines of any text in your browser — like head -n. Choose the line count, skip a header row, number each line. Free, private, no sign-up."
 tags          = ["head", "first lines", "first n lines", "head -n", "top lines", "truncate lines", "line numbers", "text tool"]
 h1            = "Head — First N Lines"

--- a/blocks/hex-codec/page/meta.toml
+++ b/blocks/hex-codec/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "hex-codec"
-title         = "Hex Encoder & Decoder — Text to Hex & Hex to Text — gizza.ai"
+title         = "Hex Encoder & Decoder — Text to Hex & Hex to Text"
 description   = "Encode text to hex and decode hex back to text in your browser. Delimiters, uppercase, and 0x prefixes; tolerant decoding accepts any format. Free and private."
 tags          = ["hex", "hex encode", "hex decode", "text to hex", "hex to text", "hexadecimal", "encoder", "decoder", "hex converter", "bytes"]
 h1            = "Hex Encoder / Decoder"

--- a/blocks/hkdf-derive/page/meta.toml
+++ b/blocks/hkdf-derive/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "hkdf-derive"
-title         = "HKDF Key Derivation — extract-and-expand (RFC 5869) — gizza.ai"
+title         = "HKDF Key Derivation — extract-and-expand (RFC 5869)"
 description   = "Derive keys with HKDF, the HMAC-based extract-and-expand KDF from RFC 5869 — choose hash, salt, info label, length and hex/base64 output, all in your browser."
 tags          = ["hkdf", "key derivation", "kdf", "rfc 5869", "extract and expand", "hmac", "hkdf-sha256", "derive key", "hkdf-expand", "info context"]
 h1            = "HKDF key derivation"

--- a/blocks/hmac-generate/page/meta.toml
+++ b/blocks/hmac-generate/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "hmac-generate"
-title         = "HMAC Generator — HMAC-SHA256, SHA-1, SHA-512, SHA-3, MD5 | gizza.ai"
+title         = "HMAC Generator — HMAC-SHA256, SHA-1, SHA-512, SHA-3, MD5"
 description   = "Generate an HMAC of any message and secret key in your browser — HMAC-SHA256, SHA-1, SHA-512, SHA-3 or MD5, hex or base64 output. Free and private."
 tags          = ["hmac", "hmac-sha256", "sha256", "sha1", "sha512", "sha3", "md5", "mac", "keyed-hash", "signature", "webhook", "hex", "base64", "cryptography"]
 h1            = "HMAC Generator"

--- a/blocks/html-form-generator/page/meta.toml
+++ b/blocks/html-form-generator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "html-form-generator"
-title         = "HTML Form Generator — Build Accessible Form Markup — gizza.ai"
+title         = "HTML Form Generator — Build Accessible Form Markup"
 description   = "Generate clean, accessible HTML form markup from a plain field list — labels, validation, selects, radios and textareas. Free, private, in-browser."
 tags          = ["html form generator", "form builder", "html form code", "accessible form", "contact form generator", "form markup", "input validation", "label for", "select radio checkbox"]
 h1            = "HTML Form Generator"

--- a/blocks/html-formatter/page/meta.toml
+++ b/blocks/html-formatter/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "html-formatter"
-title         = "HTML Formatter — pretty-print / beautify HTML — gizza.ai"
+title         = "HTML Formatter — pretty-print / beautify HTML"
 description   = "Pretty-print and beautify HTML with consistent indentation, in your browser. Handles void elements, comments, and preserves pre/script/style. Nothing is uploaded."
 tags          = ["html formatter", "html beautifier", "pretty print html", "format html", "indent html", "beautify html"]
 h1            = "HTML Formatter"

--- a/blocks/html-minifier/page/meta.toml
+++ b/blocks/html-minifier/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "html-minifier"
-title         = "HTML Minifier — collapse whitespace & strip comments — gizza.ai"
+title         = "HTML Minifier — collapse whitespace & strip comments"
 description   = "Minify HTML by collapsing whitespace and removing comments, in your browser. Preserves pre/script/style and significant inline spacing. Nothing is uploaded."
 tags          = ["html minifier", "minify html", "compress html", "remove html comments", "collapse whitespace"]
 h1            = "HTML Minifier"

--- a/blocks/html-preview-bundler/page/meta.toml
+++ b/blocks/html-preview-bundler/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "html-preview-bundler"
-title         = "HTML Preview Bundler — inline CSS & JS into one file — gizza.ai"
+title         = "HTML Preview Bundler — inline CSS & JS into one file"
 description   = "Combine separate HTML, CSS, and JS into one self-contained, runnable HTML file you can open or share — in your browser. Nothing is uploaded."
 tags          = ["html bundler", "inline css js", "single file html", "self-contained html", "html preview", "combine html css js"]
 h1            = "HTML Preview Bundler"

--- a/blocks/html-table-extractor/page/meta.toml
+++ b/blocks/html-table-extractor/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "html-table-extractor"
-title         = "Extract Tables from HTML — CSV or JSON — gizza.ai"
+title         = "Extract Tables from HTML — CSV or JSON"
 description   = "Paste HTML and pull out any <table> as clean CSV or JSON. Pick the table and output format. Runs in your browser, nothing is uploaded, free."
 tags          = ["html table to csv", "extract table", "html to json", "scrape table", "table converter"]
 h1            = "Extract Tables from HTML"

--- a/blocks/html-to-markdown/page/meta.toml
+++ b/blocks/html-to-markdown/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "html-to-markdown"
-title         = "HTML to Markdown Converter — gizza.ai"
+title         = "HTML to Markdown Converter"
 description   = "Convert HTML into clean Markdown instantly in your browser — preserves headings, links, lists, code blocks, tables, and emphasis. Free, private, no upload, no sign-up."
 tags          = ["html to markdown", "html2md", "markdown converter", "convert html", "web scraping cleanup", "rich text to markdown"]
 h1            = "HTML to Markdown"

--- a/blocks/html-to-text/page/meta.toml
+++ b/blocks/html-to-text/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "html-to-text"
-title         = "HTML to Text — Strip HTML Tags Online — gizza.ai"
+title         = "HTML to Text — Strip HTML Tags Online"
 description   = "Strip HTML markup to clean, readable plain text in your browser — keeps paragraph and list structure, removes all tags. Free, private, no upload, no sign-up."
 tags          = ["html to text", "strip html", "remove html tags", "plain text", "html stripper", "extract text"]
 h1            = "HTML to Text"

--- a/blocks/http-header-analyzer/page/meta.toml
+++ b/blocks/http-header-analyzer/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "http-header-analyzer"
-title         = "HTTP Header Analyzer — explain response headers & spot missing security headers — gizza.ai"
+title         = "HTTP Header Analyzer — explain response headers & spot missing security headers"
 description   = "Paste HTTP response headers for a plain-English explanation of each, an A+–F security grade, and missing security headers. Free, private, in your browser."
 tags          = ["http header analyzer", "http response headers", "security headers checker", "cache-control explained", "content-encoding", "missing security headers", "hsts", "content-security-policy", "header inspector"]
 h1            = "HTTP Header Analyzer"

--- a/blocks/http-request-builder/page/meta.toml
+++ b/blocks/http-request-builder/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "http-request-builder"
-title         = "HTTP Request Builder — raw HTTP/1.1 message — gizza.ai"
+title         = "HTTP Request Builder — raw HTTP/1.1 message"
 description   = "Build a well-formed raw HTTP/1.1 request from a method, URL, headers, and body — in your browser. Nothing is sent. Great for netcat, teaching, and debugging."
 tags          = ["http request builder", "raw http", "http/1.1", "request message", "netcat", "build http request"]
 h1            = "HTTP Request Builder"

--- a/blocks/iban-validator/page/meta.toml
+++ b/blocks/iban-validator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "iban-validator"
-title         = "IBAN Validator — Check & Parse an IBAN — gizza.ai"
+title         = "IBAN Validator — Check & Parse an IBAN"
 description   = "Validate an IBAN with the mod-97 checksum and parse out the country, bank, and account — instantly, in your browser. Nothing is uploaded, free."
 tags          = ["iban validator", "iban checker", "validate iban", "mod 97", "bank account number", "iso 13616"]
 h1            = "IBAN Validator"

--- a/blocks/image-bg-replace/page/meta.toml
+++ b/blocks/image-bg-replace/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "image-bg-replace"
-title         = "Green Screen / Chroma Key Background Replacer Online — gizza.ai"
+title         = "Green Screen / Chroma Key Background Replacer Online"
 description   = "Chroma-key a green-screen or solid-color background out and drop the subject onto a transparent, solid, or gradient background — free, in your browser."
 tags          = ["image", "background", "chroma key", "green screen", "remove background", "background replace", "transparent png", "gradient background", "blue screen", "composite", "png", "webp"]
 h1            = "Replace an Image Background (Chroma Key)"

--- a/blocks/image-compress/page/meta.toml
+++ b/blocks/image-compress/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "image-compress"
-title         = "Compress an Image Online — gizza.ai"
+title         = "Compress an Image Online"
 description   = "Shrink an image's file size right in your browser — re-encode a JPG, PNG, or WebP at a chosen quality, same format out. No upload to a server, runs locally, free."
 tags          = ["image", "compress", "shrink", "optimize", "quality", "jpg", "png", "webp", "file size"]
 h1            = "Compress an Image"

--- a/blocks/image-convert/page/meta.toml
+++ b/blocks/image-convert/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "image-convert"
-title         = "Convert an Image Online — gizza.ai"
+title         = "Convert an Image Online"
 description   = "Convert any image to JPEG, PNG, or WebP right in your browser — pick a target format and quality. No upload to a server, runs locally, free."
 tags          = ["image", "convert", "format", "jpeg", "png", "webp", "transcode"]
 h1            = "Convert an Image"

--- a/blocks/image-crop/page/meta.toml
+++ b/blocks/image-crop/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "image-crop"
-title         = "Crop an Image Online — gizza.ai"
+title         = "Crop an Image Online"
 description   = "Crop any image right in your browser — set the x/y offset and the width/height of the rectangle to keep. No upload to a server, runs locally, free."
 tags          = ["image", "crop", "trim", "cut", "rectangle"]
 h1            = "Crop an Image"

--- a/blocks/image-grayscale/page/meta.toml
+++ b/blocks/image-grayscale/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "image-grayscale"
-title         = "Convert an Image to Grayscale — gizza.ai"
+title         = "Convert an Image to Grayscale"
 description   = "Convert any image to grayscale instantly in your browser. No upload to a server, runs locally, completely free."
 tags          = ["image", "grayscale", "convert", "black-and-white", "filter"]
 h1            = "Convert an Image to Grayscale"

--- a/blocks/image-resize-to-filesize/page/meta.toml
+++ b/blocks/image-resize-to-filesize/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "image-resize-to-filesize"
-title         = "Compress Image to a Target File Size (KB) — gizza.ai"
+title         = "Compress Image to a Target File Size (KB)"
 description   = "Compress a JPG or WebP to a target file size in KB. Enter a KB budget and it searches the best quality that fits — all in your browser, nothing uploaded, free."
 tags          = ["image", "compress", "file size", "kb", "target size", "jpeg", "webp", "reduce"]
 h1            = "Compress an Image to a Target File Size"

--- a/blocks/image-resize/page/meta.toml
+++ b/blocks/image-resize/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "image-resize"
-title         = "Resize an Image Online — gizza.ai"
+title         = "Resize an Image Online"
 description   = "Resize any image right in your browser — set a width and/or height, pick a fit mode. No upload to a server, runs locally, free."
 tags          = ["image", "resize", "scale", "thumbnail", "dimensions"]
 h1            = "Resize an Image"

--- a/blocks/image-shrink-for-sharing/page/meta.toml
+++ b/blocks/image-shrink-for-sharing/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "image-shrink-for-sharing"
-title         = "Shrink an Image for Sharing — Resize, Strip Metadata & Compress — gizza.ai"
+title         = "Shrink an Image for Sharing — Resize, Strip Metadata & Compress"
 description   = "Downscale, strip EXIF metadata, and compress a photo in one step for messaging, email or upload. Runs locally in your browser — nothing is uploaded, free."
 tags          = ["image", "compress", "shrink", "resize", "share", "optimize", "reduce file size", "strip exif", "photo", "jpeg", "png", "webp", "whatsapp", "email"]
 h1            = "Shrink an Image for Sharing"

--- a/blocks/image-vignette/page/meta.toml
+++ b/blocks/image-vignette/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "image-vignette"
-title         = "Add a Vignette to an Image Online — Dark, Light or Colored Edges — gizza.ai"
+title         = "Add a Vignette to an Image Online — Dark, Light or Colored Edges"
 description   = "Add a dark, light or colored vignette around the edges of a photo, right in your browser — adjustable strength, center and output format. Nothing is uploaded, free."
 tags          = ["image", "vignette", "photo", "effects", "darken", "lighten", "edges", "filter", "vignette color", "white vignette", "sepia", "png", "jpg", "webp"]
 h1            = "Add a Vignette to an Image"

--- a/blocks/index-of-coincidence/page/meta.toml
+++ b/blocks/index-of-coincidence/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "index-of-coincidence"
-title         = "Index of Coincidence Calculator — gizza.ai"
+title         = "Index of Coincidence Calculator"
 description   = "Calculate the Index of Coincidence (IC) of any text — spot monoalphabetic vs polyalphabetic ciphers and estimate a Vigenère key length. Free, in your browser."
 tags          = ["index of coincidence", "ic calculator", "cryptanalysis", "vigenere", "key length", "kasiski", "frequency analysis", "monoalphabetic", "polyalphabetic", "cipher"]
 h1            = "Index of Coincidence Calculator"

--- a/blocks/ioc-defang/page/meta.toml
+++ b/blocks/ioc-defang/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "ioc-defang"
-title         = "Defang & Refang IOCs — Neutralize URLs, IPs, Domains & Emails — gizza.ai"
+title         = "Defang & Refang IOCs — Neutralize URLs, IPs, Domains & Emails"
 description   = "Defang or refang IOCs in your browser: turn http://evil.com into hxxp[://]evil[.]com so URLs, IPs, domains and emails are safe to share. Free, private."
 tags          = ["defang", "refang", "ioc", "indicators of compromise", "defang url", "defang ip", "threat intelligence", "cti", "soc", "malware analysis", "neutralize url", "hxxp"]
 h1            = "Defang / Refang IOCs"

--- a/blocks/ioc-extract/page/meta.toml
+++ b/blocks/ioc-extract/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "ioc-extract"
-title         = "IOC Extractor — Pull IPs, URLs, Domains, Emails & Hashes from Text — gizza.ai"
+title         = "IOC Extractor — Pull IPs, URLs, Domains, Emails & Hashes from Text"
 description   = "Extract IOCs from threat reports in your browser — IPs, URLs, domains, emails, MD5/SHA hashes — with defanged (hxxp, [.]) input support. Free, private, no sign-up."
 tags          = ["ioc", "ioc extractor", "indicators of compromise", "extract ip", "extract url", "extract domain", "extract hash", "threat intelligence", "cti", "soc", "malware analysis", "defang", "ioc parser"]
 h1            = "IOC Extractor"

--- a/blocks/ip-range-expand/page/meta.toml
+++ b/blocks/ip-range-expand/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "ip-range-expand"
-title         = "IP Range Expander — CIDR & Range to IP List (IPv4 & IPv6) | gizza.ai"
+title         = "IP Range Expander — CIDR & Range to IP List (IPv4 & IPv6)"
 description   = "Expand a CIDR block (192.168.1.0/24) or start-end IP range into the full list of addresses, or just count them — IPv4 and IPv6, free and private in your browser."
 tags          = ["ip range expander", "cidr to ip list", "cidr expander", "ip range to list", "expand cidr", "subnet calculator", "ipv4", "ipv6", "list ip addresses", "cidr to range"]
 h1            = "IP Range Expander"

--- a/blocks/ip-range-to-cidr/page/meta.toml
+++ b/blocks/ip-range-to-cidr/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "ip-range-to-cidr"
-title         = "IP Range to CIDR — Convert a Start-End IP Range to CIDR Blocks (IPv4 & IPv6) | gizza.ai"
+title         = "IP Range to CIDR — Convert a Start-End IP Range to CIDR Blocks (IPv4 & IPv6)"
 description   = "Convert a start-end IP range like 10.0.0.5-10.0.0.20 into the minimal set of CIDR blocks that exactly covers it — IPv4 and IPv6, free and in-browser."
 tags          = ["ip range to cidr", "range to cidr", "cidr aggregator", "ip range aggregation", "ip to cidr", "subnet from range", "cidr calculator", "ipv4", "ipv6", "cidr block list", "minimal cidr cover"]
 h1            = "IP Range to CIDR"

--- a/blocks/ja3-fingerprint/page/meta.toml
+++ b/blocks/ja3-fingerprint/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "ja3-fingerprint"
-title         = "JA3 Fingerprint Calculator — compute the JA3 TLS hash from a ClientHello — gizza.ai"
+title         = "JA3 Fingerprint Calculator — compute the JA3 TLS hash from a ClientHello"
 description   = "Compute the JA3 and JA3N fingerprints (string + MD5 hash) of a TLS ClientHello from pasted hex, GREASE removed — free and local in your browser."
 tags          = ["ja3 fingerprint", "ja3 hash calculator", "ja3n normalized", "tls fingerprint", "clienthello fingerprint", "ja3 md5", "tls client fingerprint", "grease rfc 8701", "suricata ja3", "threat intelligence"]
 h1            = "JA3 Fingerprint Calculator"

--- a/blocks/ja4-server-fingerprint/page/meta.toml
+++ b/blocks/ja4-server-fingerprint/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "ja4-server-fingerprint"
-title         = "JA4S Fingerprint Calculator — compute the JA4S TLS server hash from a ServerHello — gizza.ai"
+title         = "JA4S Fingerprint Calculator — compute the JA4S TLS server hash from a ServerHello"
 description   = "Compute a JA4S server fingerprint from a TLS ServerHello in hex — the JA4+ server hash of version, ALPN, cipher, and extensions. Nothing is uploaded."
 tags          = ["ja4s fingerprint", "ja4s calculator", "ja4 server fingerprint", "ja4+ tls", "serverhello fingerprint", "tls server fingerprint", "ja4s hash", "foxio ja4", "tls fingerprinting", "threat intelligence"]
 h1            = "JA4S Fingerprint Calculator"

--- a/blocks/join-lines/page/meta.toml
+++ b/blocks/join-lines/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "join-lines"
-title         = "Join Lines — merge multiple lines into one with any separator — gizza.ai"
+title         = "Join Lines — merge multiple lines into one with any separator"
 description   = "Join lines of text into one line with any separator — comma, space, tab or custom. Trim, drop blanks, add a prefix/suffix. Free, runs in your browser."
 tags          = ["join lines", "combine lines", "merge lines", "lines to one line", "comma separated list", "text join", "lines to csv"]
 h1            = "Join Lines"

--- a/blocks/jq-query/page/meta.toml
+++ b/blocks/jq-query/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "jq-query"
-title         = "Run jq on JSON Online — gizza.ai"
+title         = "Run jq on JSON Online"
 description   = "Run a jq program against any JSON document right in your browser — filter, map, select, reshape. Pure-Rust jq (jaq), nothing is uploaded, free."
 tags          = ["jq", "json query", "jq online", "json filter", "jq playground", "transform json"]
 h1            = "Run jq on JSON"

--- a/blocks/js-beautify/page/meta.toml
+++ b/blocks/js-beautify/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "js-beautify"
-title         = "JavaScript Beautifier — format & re-indent minified JS — gizza.ai"
+title         = "JavaScript Beautifier — format & re-indent minified JS"
 description   = "Re-indent minified or obfuscated JavaScript into clean, readable source — strings, regex and comments preserved. Free, in your browser; nothing uploaded."
 tags          = ["javascript beautifier", "js beautifier", "format javascript", "unminify javascript", "pretty print javascript", "js formatter"]
 h1            = "JavaScript Beautifier"

--- a/blocks/js-minify/page/meta.toml
+++ b/blocks/js-minify/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "js-minify"
-title         = "JavaScript Minifier — shrink & compress JS online — gizza.ai"
+title         = "JavaScript Minifier — shrink & compress JS online"
 description   = "Minify JavaScript online: strip whitespace, line breaks and comments without changing behavior — strings and regex kept verbatim. Free, in-browser, no upload."
 tags          = ["javascript minifier", "js minifier", "minify javascript", "compress javascript", "js compressor", "shrink javascript"]
 h1            = "JavaScript Minifier"

--- a/blocks/json-beautify/page/meta.toml
+++ b/blocks/json-beautify/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "json-beautify"
-title         = "JSON Beautifier — pretty-print & validate JSON — gizza.ai"
+title         = "JSON Beautifier — pretty-print & validate JSON"
 description   = "Pretty-print minified or messy JSON with configurable indentation (or minify it), validating it in the process. Runs in your browser; nothing is uploaded."
 tags          = ["json beautifier", "json formatter", "pretty print json", "validate json", "minify json", "format json"]
 h1            = "JSON Beautifier"

--- a/blocks/json-diff/page/meta.toml
+++ b/blocks/json-diff/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "json-diff"
-title         = "JSON Diff — compare two JSON documents — gizza.ai"
+title         = "JSON Diff — compare two JSON documents"
 description   = "Compare two JSON documents and see exactly what was added, removed or changed, with full JSON paths — in your browser. Nothing is uploaded."
 tags          = ["json diff", "compare json", "json compare", "json difference", "diff json online"]
 h1            = "JSON Diff"

--- a/blocks/json-escape/page/meta.toml
+++ b/blocks/json-escape/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "json-escape"
-title         = "JSON Escape / Unescape — gizza.ai"
+title         = "JSON Escape / Unescape"
 description   = "Escape or unescape special characters in a string for safe use inside JSON — quotes, backslashes, newlines, control chars. Runs in your browser; nothing uploaded."
 tags          = ["json escape", "json unescape", "escape string", "json string", "escape quotes", "unescape json"]
 h1            = "JSON Escape / Unescape"

--- a/blocks/json-ld-generator/page/meta.toml
+++ b/blocks/json-ld-generator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "json-ld-generator"
-title         = "JSON-LD Schema Markup Generator — gizza.ai"
+title         = "JSON-LD Schema Markup Generator"
 description   = "Generate schema.org JSON-LD structured data for Article, Product, FAQ, Organization, Event, Recipe and more — a ready-to-paste script tag, free in your browser."
 tags          = ["json-ld", "schema.org", "structured data", "rich results", "seo", "faq schema", "product schema", "article schema", "google rich snippets"]
 h1            = "JSON-LD Schema Markup Generator"

--- a/blocks/json-merge/page/meta.toml
+++ b/blocks/json-merge/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "json-merge"
-title         = "JSON Merge — deep-merge JSON objects — gizza.ai"
+title         = "JSON Merge — deep-merge JSON objects"
 description   = "Deep-merge two or more JSON objects, with configurable array handling and last-wins conflict resolution — in your browser. Nothing is uploaded."
 tags          = ["json merge", "deep merge json", "combine json", "merge objects", "json patch"]
 h1            = "JSON Merge"

--- a/blocks/json-redact/page/meta.toml
+++ b/blocks/json-redact/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "json-redact"
-title         = "JSON Redact — Mask Secrets, API Keys & Tokens in JSON — gizza.ai"
+title         = "JSON Redact — Mask Secrets, API Keys & Tokens in JSON"
 description   = "Detect and mask secrets — API keys, tokens, passwords, private keys and emails — in a JSON document before sharing. Structure-aware, in your browser, nothing uploaded."
 tags          = ["json redact", "mask secrets", "redact api keys", "remove tokens", "sanitize json", "hide passwords", "json privacy", "scrub secrets"]
 h1            = "JSON Redact"

--- a/blocks/json-to-typescript/page/meta.toml
+++ b/blocks/json-to-typescript/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "json-to-typescript"
-title         = "JSON to TypeScript Interfaces — gizza.ai"
+title         = "JSON to TypeScript Interfaces"
 description   = "Paste JSON and get TypeScript interfaces — nested types, optional fields, and unions inferred automatically. Runs in your browser, nothing is uploaded, free."
 tags          = ["json to typescript", "ts interfaces", "json to ts", "type generator", "infer types"]
 h1            = "JSON to TypeScript"

--- a/blocks/json-yaml-convert/page/meta.toml
+++ b/blocks/json-yaml-convert/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "json-yaml-convert"
-title         = "JSON ⇄ YAML ⇄ TOML Converter — gizza.ai"
+title         = "JSON ⇄ YAML ⇄ TOML Converter"
 description   = "Convert config data between JSON, YAML, and TOML in any direction — in your browser. Round-trips through a common model. Nothing is uploaded."
 tags          = ["json to toml", "yaml to toml", "toml to json", "json yaml toml", "config converter", "toml converter"]
 h1            = "JSON ⇄ YAML ⇄ TOML"

--- a/blocks/json-yaml-converter/page/meta.toml
+++ b/blocks/json-yaml-converter/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "json-yaml-converter"
-title         = "JSON ⇄ YAML Converter Online — gizza.ai"
+title         = "JSON ⇄ YAML Converter Online"
 description   = "Convert between JSON and YAML in either direction, right in your browser. Auto-detects the input format. Nothing is uploaded, free."
 tags          = ["json to yaml", "yaml to json", "json yaml converter", "yaml convert", "config converter"]
 h1            = "JSON ⇄ YAML Converter"

--- a/blocks/jsonata-query/page/meta.toml
+++ b/blocks/jsonata-query/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "jsonata-query"
-title         = "JSONata Online — Query & Transform JSON | gizza.ai"
+title         = "JSONata Online — Query & Transform JSON"
 description   = "Run a JSONata expression against any JSON document right in your browser — query, filter, aggregate, and reshape JSON. Pure-Rust engine, nothing is uploaded, free."
 tags          = ["jsonata", "json query", "jsonata online", "json transform", "jsonata playground", "json query language"]
 h1            = "Query & transform JSON with JSONata"

--- a/blocks/jsonpath-query/page/meta.toml
+++ b/blocks/jsonpath-query/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "jsonpath-query"
-title         = "JSONPath Query Online (RFC 9535) — gizza.ai"
+title         = "JSONPath Query Online (RFC 9535)"
 description   = "Evaluate JSONPath expressions (RFC 9535) against any JSON in your browser — wildcards, slices, recursive descent, filters. Free, private, nothing uploaded."
 tags          = ["jsonpath", "json query", "jsonpath online", "jsonpath evaluator", "rfc 9535", "json filter"]
 h1            = "JSONPath Query"

--- a/blocks/jwk-thumbprint/page/meta.toml
+++ b/blocks/jwk-thumbprint/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "jwk-thumbprint"
-title         = "JWK Thumbprint (RFC 7638) — gizza.ai"
+title         = "JWK Thumbprint (RFC 7638)"
 description   = "Compute the RFC 7638 SHA-256 thumbprint of a JSON Web Key — the canonical kid — in your browser. Supports RSA, EC, OKP, and oct keys. Nothing is uploaded."
 tags          = ["jwk thumbprint", "rfc 7638", "jwk kid", "json web key", "key fingerprint", "jose"]
 h1            = "JWK Thumbprint"

--- a/blocks/jwt-decode/page/meta.toml
+++ b/blocks/jwt-decode/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "jwt-decode"
-title         = "JWT Decode — Decodes a JSON Web Token offline — gizza.ai"
+title         = "JWT Decode — Decodes a JSON Web Token offline"
 description   = "Decode any compact JSON Web Token (JWT) offline to inspect its header, payload claims, signature, and time-based validations. No data leaves your device."
 tags          = ["jwt decode", "jwt decoder", "json web token", "jws", "decode jwt", "offline jwt decoder", "base64url decode jwt"]
 h1            = "JWT decode"

--- a/blocks/jwt-sign/page/meta.toml
+++ b/blocks/jwt-sign/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "jwt-sign"
-title         = "JWT Sign — Create a signed JSON Web Token (HS/RS/ES) — gizza.ai"
+title         = "JWT Sign — Create a signed JSON Web Token (HS/RS/ES)"
 description   = "Sign a JSON Web Token (JWT) from a payload with HS256/384/512, RS256/384/512 or ES256/384 in your browser. The secret and key never leave your device."
 tags          = ["jwt sign", "jwt generator", "json web token", "jws", "hs256", "rs256", "es256", "jwt encoder"]
 h1            = "JWT sign"

--- a/blocks/jwt-verify/page/meta.toml
+++ b/blocks/jwt-verify/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "jwt-verify"
-title         = "JWT Verify — Validate a JSON Web Token signature & claims — gizza.ai"
+title         = "JWT Verify — Validate a JSON Web Token signature & claims"
 description   = "Verify a JWT signature (HS256/384/512, RS256/384/512, ES256/384) and its exp, nbf, iss and aud claims in your browser — token and key never leave your device."
 tags          = ["jwt verify", "jwt validator", "json web token", "jws", "verify jwt signature", "hs256", "rs256", "es256", "jwt decoder"]
 h1            = "JWT verify"

--- a/blocks/keccak-hash/page/meta.toml
+++ b/blocks/keccak-hash/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "keccak-hash"
-title         = "Keccak-256 Hash Generator (Ethereum) — Keccak-256 / Keccak-512 | gizza.ai"
+title         = "Keccak-256 Hash Generator (Ethereum) — Keccak-256 / Keccak-512"
 description   = "Compute the original Keccak-256 or Keccak-512 hash of any text in your browser — the exact hash Ethereum uses, not FIPS SHA-3. Free and private."
 tags          = ["keccak", "keccak-256", "keccak256", "keccak-512", "ethereum", "evm", "sha3", "hash", "digest", "hex", "base64", "cryptography"]
 h1            = "Keccak-256 Hash Generator"

--- a/blocks/latex-table/page/meta.toml
+++ b/blocks/latex-table/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "latex-table"
-title         = "CSV to LaTeX Table — tabular & booktabs generator — gizza.ai"
+title         = "CSV to LaTeX Table — tabular & booktabs generator"
 description   = "Convert CSV or TSV data into a LaTeX tabular environment (booktabs, grid, or plain), in your browser. Free, private, no upload."
 tags          = ["csv to latex", "latex table generator", "tsv to latex", "booktabs table", "latex tabular"]
 h1            = "CSV to LaTeX table"

--- a/blocks/latex-to-mathml/page/meta.toml
+++ b/blocks/latex-to-mathml/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "latex-to-mathml"
-title         = "LaTeX to MathML Converter — gizza.ai"
+title         = "LaTeX to MathML Converter"
 description   = "Convert LaTeX math to MathML in your browser — accessible <math> markup for HTML, EPUB and Office, with block or inline mode and pretty-print. Free, private."
 tags          = ["latex to mathml", "mathml", "latex", "math markup", "accessible math", "html math", "epub math", "tex to mathml", "mathml converter"]
 h1            = "LaTeX → MathML Converter"

--- a/blocks/link-extractor/page/meta.toml
+++ b/blocks/link-extractor/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "link-extractor"
-title         = "Link Extractor — Pull Hyperlinks & Anchors from HTML or Markdown — gizza.ai"
+title         = "Link Extractor — Pull Hyperlinks & Anchors from HTML or Markdown"
 description   = "Extract every hyperlink and in-page anchor from pasted HTML or Markdown — URL, link text, relative-link flags, text or JSON output. Free, in your browser."
 tags          = ["link extractor", "extract links from html", "extract links from markdown", "list all hyperlinks", "anchor extractor"]
 h1            = "Link Extractor"

--- a/blocks/list-converter/page/meta.toml
+++ b/blocks/list-converter/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "list-converter"
-title         = "List Converter — Reformat, Clean, and Sort Lists — gizza.ai"
+title         = "List Converter — Reformat, Clean, and Sort Lists"
 description   = "Convert, clean and sort lists online — comma-separated to lines, SQL IN, JSON, XML or custom delimiters, with prefix, dedupe and case options. Free, in-browser."
 tags          = ["list converter", "comma to lines", "sql list formatter", "json list maker", "dedupe list", "sort list", "add prefix to list"]
 h1            = "List Converter"

--- a/blocks/list-set-diff/page/meta.toml
+++ b/blocks/list-set-diff/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "list-set-diff"
-title         = "Compare Two Lists — Only in A, Only in B, Shared | gizza.ai"
+title         = "Compare Two Lists — Only in A, Only in B, Shared"
 description   = "Compare two lists as sets and see which items are only in A, only in B, or shared — with counts. Ignore case, trim, dedupe, and leading zeros. Runs in your browser."
 tags          = ["list", "diff", "compare", "set", "text"]
 h1            = "Compare Two Lists"

--- a/blocks/log-analyzer/page/meta.toml
+++ b/blocks/log-analyzer/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "log-analyzer"
-title         = "Log Analyzer — Level Counts, Top Errors & Volume Timeline — gizza.ai"
+title         = "Log Analyzer — Level Counts, Top Errors & Volume Timeline"
 description   = "Free log analyzer — paste JSON/NDJSON, logfmt, syslog or Apache/nginx logs and get level counts, grouped top errors, time span, and a volume timeline."
 tags          = ["log analyzer", "log analysis", "error summary", "log level counts", "top errors", "log timeline", "json logs", "ndjson", "logfmt", "syslog analyzer", "apache access log", "nginx access log", "log stats"]
 h1            = "Log Analyzer"

--- a/blocks/log-parser/page/meta.toml
+++ b/blocks/log-parser/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "log-parser"
-title         = "Log Parser — JSON, logfmt, syslog & Apache/nginx Access Logs — gizza.ai"
+title         = "Log Parser — JSON, logfmt, syslog & Apache/nginx Access Logs"
 description   = "Free log parser — auto-detects JSON/NDJSON, logfmt, syslog and Apache/nginx access logs into a filterable table, JSON, or CSV. Runs in your browser, no upload."
 tags          = ["log parser", "log viewer", "log analyzer", "json logs", "ndjson", "logfmt", "syslog parser", "apache access log", "nginx access log", "combined log format", "clf", "log to csv", "log to table"]
 h1            = "Log Parser"

--- a/blocks/loop-video/page/meta.toml
+++ b/blocks/loop-video/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "loop-video"
-title         = "Loop a Video Online — gizza.ai"
+title         = "Loop a Video Online"
 description   = "Loop a video or GIF into one continuous file — repeat it N times or fill a target duration, free and in your browser with nothing uploaded."
 tags          = ["loop video", "repeat video", "loop gif", "video loop", "repeat clip"]
 h1            = "Loop a Video"

--- a/blocks/luhn-checkdigit/page/meta.toml
+++ b/blocks/luhn-checkdigit/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "luhn-checkdigit"
-title         = "Luhn Check Digit Calculator — Generate the Check Digit — gizza.ai"
+title         = "Luhn Check Digit Calculator — Generate the Check Digit"
 description   = "Compute the Luhn (mod-10) check digit for a partial number and get the completed, valid number — instantly, in your browser. Nothing is uploaded, free."
 tags          = ["luhn check digit", "check digit calculator", "mod 10", "checksum generator", "credit card check digit", "imei check digit"]
 h1            = "Luhn Check Digit Calculator"

--- a/blocks/luhn-validate/page/meta.toml
+++ b/blocks/luhn-validate/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "luhn-validate"
-title         = "Luhn Validator — Check a Card / IMEI Number — gizza.ai"
+title         = "Luhn Validator — Check a Card / IMEI Number"
 description   = "Validate a credit card, IMEI, or any number against the Luhn check-digit algorithm — instantly, in your browser. Nothing is uploaded, free."
 tags          = ["luhn", "credit card validator", "imei check", "checksum", "card number validator", "mod 10"]
 h1            = "Luhn Validator"

--- a/blocks/lz-string-compress/page/meta.toml
+++ b/blocks/lz-string-compress/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "lz-string-compress"
-title         = "LZ-String Compress & Decompress — gizza.ai"
+title         = "LZ-String Compress & Decompress"
 description   = "Compress and decompress text with LZ-String in your browser — Base64, URL-safe, or UTF-16 output, byte-compatible with the lz-string JS library. Free, private."
 tags          = ["lz-string", "lzstring", "compress", "decompress", "base64", "url safe", "encodeduricomponent", "utf16", "localstorage"]
 h1            = "LZ-String Compress / Decompress"

--- a/blocks/lznt1-decompress/page/meta.toml
+++ b/blocks/lznt1-decompress/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "lznt1-decompress"
-title         = "LZNT1 Decompress — Decode RtlCompressBuffer Blobs — gizza.ai"
+title         = "LZNT1 Decompress — Decode RtlCompressBuffer Blobs"
 description   = "Decompress LZNT1 (Windows RtlCompressBuffer) blobs from hex or Base64 in your browser — registry hives, hiberfil, malware configs. Free, private, no sign-up."
 tags          = ["lznt1", "lznt1 decompress", "rtldecompressbuffer", "rtlcompressbuffer", "ntfs compression", "registry hive", "hibernation file", "malware analysis", "forensics", "compression_format_lznt1"]
 h1            = "LZNT1 Decompress"

--- a/blocks/mac-address-format/page/meta.toml
+++ b/blocks/mac-address-format/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "mac-address-format"
-title         = "MAC Address Format Converter — colon, hyphen, Cisco, bare — gizza.ai"
+title         = "MAC Address Format Converter — colon, hyphen, Cisco, bare"
 description   = "Reformat MAC addresses between colon, hyphen, Cisco dotted-quad, and bare hex — in lower or upper case. Paste one or many; runs in your browser, nothing uploaded."
 tags          = ["mac address format", "mac address converter", "colon to hyphen mac", "cisco mac format", "bare mac", "eui-48", "eui-64", "uppercase mac"]
 h1            = "MAC Address Format Converter"

--- a/blocks/mac-vendor-lookup/page/meta.toml
+++ b/blocks/mac-vendor-lookup/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "mac-vendor-lookup"
-title         = "MAC Address Vendor Lookup — gizza.ai"
+title         = "MAC Address Vendor Lookup"
 description   = "Look up the manufacturer of any MAC address from its OUI prefix with the bundled IEEE registry — colon, hyphen, dot or bare hex. Offline, free, in-browser."
 tags          = ["mac address lookup", "oui lookup", "mac vendor", "ieee oui", "network", "ethernet", "vendor lookup", "device manufacturer", "mac address"]
 h1            = "MAC Address Vendor Lookup"

--- a/blocks/macd-calculator/page/meta.toml
+++ b/blocks/macd-calculator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "macd-calculator"
-title         = "MACD Calculator (MACD Line, Signal & Histogram) — gizza.ai"
+title         = "MACD Calculator (MACD Line, Signal & Histogram)"
 description   = "Compute the MACD indicator from any price series — MACD line, signal line and histogram, with configurable 12/26/9 EMA periods. Free, private, in-browser."
 tags          = ["macd", "macd calculator", "moving average convergence divergence", "signal line", "macd histogram", "ema", "technical analysis", "momentum indicator", "trading indicator", "stock prices"]
 h1            = "MACD Calculator"

--- a/blocks/magnet-link-parser/page/meta.toml
+++ b/blocks/magnet-link-parser/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "magnet-link-parser"
-title         = "Magnet Link Parser & Builder — decode magnet: URIs — gizza.ai"
+title         = "Magnet Link Parser & Builder — decode magnet: URIs"
 description   = "Parse a BitTorrent magnet link into info-hash, display name, trackers, and web seeds — or build one from parts. Runs in your browser, nothing uploaded."
 tags          = ["magnet link parser", "magnet uri", "parse magnet link", "bittorrent magnet", "info hash", "btih", "magnet link builder", "torrent magnet decoder"]
 h1            = "Magnet Link Parser & Builder"

--- a/blocks/markdown-lint/page/meta.toml
+++ b/blocks/markdown-lint/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "markdown-lint"
-title         = "Markdown Linter — check & auto-fix Markdown style — gizza.ai"
+title         = "Markdown Linter — check & auto-fix Markdown style"
 description   = "Lint Markdown for trailing whitespace, hard tabs, heading spacing, list-marker consistency and more — then auto-fix it. Runs in your browser, nothing uploaded."
 tags          = ["markdown lint", "markdownlint", "markdown linter", "fix markdown", "markdown style check", "format markdown"]
 h1            = "Markdown Linter"

--- a/blocks/markdown-render/page/meta.toml
+++ b/blocks/markdown-render/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "markdown-render"
-title         = "Markdown to HTML Renderer — gizza.ai"
+title         = "Markdown to HTML Renderer"
 description   = "Render Markdown to sanitized HTML in your browser — tables, code blocks, task lists, and footnotes supported. Free, private, no upload."
 tags          = ["markdown to html", "render markdown", "md to html", "markdown renderer", "github flavored markdown", "sanitized html"]
 h1            = "Markdown to HTML"

--- a/blocks/markdown-section-extractor/page/meta.toml
+++ b/blocks/markdown-section-extractor/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "markdown-section-extractor"
-title         = "Markdown Section Extractor — Pull One Section by Heading | gizza.ai"
+title         = "Markdown Section Extractor — Pull One Section by Heading"
 description   = "Extract one section from a Markdown document by heading — keep or drop subsections, exact or substring match, ATX and setext. Free, in your browser."
 tags          = ["markdown", "section extractor", "heading", "extract section", "markdown parser", "split markdown", "subsection", "documentation", "readme"]
 h1            = "Markdown Section Extractor"

--- a/blocks/markdown-table-format/page/meta.toml
+++ b/blocks/markdown-table-format/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "markdown-table-format"
-title         = "Markdown Table Formatter — align & pretty-print GFM tables — gizza.ai"
+title         = "Markdown Table Formatter — align & pretty-print GFM tables"
 description   = "Format GitHub-flavored Markdown tables online — even column widths, tidy delimiter rows, alignment kept or forced. Free, in your browser, no upload."
 tags          = ["markdown table formatter", "format markdown table", "align markdown table", "markdown table generator", "pretty print markdown table", "gfm table"]
 h1            = "Markdown Table Formatter"

--- a/blocks/markdown-to-latex/page/meta.toml
+++ b/blocks/markdown-to-latex/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "markdown-to-latex"
-title         = "Markdown to LaTeX Converter — gizza.ai"
+title         = "Markdown to LaTeX Converter"
 description   = "Convert Markdown to LaTeX in your browser — headings, lists, tables, code blocks, links, math passthrough; body fragment or full document. Free, no upload."
 tags          = ["markdown to latex", "md to tex", "markdown to tex", "latex converter", "markdown latex", "tex generator", "booktabs table", "listings code"]
 h1            = "Markdown to LaTeX"

--- a/blocks/markdown-to-slides/page/meta.toml
+++ b/blocks/markdown-to-slides/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "markdown-to-slides"
-title         = "Markdown to Slides — Turn Markdown into an HTML Slide Deck — gizza.ai"
+title         = "Markdown to Slides — Turn Markdown into an HTML Slide Deck"
 description   = "Convert Markdown to a self-contained HTML slide deck in your browser — split slides with ---, arrow-key and swipe navigation, light or dark theme. Free, private."
 tags          = ["markdown to slides", "markdown presentation", "markdown slideshow", "html slide deck", "markdown to html slides", "slide generator", "markdown deck", "reveal markdown"]
 h1            = "Markdown to Slides"

--- a/blocks/mkv-to-mp4/page/meta.toml
+++ b/blocks/mkv-to-mp4/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "mkv-to-mp4"
-title         = "Convert MKV to MP4 Online — gizza.ai"
+title         = "Convert MKV to MP4 Online"
 description   = "Free MKV to MP4 converter that runs in your browser. Lossless stream-copy remux for H.264/HEVC clips, or re-encode VP9/AV1. Nothing is uploaded."
 tags          = ["mkv", "mp4", "convert", "video", "remux", "stream-copy", "matroska", "h264", "hevc", "vp9", "av1", "reencode"]
 h1            = "Convert MKV to MP4"

--- a/blocks/mock-data-generator/page/meta.toml
+++ b/blocks/mock-data-generator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "mock-data-generator"
-title         = "Mock Data Generator — Realistic Mock JSON from a Schema — gizza.ai"
+title         = "Mock Data Generator — Realistic Mock JSON from a Schema"
 description   = "Generate realistic mock JSON from a shorthand schema — your own fields, 30+ types, nested objects, arrays, and a seed to reproduce. Free, in-browser."
 tags          = ["mock data", "mock json", "test data generator", "json generator", "fake json", "sample data", "schema", "api mocking", "seed data", "dummy data"]
 h1            = "Mock Data Generator"

--- a/blocks/morse-code/page/meta.toml
+++ b/blocks/morse-code/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "morse-code"
-title         = "Morse Code Translator — Text to Morse & Back — gizza.ai"
+title         = "Morse Code Translator — Text to Morse & Back"
 description   = "Translate text to International Morse code and decode Morse back to text in your browser — A-Z, 0-9, punctuation, custom separators. Free and private."
 tags          = ["morse code", "morse translator", "text to morse", "morse to text", "morse decoder", "morse encoder", "international morse", "sos", "cw", "dot dash"]
 h1            = "Morse Code Translator"

--- a/blocks/mov-to-mp4/page/meta.toml
+++ b/blocks/mov-to-mp4/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "mov-to-mp4"
-title         = "Convert MOV to MP4 Online — gizza.ai"
+title         = "Convert MOV to MP4 Online"
 description   = "Free MOV to MP4 converter that runs in your browser. Lossless container remux (stream-copy) for H.264/HEVC clips, or re-encode ProRes. Nothing is uploaded."
 tags          = ["mov", "mp4", "convert", "video", "remux", "stream-copy", "quicktime", "iphone", "h264", "hevc", "prores", "reencode"]
 h1            = "Convert MOV to MP4"

--- a/blocks/moving-average/page/meta.toml
+++ b/blocks/moving-average/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "moving-average"
-title         = "Moving Average Calculator (SMA, EMA & WMA) — gizza.ai"
+title         = "Moving Average Calculator (SMA, EMA & WMA)"
 description   = "Calculate simple, exponential and weighted moving averages (SMA, EMA, WMA) over any number series with your chosen window. Free, private, in-browser."
 tags          = ["moving average", "sma", "ema", "wma", "simple moving average", "exponential moving average", "weighted moving average", "smoothing", "time series", "stock prices", "technical analysis"]
 h1            = "Moving Average Calculator"

--- a/blocks/mp4-to-m4a/page/meta.toml
+++ b/blocks/mp4-to-m4a/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "mp4-to-m4a"
-title         = "Extract M4A Audio from MP4 Online — gizza.ai"
+title         = "Extract M4A Audio from MP4 Online"
 description   = "Extract an MP4's audio track to M4A in your browser. Lossless stream-copy remux — no re-encode, no quality loss, nothing uploaded."
 tags          = ["mp4", "m4a", "extract audio", "audio", "remux", "stream-copy", "lossless", "no-reencode", "video to audio"]
 h1            = "Extract M4A Audio from MP4"

--- a/blocks/mp4-to-mkv/page/meta.toml
+++ b/blocks/mp4-to-mkv/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "mp4-to-mkv"
-title         = "Convert MP4 to MKV Online — gizza.ai"
+title         = "Convert MP4 to MKV Online"
 description   = "Free MP4 to MKV converter in your browser. Lossless stream-copy remux — keeps video, audio and subtitle tracks, nothing re-encoded or uploaded."
 tags          = ["mp4", "mkv", "convert", "video", "remux", "stream-copy", "matroska", "lossless", "no-reencode"]
 h1            = "Convert MP4 to MKV"

--- a/blocks/multi-encoder/page/meta.toml
+++ b/blocks/multi-encoder/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "multi-encoder"
-title         = "Multi Encoder — Base64 / Hex / Binary / Morse — gizza.ai"
+title         = "Multi Encoder — Base64 / Hex / Binary / Morse"
 description   = "Encode or decode text across Base64, hex, binary, URL-encoding, ROT13, and Morse — one tool, both directions. Runs in your browser, nothing uploaded, free."
 tags          = ["base64", "hex encode", "binary text", "url encode", "rot13", "morse code", "encoder decoder"]
 h1            = "Multi Encoder"

--- a/blocks/nt-hash/page/meta.toml
+++ b/blocks/nt-hash/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "nt-hash"
-title         = "NT / NTLM Hash Generator — gizza.ai"
+title         = "NT / NTLM Hash Generator"
 description   = "Generate the NT (NTLM) hash of a password — MD4 of its UTF-16LE encoding — instantly in your browser. Hex or base64 output. Free, private, nothing uploaded."
 tags          = ["nt-hash", "ntlm", "ntlm-hash", "md4", "windows-password", "pass-the-hash", "hash", "hex"]
 h1            = "NT / NTLM Hash Generator"

--- a/blocks/opml-converter/page/meta.toml
+++ b/blocks/opml-converter/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "opml-converter"
-title         = "OPML Converter — OPML ⇄ JSON ⇄ CSV — gizza.ai"
+title         = "OPML Converter — OPML ⇄ JSON ⇄ CSV"
 description   = "Convert OPML subscription files (podcast/RSS exports) to and from JSON and CSV in any direction — in your browser. Folders round-trip; nothing is uploaded."
 tags          = ["opml to json", "opml to csv", "json to opml", "csv to opml", "opml converter", "rss opml", "podcast opml export"]
 h1            = "OPML ⇄ JSON ⇄ CSV Converter"

--- a/blocks/otpauth-uri/page/meta.toml
+++ b/blocks/otpauth-uri/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "otpauth-uri"
-title         = "otpauth:// URI Generator — authenticator setup QR — gizza.ai"
+title         = "otpauth:// URI Generator — authenticator setup QR"
 description   = "Build an otpauth:// provisioning URI (TOTP/HOTP) from an issuer, account, and base32 secret to set up any authenticator app. The secret stays in your browser."
 tags          = ["otpauth", "totp", "hotp", "2fa", "authenticator", "qr code", "otp", "two-factor", "provisioning uri"]
 h1            = "otpauth:// URI generator"

--- a/blocks/outlier-detector/page/meta.toml
+++ b/blocks/outlier-detector/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "outlier-detector"
-title         = "Outlier Detector — flag outliers with z-score and IQR — gizza.ai"
+title         = "Outlier Detector — flag outliers with z-score and IQR"
 description   = "Find outliers in a list of numbers using the z-score, modified z-score (MAD) and IQR (Tukey's fences) methods, in your browser. Free, private, no upload."
 tags          = ["outlier detector", "z-score", "modified z-score", "iqr method", "tukey fences", "anomaly detection", "data cleaning"]
 h1            = "Outlier detector"

--- a/blocks/outline-to-json/page/meta.toml
+++ b/blocks/outline-to-json/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "outline-to-json"
-title         = "Outline to JSON Converter — gizza.ai"
+title         = "Outline to JSON Converter"
 description   = "Turn an indented text outline into nested JSON in your browser — spaces or tabs, children-array or nested-object shape, pretty or minified. Free, private."
 tags          = ["outline to json", "indented text to json", "tree to json", "nested json", "text outline", "json converter", "tab to json", "bullet list to json"]
 h1            = "Outline to JSON"

--- a/blocks/outline-to-mindmap/page/meta.toml
+++ b/blocks/outline-to-mindmap/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "outline-to-mindmap"
-title         = "Outline to Mind Map — turn an indented outline into an SVG mind map — gizza.ai"
+title         = "Outline to Mind Map — turn an indented outline into an SVG mind map"
 description   = "Paste an indented text outline and get a clean mind-map SVG in your browser — nothing uploaded. Indentation sets nesting; right or top-down layouts, dark theme."
 tags          = ["outline to mind map", "text to mind map", "mind map maker", "mind map svg", "outline mind map generator", "indented outline diagram"]
 h1            = "Outline to Mind Map"

--- a/blocks/page-weight-analyzer/page/meta.toml
+++ b/blocks/page-weight-analyzer/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "page-weight-analyzer"
-title         = "Page Weight Analyzer — Resource Counts & Render-Blocking Audit | gizza.ai"
+title         = "Page Weight Analyzer — Resource Counts & Render-Blocking Audit"
 description   = "Analyze page weight from pasted HTML — resource counts, render-blocking scripts and styles, inline JS/CSS sizes, and a page-weight budget. Free, in-browser."
 tags          = ["page weight", "page weight analyzer", "render blocking", "performance budget", "html analyzer", "resource counter", "web performance", "render-blocking css", "page size", "front-end audit"]
 h1            = "Page Weight Analyzer"

--- a/blocks/parse-datetime/page/meta.toml
+++ b/blocks/parse-datetime/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "parse-datetime"
-title         = "Date/Time Parser — parse any date string into structured parts — gizza.ai"
+title         = "Date/Time Parser — parse any date string into structured parts"
 description   = "Parse a date or time in almost any format — ISO 8601, RFC 2822, US/European dates — into year, month, day, weekday, ISO week and a canonical ISO 8601 value."
 tags          = ["date parser", "datetime parser", "parse date", "iso 8601", "rfc 3339", "rfc 2822", "date components", "weekday from date", "day of year", "iso week number", "timestamp parser"]
 h1            = "Date / Time Parser"

--- a/blocks/parse-ethernet-frame/page/meta.toml
+++ b/blocks/parse-ethernet-frame/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "parse-ethernet-frame"
-title         = "Ethernet Frame Parser — decode an Ethernet II / 802.3 frame from hex — gizza.ai"
+title         = "Ethernet Frame Parser — decode an Ethernet II / 802.3 frame from hex"
 description   = "Paste an Ethernet frame in hex and decode destination/source MAC, EtherType or 802.3 length, 802.1Q / Q-in-Q VLAN tags, and payload — free, in your browser."
 tags          = ["ethernet frame parser", "decode ethernet frame", "ethernet ii", "802.3 frame", "mac address", "ethertype", "802.1q vlan", "qinq", "frame hex decoder"]
 h1            = "Ethernet Frame Parser"

--- a/blocks/parse-grpc-frame/page/meta.toml
+++ b/blocks/parse-grpc-frame/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "parse-grpc-frame"
-title         = "gRPC Frame Parser — Decode gRPC Length-Prefixed Messages | gizza.ai"
+title         = "gRPC Frame Parser — Decode gRPC Length-Prefixed Messages"
 description   = "Parse gRPC length-prefixed frames from base64 or hex and decode each protobuf payload into a readable field tree. No .proto needed — free, in your browser."
 tags          = ["grpc", "grpc frame", "length-prefixed message", "protobuf", "decode grpc", "grpc wire format", "reverse engineering", "http2"]
 h1            = "gRPC Frame Parser"

--- a/blocks/parse-http-message/page/meta.toml
+++ b/blocks/parse-http-message/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "parse-http-message"
-title         = "HTTP Message Parser — decode a raw HTTP request or response — gizza.ai"
+title         = "HTTP Message Parser — decode a raw HTTP request or response"
 description   = "Parse a raw HTTP/1.x request or response — decode the method, target, status, version, all headers and the body, in your browser. Free, nothing uploaded."
 tags          = ["http message parser", "parse http request", "parse http response", "http header parser", "raw http", "http/1.1", "request line", "status line", "header decoder"]
 h1            = "HTTP Message Parser"

--- a/blocks/parse-ipv4-header/page/meta.toml
+++ b/blocks/parse-ipv4-header/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "parse-ipv4-header"
-title         = "IPv4 Header Parser — decode a raw IPv4 packet header from hex — gizza.ai"
+title         = "IPv4 Header Parser — decode a raw IPv4 packet header from hex"
 description   = "IPv4 header parser: paste hex and decode DSCP/ECN, flags, fragment offset, TTL, protocol, checksum validity, and addresses — free, in your browser."
 tags          = ["ipv4 header parser", "decode ipv4 header", "ip packet header", "ip header decoder", "dscp", "ecn", "ttl", "ip protocol number", "header checksum", "fragment offset"]
 h1            = "IPv4 Header Parser"

--- a/blocks/parse-query-string/page/meta.toml
+++ b/blocks/parse-query-string/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "parse-query-string"
-title         = "Query String Parser — gizza.ai"
+title         = "Query String Parser"
 description   = "Parse a URL query string into key/value pairs and structured JSON — repeated keys, PHP/Rails bracket notation, percent and + decoding. Free, in your browser."
 tags          = ["query string", "parse query string", "url parameters", "querystring", "parse url params", "bracket notation", "form urlencoded", "percent decode", "key value pairs"]
 h1            = "Query String Parser"

--- a/blocks/parse-tcp-header/page/meta.toml
+++ b/blocks/parse-tcp-header/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "parse-tcp-header"
-title         = "TCP Header Parser — decode a raw TCP segment header from hex — gizza.ai"
+title         = "TCP Header Parser — decode a raw TCP segment header from hex"
 description   = "Decode a raw TCP header from hex in your browser: ports, sequence/ack numbers, SYN/ACK/FIN flags, window, checksum and TCP options. Nothing is uploaded."
 tags          = ["tcp header parser", "decode tcp header", "tcp segment header", "tcp flags", "syn ack fin", "tcp options", "mss", "window scale", "sequence number", "tcp port"]
 h1            = "TCP Header Parser"

--- a/blocks/parse-tls-record/page/meta.toml
+++ b/blocks/parse-tls-record/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "parse-tls-record"
-title         = "TLS Record Parser — decode a TLS handshake / ClientHello from hex — gizza.ai"
+title         = "TLS Record Parser — decode a TLS handshake / ClientHello from hex"
 description   = "Decode TLS record bytes from hex in your browser — record header plus full ClientHello/ServerHello: cipher suites, SNI, ALPN, versions. Nothing is uploaded."
 tags          = ["tls record parser", "decode tls handshake", "clienthello parser", "serverhello", "tls cipher suites", "sni", "alpn", "supported_versions", "tls 1.3", "tls extensions"]
 h1            = "TLS Record Parser"

--- a/blocks/parse-udp-header/page/meta.toml
+++ b/blocks/parse-udp-header/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "parse-udp-header"
-title         = "UDP Header Parser — decode a raw UDP datagram header from hex — gizza.ai"
+title         = "UDP Header Parser — decode a raw UDP datagram header from hex"
 description   = "Decode a UDP header from hex — source and destination ports with service names, length, payload size, and checksum. Free, private, runs in your browser."
 tags          = ["udp header parser", "decode udp header", "udp datagram header", "udp port", "udp length", "udp checksum", "rfc 768", "dns port 53", "ntp port 123", "quic port 443"]
 h1            = "UDP Header Parser"

--- a/blocks/parse-uri/page/meta.toml
+++ b/blocks/parse-uri/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "parse-uri"
-title         = "URI Parser — split a URL into scheme, host, path, query & fragment — gizza.ai"
+title         = "URI Parser — split a URL into scheme, host, path, query & fragment"
 description   = "Parse a URI or URL into scheme, user info, host, port, path, percent-decoded query parameters, and fragment — free and private, right in your browser."
 tags          = ["uri parser", "url parser", "parse url", "url components", "query string parser", "rfc 3986", "url breakdown", "host port path", "url decoder"]
 h1            = "URI / URL Parser"

--- a/blocks/parse-websocket-frame/page/meta.toml
+++ b/blocks/parse-websocket-frame/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "parse-websocket-frame"
-title         = "WebSocket Frame Parser — Decode RFC 6455 Frames (FIN, Opcode, Mask, Payload) | gizza.ai"
+title         = "WebSocket Frame Parser — Decode RFC 6455 Frames (FIN, Opcode, Mask, Payload)"
 description   = "Decode a WebSocket frame (RFC 6455) from base64 or hex — FIN, RSV bits, opcode, mask flag, payload length, masking key, unmasked payload — in your browser."
 tags          = ["websocket", "websocket frame", "rfc 6455", "ws frame", "frame decoder", "opcode", "masking key", "unmask payload", "web sockets"]
 h1            = "WebSocket Frame Parser"

--- a/blocks/password-entropy/page/meta.toml
+++ b/blocks/password-entropy/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "password-entropy"
-title         = "Password Strength / Entropy Checker — gizza.ai"
+title         = "Password Strength / Entropy Checker"
 description   = "Estimate a password's entropy in bits and crack time, and flag weaknesses — entirely in your browser. Your password is never sent anywhere, free."
 tags          = ["password strength", "password entropy", "password checker", "bits of entropy", "crack time"]
 h1            = "Password Strength Checker"

--- a/blocks/password-generator/page/meta.toml
+++ b/blocks/password-generator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "password-generator"
-title         = "Password & Passphrase Generator — gizza.ai"
+title         = "Password & Passphrase Generator"
 description   = "Generate strong random passwords or passphrases with configurable length, character sets, and word count — entirely in your browser, nothing uploaded, free."
 tags          = ["password generator", "passphrase generator", "random password", "strong password", "secure password"]
 h1            = "Password Generator"

--- a/blocks/pbkdf2-derive/page/meta.toml
+++ b/blocks/pbkdf2-derive/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "pbkdf2-derive"
-title         = "PBKDF2 Key Derivation — derive a key from a password — gizza.ai"
+title         = "PBKDF2 Key Derivation — derive a key from a password"
 description   = "Derive a key from a password with PBKDF2-HMAC (SHA-1/256/512). Pick iterations, salt, length and hex/base64 output — all in your browser. Nothing is uploaded."
 tags          = ["pbkdf2", "key derivation", "kdf", "pbkdf2-hmac-sha256", "derive key from password", "rfc 2898", "rfc 8018", "password based key derivation"]
 h1            = "PBKDF2 key derivation"

--- a/blocks/pem-der-convert/page/meta.toml
+++ b/blocks/pem-der-convert/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "pem-der-convert"
-title         = "PEM to DER & DER to PEM Converter — gizza.ai"
+title         = "PEM to DER & DER to PEM Converter"
 description   = "Convert keys, certificates and CSRs between PEM (base64 text) and DER (binary, shown as hex or base64) in either direction. Runs in your browser, nothing uploaded, free."
 tags          = ["pem to der", "der to pem", "convert certificate", "pem decode", "der encode", "x509 converter", "csr converter"]
 h1            = "PEM ⇄ DER Converter"

--- a/blocks/pem-public-key-extract/page/meta.toml
+++ b/blocks/pem-public-key-extract/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "pem-public-key-extract"
-title         = "Extract Public Key from Private Key (PEM) — gizza.ai"
+title         = "Extract Public Key from Private Key (PEM)"
 description   = "Derive the public key from an RSA, EC (P-256/P-384) or Ed25519 private key as a PEM public-key block. Free, in your browser — nothing is uploaded."
 tags          = ["extract public key", "private key to public key", "pem public key", "openssl pkey pubout", "rsa public key", "ec public key", "ed25519 public key"]
 h1            = "Extract Public Key from a Private Key"

--- a/blocks/pem-to-jwk/page/meta.toml
+++ b/blocks/pem-to-jwk/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "pem-to-jwk"
-title         = "PEM to JWK Converter — gizza.ai"
+title         = "PEM to JWK Converter"
 description   = "Convert a PEM-encoded RSA or EC key into a JSON Web Key (JWK), in your browser. Nothing is uploaded."
 tags          = ["pem", "jwk", "rsa", "ec", "json web key", "crypto", "developer"]
 h1            = "PEM → JWK converter"

--- a/blocks/percentage-calculator/page/meta.toml
+++ b/blocks/percentage-calculator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "percentage-calculator"
-title         = "Percentage Calculator — Percent Of, Percent Change & Share of Total — gizza.ai"
+title         = "Percentage Calculator — Percent Of, Percent Change & Share of Total"
 description   = "Free percentage calculator: what is P% of X, what percent X is of Y, percent increase or decrease, and share of a total. Private, runs in your browser."
 tags          = ["percentage calculator", "percent of a number", "percent change calculator", "percent increase calculator", "percent decrease calculator", "what percent calculator", "percentage of total", "percent difference"]
 h1            = "Percentage Calculator"

--- a/blocks/period-predictor/page/meta.toml
+++ b/blocks/period-predictor/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "period-predictor"
-title         = "Period Predictor — Next Period, Ovulation & Fertile Window Dates — gizza.ai"
+title         = "Period Predictor — Next Period, Ovulation & Fertile Window Dates"
 description   = "Predict your next period start dates from your last period and cycle length, with ovulation estimates and fertile windows. Free, private, in-browser."
 tags          = ["period predictor", "period calculator", "menstrual cycle calculator", "next period date", "ovulation calculator", "fertile window", "cycle length", "period tracker", "when is my next period"]
 h1            = "Period Predictor"

--- a/blocks/pgp-key-info/page/meta.toml
+++ b/blocks/pgp-key-info/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "pgp-key-info"
-title         = "PGP Key Info — OpenPGP fingerprint inspector — gizza.ai"
+title         = "PGP Key Info — OpenPGP fingerprint inspector"
 description   = "Inspect an ASCII-armored PGP public or private key locally: fingerprint, key ID, algorithm, user IDs, dates, and subkeys."
 tags          = ["pgp key info", "openpgp fingerprint", "gpg key id", "pgp public key inspector"]
 h1            = "PGP key info"

--- a/blocks/pgp-verify/page/meta.toml
+++ b/blocks/pgp-verify/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "pgp-verify"
-title         = "PGP Verify — Check an OpenPGP signature in your browser — gizza.ai"
+title         = "PGP Verify — Check an OpenPGP signature in your browser"
 description   = "Verify a PGP signature online — detached or clearsigned — against a message and public key; reports validity and signer key ID. Runs in your browser."
 tags          = ["pgp verify", "gpg verify", "openpgp signature", "verify pgp signature", "detached signature", "clearsign", "check signature", "pgp signature validator"]
 h1            = "PGP verify"

--- a/blocks/phishing-header-inspector/page/meta.toml
+++ b/blocks/phishing-header-inspector/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "phishing-header-inspector"
-title         = "Phishing Header Inspector — Check Email Headers | gizza.ai"
+title         = "Phishing Header Inspector — Check Email Headers"
 description   = "Paste raw email headers to flag From/Return-Path mismatches, Reply-To detours, failed SPF/DKIM/DMARC, and suspicious Received hops locally."
 tags          = ["email header analyzer", "phishing header checker", "spoofing detector", "spf dkim dmarc", "return path mismatch", "received headers", "email security"]
 h1            = "Phishing Header Inspector"

--- a/blocks/phone-format/page/meta.toml
+++ b/blocks/phone-format/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "phone-format"
-title         = "Phone Number Formatter & Validator — gizza.ai"
+title         = "Phone Number Formatter & Validator"
 description   = "Parse, validate and format any international phone number — E.164, national and international formats, country and line type. Free, in-browser."
 tags          = ["phone number", "validation", "E.164", "formatter"]
 h1            = "Phone Number Formatter & Validator"

--- a/blocks/photo-filter-presets/page/meta.toml
+++ b/blocks/photo-filter-presets/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "photo-filter-presets"
-title         = "Photo Filter Presets — gizza.ai"
+title         = "Photo Filter Presets"
 description   = "Apply a one-click photo filter — sepia, vintage, warm, cool, noir, grayscale, vivid, invert, or fade — right in your browser. No upload to a server, runs locally, free."
 tags          = ["photo", "filter", "presets", "sepia", "vintage", "grayscale", "black-and-white", "effects"]
 h1            = "Photo Filter Presets"

--- a/blocks/php-serialize/page/meta.toml
+++ b/blocks/php-serialize/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "php-serialize"
-title         = "JSON to PHP serialize() Converter — gizza.ai"
+title         = "JSON to PHP serialize() Converter"
 description   = "Convert JSON to PHP serialize() format in your browser — byte-accurate strings that PHP's unserialize() can read. Free, private, no sign-up."
 tags          = ["php serialize", "json to php", "unserialize", "php session", "wordpress options", "serialized array", "php array", "interop"]
 h1            = "JSON → PHP serialize()"

--- a/blocks/php-unserialize/page/meta.toml
+++ b/blocks/php-unserialize/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "php-unserialize"
-title         = "PHP unserialize() to JSON Converter — gizza.ai"
+title         = "PHP unserialize() to JSON Converter"
 description   = "Decode a PHP serialize() string to readable JSON in your browser. Inspect PHP sessions and WordPress wp_options values. Free, private, no sign-up."
 tags          = ["php unserialize", "php to json", "serialize", "php session", "wordpress options", "serialized array", "php array", "deserialize"]
 h1            = "PHP unserialize() → JSON"

--- a/blocks/pii-tokenize/page/meta.toml
+++ b/blocks/pii-tokenize/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "pii-tokenize"
-title         = "PII Tokenizer — Deterministic, Format-Preserving Pseudonyms — gizza.ai"
+title         = "PII Tokenizer — Deterministic, Format-Preserving Pseudonyms"
 description   = "Replace emails, phones, IPs, cards and SSNs with deterministic, format-preserving tokens. Same value maps to the same token, so data stays linkable. No upload."
 tags          = ["pii tokenizer", "pseudonymize", "format-preserving tokenization", "deterministic tokens", "de-identify text", "anonymize data", "referential integrity"]
 h1            = "PII Tokenizer"

--- a/blocks/pin-image-resizer/page/meta.toml
+++ b/blocks/pin-image-resizer/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "pin-image-resizer"
-title         = "Pinterest Pin Image Resizer — 1000×1500 (2:3) — gizza.ai"
+title         = "Pinterest Pin Image Resizer — 1000×1500 (2:3)"
 description   = "Resize and crop any image to a Pinterest pin size right in your browser — 1000×1500 (2:3), square, tall, or story. Smart crop, no upload, free."
 tags          = ["pinterest", "pin", "image", "resize", "2:3", "1000x1500", "crop"]
 h1            = "Pinterest Pin Image Resizer"

--- a/blocks/plist-viewer/page/meta.toml
+++ b/blocks/plist-viewer/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "plist-viewer"
-title         = "Plist Viewer — Apple Property List to JSON/tree — gizza.ai"
+title         = "Plist Viewer — Apple Property List to JSON/tree"
 description   = "Parse XML plist or Base64 binary bplist data and render it as readable JSON or a plutil-style tree. Free, private, in-browser."
 tags          = ["plist", "property list", "bplist", "apple", "json", "viewer"]
 h1            = "Plist viewer"

--- a/blocks/podcast-feed-parser/page/meta.toml
+++ b/blocks/podcast-feed-parser/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "podcast-feed-parser"
-title         = "Podcast Feed Parser — RSS/XML episode list to JSON — gizza.ai"
+title         = "Podcast Feed Parser — RSS/XML episode list to JSON"
 description   = "Parse a pasted podcast RSS/XML feed into clean JSON with episode titles, dates, durations, and audio enclosure URLs. Free, private, in-browser."
 tags          = ["podcast", "rss", "xml", "feed", "itunes", "episodes", "json"]
 h1            = "Podcast feed parser"

--- a/blocks/protobuf-decode/page/meta.toml
+++ b/blocks/protobuf-decode/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "protobuf-decode"
-title         = "Protobuf Decoder — Decode Protobuf Wire Bytes Without a .proto | gizza.ai"
+title         = "Protobuf Decoder — Decode Protobuf Wire Bytes Without a .proto"
 description   = "Decode raw protobuf wire bytes (base64 or hex) into a field-number/wire-type tree — no .proto schema needed, nested messages recursed. Free, in your browser."
 tags          = ["protobuf", "protocol buffers", "decode protobuf", "protobuf wire format", "grpc", "protobuf inspector", "no schema", "reverse engineering"]
 h1            = "Protobuf Wire Decoder"

--- a/blocks/qif-ofx-convert/page/meta.toml
+++ b/blocks/qif-ofx-convert/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "qif-ofx-convert"
-title         = "QIF & OFX to CSV Converter — Bank Export to Spreadsheet — gizza.ai"
+title         = "QIF & OFX to CSV Converter — Bank Export to Spreadsheet"
 description   = "Convert QIF, OFX and QFX bank exports to clean normalized CSV in your browser — Date, Amount, Payee, Memo, Category and more. Free, private, no upload."
 tags          = ["qif to csv", "ofx to csv", "qfx to csv", "bank statement to csv", "quicken to csv", "convert bank export", "transactions to csv", "budgeting import"]
 h1            = "QIF / OFX to CSV Converter"

--- a/blocks/rabbit-cipher/page/meta.toml
+++ b/blocks/rabbit-cipher/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "rabbit-cipher"
-title         = "Rabbit Cipher — Encrypt/decrypt with the Rabbit stream cipher — gizza.ai"
+title         = "Rabbit Cipher — Encrypt/decrypt with the Rabbit stream cipher"
 description   = "Encrypt or decrypt text with the Rabbit stream cipher (RFC 4503 / eSTREAM) — 128-bit key, optional 64-bit IV, hex or base64. Free, in-browser, no upload."
 tags          = ["rabbit", "rabbit cipher", "rabbit encrypt", "rabbit decrypt", "estream", "rfc 4503", "stream cipher"]
 h1            = "Rabbit cipher"

--- a/blocks/rake-keywords/page/meta.toml
+++ b/blocks/rake-keywords/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "rake-keywords"
-title         = "RAKE Keyword Extractor — gizza.ai"
+title         = "RAKE Keyword Extractor"
 description   = "Extract the top keywords and keyphrases from any document using the RAKE algorithm — ranked by relevance, right in your browser. Nothing is uploaded."
 tags          = ["rake", "keyword extraction", "keyphrase extraction", "keywords", "text analysis", "nlp", "extract keywords"]
 h1            = "RAKE Keyword Extractor"

--- a/blocks/random-token-generator/page/meta.toml
+++ b/blocks/random-token-generator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "random-token-generator"
-title         = "Random Token Generator — gizza.ai"
+title         = "Random Token Generator"
 description   = "Generate cryptographically secure random tokens, API keys, and secrets with a configurable length and character set — entirely in your browser, nothing uploaded, free."
 tags          = ["random token generator", "api key generator", "secret generator", "random string generator", "secure token"]
 h1            = "Random Token Generator"

--- a/blocks/rc2-cipher/page/meta.toml
+++ b/blocks/rc2-cipher/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "rc2-cipher"
-title         = "RC2 Cipher — Encrypt/decrypt with RC2 (ECB/CBC, RFC 2268) — gizza.ai"
+title         = "RC2 Cipher — Encrypt/decrypt with RC2 (ECB/CBC, RFC 2268)"
 description   = "Encrypt or decrypt with the RC2 block cipher (RFC 2268) in ECB or CBC mode, configurable effective key bits, hex or Base64 output — in your browser."
 tags          = ["rc2", "rc2 encrypt", "rc2 decrypt", "rfc 2268", "effective key length", "ecb", "cbc", "legacy cipher"]
 h1            = "RC2 cipher"

--- a/blocks/rc4-cipher/page/meta.toml
+++ b/blocks/rc4-cipher/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "rc4-cipher"
-title         = "RC4 Cipher — Encrypt/decrypt with RC4 (with drop-N) — gizza.ai"
+title         = "RC4 Cipher — Encrypt/decrypt with RC4 (with drop-N)"
 description   = "Encrypt or decrypt text with the RC4 stream cipher — optional drop-N to skip weak keystream bytes, hex or base64 output — free and in your browser."
 tags          = ["rc4", "rc4 encrypt", "rc4 decrypt", "rc4-drop", "stream cipher", "arcfour", "cipher"]
 h1            = "RC4 cipher"

--- a/blocks/rc6-cipher/page/meta.toml
+++ b/blocks/rc6-cipher/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "rc6-cipher"
-title         = "RC6 Cipher — Encrypt/decrypt with RC6 (ECB/CBC) — gizza.ai"
+title         = "RC6 Cipher — Encrypt/decrypt with RC6 (ECB/CBC)"
 description   = "Encrypt or decrypt data with RC6-32/20 in ECB or CBC mode with hex/base64 I/O — in your browser. For interop, learning, and CTFs. Nothing is uploaded."
 tags          = ["rc6", "rc6 encrypt", "rc6 decrypt", "block cipher", "ecb", "cbc", "aes finalist", "legacy cipher"]
 h1            = "RC6 cipher"

--- a/blocks/readability-score/page/meta.toml
+++ b/blocks/readability-score/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "readability-score"
-title         = "Readability Score — Flesch-Kincaid, Gunning-Fog & SMOG grader — gizza.ai"
+title         = "Readability Score — Flesch-Kincaid, Gunning-Fog & SMOG grader"
 description   = "Score any text for readability with Flesch Reading Ease, Flesch-Kincaid Grade, Gunning-Fog and SMOG, in your browser. Nothing is uploaded."
 tags          = ["readability score", "flesch reading ease", "flesch-kincaid grade", "gunning fog", "smog index", "reading level"]
 h1            = "Readability score"

--- a/blocks/redact-pii/page/meta.toml
+++ b/blocks/redact-pii/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "redact-pii"
-title         = "Redact PII — Mask emails, phones, IPs, cards, SSNs — gizza.ai"
+title         = "Redact PII — Mask emails, phones, IPs, cards, SSNs"
 description   = "Detect and redact PII (emails, phone numbers, IPs, credit-card and SSN numbers) in text, in your browser. Nothing is uploaded."
 tags          = ["redact pii", "mask pii", "remove personal data", "anonymize text", "scrub", "privacy"]
 h1            = "Redact PII"

--- a/blocks/regex-extract/page/meta.toml
+++ b/blocks/regex-extract/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "regex-extract"
-title         = "Regex Extract — Pull Every Match from Text — gizza.ai"
+title         = "Regex Extract — Pull Every Match from Text"
 description   = "Run a regular expression over text and extract every match — case-insensitive, multiline, dot-all, capture groups, dedupe. Free, in your browser."
 tags          = ["regex extract", "regex tester", "regex match", "extract matches", "regular expression", "capture group", "find all matches"]
 h1            = "Regex Extract"

--- a/blocks/regex-tester/page/meta.toml
+++ b/blocks/regex-tester/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "regex-tester"
-title         = "Regex Tester — Debug Patterns & Inspect Capture Groups — gizza.ai"
+title         = "Regex Tester — Debug Patterns & Inspect Capture Groups"
 description   = "Test regular expressions online — see every match with positions plus the value and span of each numbered and named capture group. Free, in-browser, no upload."
 tags          = ["regex tester", "test regex", "regular expression", "capture group", "regex debugger", "named groups", "regex match positions"]
 h1            = "Regex Tester"

--- a/blocks/remove-control-chars/page/meta.toml
+++ b/blocks/remove-control-chars/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "remove-control-chars"
-title         = "Remove Control Characters — Strip null bytes & non-printable chars — gizza.ai"
+title         = "Remove Control Characters — Strip null bytes & non-printable chars"
 description   = "Strip null bytes and non-printable control characters from text, in your browser. Keep tabs and newlines or remove them too. Nothing is uploaded."
 tags          = ["remove control characters", "strip null bytes", "remove non-printable characters", "clean text", "remove invisible characters"]
 h1            = "Remove control characters"

--- a/blocks/remove-duplicate-lines/page/meta.toml
+++ b/blocks/remove-duplicate-lines/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "remove-duplicate-lines"
-title         = "Remove Duplicate Lines — online deduplicator — gizza.ai"
+title         = "Remove Duplicate Lines — online deduplicator"
 description   = "Remove duplicate lines from text in your browser — keep first or last occurrence, ignore case or whitespace, uniq-style consecutive mode. Free, private."
 tags          = ["remove duplicate lines", "delete duplicate lines", "deduplicate text", "dedupe lines", "unique lines"]
 h1            = "Remove Duplicate Lines"

--- a/blocks/remove-whitespace/page/meta.toml
+++ b/blocks/remove-whitespace/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "remove-whitespace"
-title         = "Remove Whitespace — Trim, collapse, or strip whitespace — gizza.ai"
+title         = "Remove Whitespace — Trim, collapse, or strip whitespace"
 description   = "Trim leading/trailing whitespace, collapse extra spaces, or strip all whitespace from text, in your browser. Nothing is uploaded."
 tags          = ["remove whitespace", "trim text", "collapse spaces", "strip spaces", "remove extra spaces"]
 h1            = "Remove whitespace"

--- a/blocks/render-jinja2/page/meta.toml
+++ b/blocks/render-jinja2/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "render-jinja2"
-title         = "Jinja2 Template Renderer — gizza.ai"
+title         = "Jinja2 Template Renderer"
 description   = "Render a Jinja2 template against JSON or YAML data in your browser — variables, loops, conditionals and filters. Free, private, no upload."
 tags          = ["jinja2 renderer", "jinja template online", "jinja2 playground", "render jinja template", "template engine", "json to text", "yaml to text"]
 h1            = "Jinja2 Template Renderer"

--- a/blocks/render-template/page/meta.toml
+++ b/blocks/render-template/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "render-template"
-title         = "Handlebars / Mustache Template Renderer — gizza.ai"
+title         = "Handlebars / Mustache Template Renderer"
 description   = "Render a Handlebars or Mustache template against JSON data in your browser — {{variables}}, nested paths, {{#each}} loops and {{#if}} conditionals. Free, private."
 tags          = ["handlebars renderer", "mustache template", "render template online", "template engine", "json to text", "handlebars playground"]
 h1            = "Template Renderer"

--- a/blocks/rsa-encrypt/page/meta.toml
+++ b/blocks/rsa-encrypt/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "rsa-encrypt"
-title         = "RSA Encrypt — Encrypt a message to an RSA public key (OAEP / PKCS#1) — gizza.ai"
+title         = "RSA Encrypt — Encrypt a message to an RSA public key (OAEP / PKCS#1)"
 description   = "Encrypt a short message to an RSA public key (OAEP or PKCS#1 v1.5, SHA-256/384/512) and get base64 ciphertext, in your browser. Nothing is uploaded."
 tags          = ["rsa encrypt", "rsa oaep", "pkcs1", "public key encryption", "rsa cipher", "crypto"]
 h1            = "RSA encrypt"

--- a/blocks/rsa-sign/page/meta.toml
+++ b/blocks/rsa-sign/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "rsa-sign"
-title         = "RSA Sign — Sign a message with an RSA key (PKCS#1 / PSS) — gizza.ai"
+title         = "RSA Sign — Sign a message with an RSA key (PKCS#1 / PSS)"
 description   = "Sign a message with an RSA private key (PKCS#1 v1.5 or PSS, SHA-256/384/512) and get a base64 signature, in your browser. Nothing is uploaded."
 tags          = ["rsa sign", "rsa signature", "pkcs1", "rsa pss", "digital signature", "crypto"]
 h1            = "RSA sign"

--- a/blocks/rsa-verify/page/meta.toml
+++ b/blocks/rsa-verify/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "rsa-verify"
-title         = "RSA Verify — Verify an RSA signature (PKCS#1 / PSS) — gizza.ai"
+title         = "RSA Verify — Verify an RSA signature (PKCS#1 / PSS)"
 description   = "Verify an RSA signature (PKCS#1 v1.5 or PSS, SHA-256/384/512) over a message against an RSA public key, in your browser. Nothing is uploaded."
 tags          = ["rsa verify", "verify rsa signature", "pkcs1", "rsa pss", "signature verification", "crypto"]
 h1            = "RSA verify"

--- a/blocks/rsi-calculator/page/meta.toml
+++ b/blocks/rsi-calculator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "rsi-calculator"
-title         = "RSI Calculator — Relative Strength Index from prices — gizza.ai"
+title         = "RSI Calculator — Relative Strength Index from prices"
 description   = "Calculate Wilder's Relative Strength Index (RSI) from pasted closing prices with configurable period and overbought/oversold thresholds. Runs locally in your browser."
 tags          = ["rsi calculator", "relative strength index", "technical analysis", "wilder rsi", "momentum indicator", "trading"]
 h1            = "RSI calculator"

--- a/blocks/salsa20-cipher/page/meta.toml
+++ b/blocks/salsa20-cipher/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "salsa20-cipher"
-title         = "Salsa20 Cipher — Encrypt/decrypt with Salsa20 (key + nonce) — gizza.ai"
+title         = "Salsa20 Cipher — Encrypt/decrypt with Salsa20 (key + nonce)"
 description   = "Encrypt and decrypt with the Salsa20 stream cipher in your browser — 16/32-byte key, 8-byte nonce, hex or base64 output. Free, private, nothing uploaded."
 tags          = ["salsa20", "salsa20 encrypt", "salsa20 decrypt", "stream cipher", "djb", "estream", "cipher"]
 h1            = "Salsa20 cipher"

--- a/blocks/scrypt-derive/page/meta.toml
+++ b/blocks/scrypt-derive/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "scrypt-derive"
-title         = "scrypt Key Derivation — derive a key from a password — gizza.ai"
+title         = "scrypt Key Derivation — derive a key from a password"
 description   = "Derive a key from a password with the scrypt memory-hard KDF (RFC 7914). Set N, r, p, salt and hex/base64 output — free and fully in-browser."
 tags          = ["scrypt", "key derivation", "kdf", "memory-hard", "derive key from password", "rfc 7914", "password based key derivation", "scrypt online"]
 h1            = "scrypt key derivation"

--- a/blocks/seconds-to-hms/page/meta.toml
+++ b/blocks/seconds-to-hms/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "seconds-to-hms"
-title         = "Seconds to HH:MM:SS converter — gizza.ai"
+title         = "Seconds to HH:MM:SS converter"
 description   = "Convert seconds into HH:MM:SS, D:HH:MM:SS, ISO-8601, or human-readable duration text with optional fractional seconds. Runs locally in your browser."
 tags          = ["seconds to hms", "duration converter", "hh:mm:ss", "time converter", "iso 8601 duration", "video timestamp"]
 h1            = "Seconds to HH:MM:SS"

--- a/blocks/seo-audit/page/meta.toml
+++ b/blocks/seo-audit/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "seo-audit"
-title         = "SEO Audit — Check On-Page SEO of HTML Online — gizza.ai"
+title         = "SEO Audit — Check On-Page SEO of HTML Online"
 description   = "Paste a page's HTML and get a scored on-page SEO audit — title, meta description, headings, image alt text, canonical, and Open Graph tags. Free, private, no upload."
 tags          = ["seo audit", "on-page seo", "meta tags checker", "html seo check", "open graph checker", "seo score"]
 h1            = "SEO Audit"

--- a/blocks/sha1-hash/page/meta.toml
+++ b/blocks/sha1-hash/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "sha1-hash"
-title         = "SHA-1 Hash Generator — gizza.ai"
+title         = "SHA-1 Hash Generator"
 description   = "Generate a SHA-1 hash of any text in your browser — hex or base64 output, uppercase option, hex/base64 input decoding. Free, private, nothing uploaded."
 tags          = ["sha1", "sha-1", "hash", "checksum", "digest", "hex", "base64", "cryptography"]
 h1            = "SHA-1 Hash Generator"

--- a/blocks/sha256-hash/page/meta.toml
+++ b/blocks/sha256-hash/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "sha256-hash"
-title         = "SHA-256 Hash Generator — gizza.ai"
+title         = "SHA-256 Hash Generator"
 description   = "Generate a SHA-256 (SHA-2) hash of any text instantly in your browser — hex or base64 output, uppercase option. Free, private, nothing is uploaded."
 tags          = ["sha256", "sha-256", "sha2", "hash", "checksum", "digest", "hex", "base64", "cryptography"]
 h1            = "SHA-256 Hash Generator"

--- a/blocks/sha3-hash/page/meta.toml
+++ b/blocks/sha3-hash/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "sha3-hash"
-title         = "SHA-3 Hash Generator — SHA3-256 / SHA3-384 / SHA3-512 (FIPS-202) | gizza.ai"
+title         = "SHA-3 Hash Generator — SHA3-256 / SHA3-384 / SHA3-512 (FIPS-202)"
 description   = "Compute the FIPS-202 SHA-3 hash (SHA3-256/384/512) of any text in your browser — the NIST standard, not Keccak. Hex or base64 output. Free, private, no sign-up."
 tags          = ["sha3", "sha3-256", "sha3-384", "sha3-512", "fips-202", "nist", "keccak", "hash", "digest", "checksum", "hex", "base64", "cryptography"]
 h1            = "SHA-3 Hash Generator"

--- a/blocks/sitemap-url-extractor/page/meta.toml
+++ b/blocks/sitemap-url-extractor/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "sitemap-url-extractor"
-title         = "Sitemap URL Extractor — gizza.ai"
+title         = "Sitemap URL Extractor"
 description   = "Paste an XML sitemap or sitemap index and pull out every URL (and lastmod date) as a clean list — in your browser. Nothing is uploaded."
 tags          = ["sitemap url extractor", "extract urls from sitemap", "parse sitemap xml", "sitemap index", "sitemap loc list", "sitemap lastmod"]
 h1            = "Sitemap URL Extractor"

--- a/blocks/slugify/page/meta.toml
+++ b/blocks/slugify/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "slugify"
-title         = "Slugify — URL Slug Generator — gizza.ai"
+title         = "Slugify — URL Slug Generator"
 description   = "Turn any title into a clean URL-safe slug — accents transliterated to ASCII, lowercased, punctuation collapsed to hyphens. Free slug generator, in-browser."
 tags          = ["slugify", "url slug", "slug generator", "permalink", "seo url", "url friendly", "transliterate", "ascii slug", "kebab case"]
 h1            = "Slugify — URL Slug Generator"

--- a/blocks/sm2-public-from-private/page/meta.toml
+++ b/blocks/sm2-public-from-private/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "sm2-public-from-private"
-title         = "SM2 Public Key from Private Key — Derive Q = d·G (GM/T 0003) — gizza.ai"
+title         = "SM2 Public Key from Private Key — Derive Q = d·G (GM/T 0003)"
 description   = "Derive an SM2 public key from a private key (GM/T 0003, curve sm2p256v1) — hex scalar or PKCS#8 PEM in, SEC1 hex and SPKI PEM out. In-browser, no upload."
 tags          = ["sm2", "sm2p256v1", "public key", "private key", "gm/t 0003", "oscca", "sec1", "pkcs8"]
 h1            = "SM2 public key from private key"

--- a/blocks/sm4-cipher/page/meta.toml
+++ b/blocks/sm4-cipher/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "sm4-cipher"
-title         = "SM4 Cipher — Encrypt/decrypt with SM4 (ECB/CBC) — gizza.ai"
+title         = "SM4 Cipher — Encrypt/decrypt with SM4 (ECB/CBC)"
 description   = "Encrypt or decrypt data with the SM4 block cipher (GB/T 32907) in ECB or CBC mode, with hex/base64 I/O — in your browser. 128-bit key. Nothing is uploaded."
 tags          = ["sm4", "sm4 encrypt", "sm4 decrypt", "block cipher", "ecb", "cbc"]
 h1            = "SM4 cipher"

--- a/blocks/smart-quotes-clean/page/meta.toml
+++ b/blocks/smart-quotes-clean/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "smart-quotes-clean"
-title         = "Smart Quotes Cleaner — Curly Quotes to Straight Quotes — gizza.ai"
+title         = "Smart Quotes Cleaner — Curly Quotes to Straight Quotes"
 description   = "Replace smart (curly) quotes, em and en dashes, ellipses, and other typographic characters with plain ASCII in your browser. Free, private, no sign-up."
 tags          = ["smart quotes", "curly quotes to straight quotes", "straighten quotes", "em dash to hyphen", "ascii cleaner", "typographic characters", "remove smart quotes", "non-breaking space", "fancy quotes"]
 h1            = "Smart Quotes Cleaner"

--- a/blocks/sort-lines/page/meta.toml
+++ b/blocks/sort-lines/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "sort-lines"
-title         = "Sort Lines — alphabetical, numeric & natural line sorting — gizza.ai"
+title         = "Sort Lines — alphabetical, numeric & natural line sorting"
 description   = "Sort lines of text alphabetically, numerically, naturally or by length, remove duplicates and blank lines — free and private in your browser."
 tags          = ["sort lines", "alphabetical sort", "line sorter", "numeric sort", "natural sort", "sort text", "remove duplicate lines"]
 h1            = "Sort Lines"

--- a/blocks/spell-check/page/meta.toml
+++ b/blocks/spell-check/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "spell-check"
-title         = "Spell Checker — Free Online Spelling Corrector — gizza.ai"
+title         = "Spell Checker — Free Online Spelling Corrector"
 description   = "Check English spelling, get ranked suggestions, and copy a corrected version. Private, free, and runs in your browser."
 tags          = ["spell checker", "spell check", "spelling corrector", "fix spelling", "typo finder", "correct text", "proofreading", "spelling suggestions", "english spell check"]
 h1            = "Spell Checker"

--- a/blocks/split-text/page/meta.toml
+++ b/blocks/split-text/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "split-text"
-title         = "Split Text by Delimiter — One Item Per Line — gizza.ai"
+title         = "Split Text by Delimiter — One Item Per Line"
 description   = "Split text on any delimiter into one item per line — comma, tab, custom, whitespace, or characters, with trim and drop-blanks options. Free, in-browser."
 tags          = ["split text", "text splitter", "delimiter", "comma to lines", "one per line", "split by whitespace", "split into characters", "csv to list"]
 h1            = "Split Text by Delimiter"

--- a/blocks/sql-dump-to-csv/page/meta.toml
+++ b/blocks/sql-dump-to-csv/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "sql-dump-to-csv"
-title         = "SQL Dump to CSV — Extract INSERT Rows | gizza.ai"
+title         = "SQL Dump to CSV — Extract INSERT Rows"
 description   = "Paste a SQL dump and pull the rows out of its INSERT statements into CSV — one CSV per table, with delimiter, header, NULL and quoting options. Free, private, no upload."
 tags          = ["sql to csv", "sql dump to csv", "insert to csv", "mysql dump to csv", "sql export csv", "convert sql to csv", "sql insert extract", "database dump csv"]
 h1            = "SQL Dump → CSV"

--- a/blocks/sql-formatter/page/meta.toml
+++ b/blocks/sql-formatter/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "sql-formatter"
-title         = "SQL Formatter — pretty-print / beautify SQL queries — gizza.ai"
+title         = "SQL Formatter — pretty-print / beautify SQL queries"
 description   = "Format, beautify and standardize SQL queries in your browser. Clauses on their own lines, configurable indentation, keyword casing. Nothing is uploaded."
 tags          = ["sql formatter", "sql beautifier", "format sql", "pretty print sql", "sql pretty print", "beautify sql query", "sql indenter"]
 h1            = "SQL Formatter"

--- a/blocks/srt-shift/page/meta.toml
+++ b/blocks/srt-shift/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "srt-shift"
-title         = "SRT Subtitle Shifter — Resync .srt Timings | gizza.ai"
+title         = "SRT Subtitle Shifter — Resync .srt Timings"
 description   = "Shift SRT subtitle timestamps forward or backward to resync subtitles that run early or late — seconds or milliseconds. Free, private, runs in your browser."
 tags          = ["srt", "subtitle", "subtitle sync", "srt shift", "resync subtitles", "subtitle delay", "subrip", "subtitle timing", "subtitle offset"]
 h1            = "SRT Subtitle Shifter"

--- a/blocks/srt-to-vtt/page/meta.toml
+++ b/blocks/srt-to-vtt/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "srt-to-vtt"
-title         = "SRT to VTT Converter — Convert Subtitles Both Ways | gizza.ai"
+title         = "SRT to VTT Converter — Convert Subtitles Both Ways"
 description   = "Convert SRT to VTT and VTT to SRT free in your browser — format auto-detected, timestamps rewritten, WEBVTT header handled. No upload, no sign-up."
 tags          = ["srt to vtt", "vtt to srt", "subtitle converter", "subrip", "webvtt", "convert subtitles", "srt", "vtt", "caption converter"]
 h1            = "SRT to VTT Subtitle Converter"

--- a/blocks/ssh-public-key-from-private/page/meta.toml
+++ b/blocks/ssh-public-key-from-private/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "ssh-public-key-from-private"
-title         = "Get SSH Public Key from a Private Key — gizza.ai"
+title         = "Get SSH Public Key from a Private Key"
 description   = "Derive the OpenSSH public key (id_*.pub line) from an RSA, ECDSA (P-256/P-384) or Ed25519 private key. Runs in your browser, nothing uploaded, free."
 tags          = ["ssh public key from private", "ssh-keygen -y", "id_rsa.pub", "openssh public key", "ssh-ed25519", "ecdsa-sha2-nistp256", "ssh-rsa", "authorized_keys"]
 h1            = "Get the SSH Public Key from a Private Key"

--- a/blocks/string-escaper/page/meta.toml
+++ b/blocks/string-escaper/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "string-escaper"
-title         = "String Escaper — Escape for JSON, JS, HTML, URL, Shell, SQL, Regex — gizza.ai"
+title         = "String Escaper — Escape for JSON, JS, HTML, URL, Shell, SQL, Regex"
 description   = "Escape (or unescape) any string for JSON, JavaScript, HTML, URL, shell, SQL, or regex. Spec-aware escaping that runs in your browser; nothing is uploaded."
 tags          = ["string escaper", "escape string", "json escape", "html escape", "url encode", "sql escape", "regex escape", "shell escape", "javascript escape"]
 h1            = "String Escaper"

--- a/blocks/string-obfuscator/page/meta.toml
+++ b/blocks/string-obfuscator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "string-obfuscator"
-title         = "String Obfuscator — Mask, ROT13, Leetspeak & Homoglyph — gizza.ai"
+title         = "String Obfuscator — Mask, ROT13, Leetspeak & Homoglyph"
 description   = "Mask secrets and PII or transform text with ROT13, leetspeak, and Unicode homoglyphs in your browser — keep first/last chars visible. Free, private."
 tags          = ["string obfuscator", "mask string", "redact text", "rot13", "caesar cipher", "leetspeak", "homoglyph", "unicode confusable", "hide api key", "screenshot redaction"]
 h1            = "String Obfuscator"

--- a/blocks/strip-ansi-codes/page/meta.toml
+++ b/blocks/strip-ansi-codes/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "strip-ansi-codes"
-title         = "Strip ANSI Codes — Remove Terminal Color Escape Codes | gizza.ai"
+title         = "Strip ANSI Codes — Remove Terminal Color Escape Codes"
 description   = "Remove ANSI escape and color codes from terminal output and CI logs instantly in your browser. Strip everything or only colors. Free, private, no sign-up."
 tags          = ["strip ansi", "remove ansi codes", "ansi escape codes", "terminal colors", "clean log output", "ci log cleaner", "remove color codes", "sgr codes", "escape sequence"]
 h1            = "Strip ANSI Codes"

--- a/blocks/strip-ipv4-header/page/meta.toml
+++ b/blocks/strip-ipv4-header/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "strip-ipv4-header"
-title         = "IPv4 Header Stripper — remove the IPv4 header and get the payload — gizza.ai"
+title         = "IPv4 Header Stripper — remove the IPv4 header and get the payload"
 description   = "Strip the IPv4 header from a raw hex packet — honoring IHL options and Total Length padding — to get the TCP/UDP/ICMP payload as hex, free in your browser."
 tags          = ["strip ipv4 header", "remove ip header", "ipv4 payload", "ip packet payload", "decapsulate ipv4", "ip header length", "ihl", "extract tcp payload", "extract udp payload", "ip protocol number"]
 h1            = "IPv4 Header Stripper"

--- a/blocks/strip-udp-header/page/meta.toml
+++ b/blocks/strip-udp-header/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "strip-udp-header"
-title         = "UDP Header Stripper — remove the 8-byte UDP header and get the payload — gizza.ai"
+title         = "UDP Header Stripper — remove the 8-byte UDP header and get the payload"
 description   = "Strip the 8-byte UDP header from a hex datagram to get the payload, plus source/destination ports, length and checksum — free, in your browser."
 tags          = ["strip udp header", "remove udp header", "udp payload", "udp datagram payload", "decapsulate udp", "extract udp payload", "udp source port", "udp destination port", "udp length field", "udp checksum"]
 h1            = "UDP Header Stripper"

--- a/blocks/structured-data-validator/page/meta.toml
+++ b/blocks/structured-data-validator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "structured-data-validator"
-title         = "Structured Data Validator — JSON-LD, Microdata & RDFa | gizza.ai"
+title         = "Structured Data Validator — JSON-LD, Microdata & RDFa"
 description   = "Validate schema.org structured data from pasted HTML — extract JSON-LD, microdata and RDFa and flag markup errors, locally in your browser."
 tags          = ["structured data validator", "json ld validator", "schema.org", "microdata", "rdfa", "seo", "rich results", "html validator", "json-ld", "schema markup"]
 h1            = "Structured Data Validator"

--- a/blocks/subscription-finder/page/meta.toml
+++ b/blocks/subscription-finder/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "subscription-finder"
-title         = "Subscription Finder — Spot Recurring Charges in Your Statement — gizza.ai"
+title         = "Subscription Finder — Spot Recurring Charges in Your Statement"
 description   = "Paste bank or card transactions to find recurring charges, forgotten subscriptions, next charge dates, and projected yearly cost. Free and private."
 tags          = ["subscription finder", "recurring charges", "find subscriptions", "cancel subscriptions", "recurring payments", "bank statement analysis", "subscription tracker", "yearly cost", "forgotten subscriptions"]
 h1            = "Subscription Finder"

--- a/blocks/subtitle-merge/page/meta.toml
+++ b/blocks/subtitle-merge/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "subtitle-merge"
-title         = "Subtitle Merger — Combine SRT &amp; VTT Files Into One | gizza.ai"
+title         = "Subtitle Merger — Combine SRT &amp; VTT Files Into One"
 description   = "Merge SRT or VTT subtitle files into one — combine split parts or overlay a second language track, with optional per-file time-shift. Free, in your browser."
 tags          = ["subtitle merge", "merge srt", "combine subtitles", "srt", "vtt", "webvtt", "subrip", "join subtitles", "bilingual subtitles", "subtitle combiner"]
 h1            = "Subtitle Merger"

--- a/blocks/svg-optimize/page/meta.toml
+++ b/blocks/svg-optimize/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "svg-optimize"
-title         = "SVG Optimizer — minify & clean up SVG markup — gizza.ai"
+title         = "SVG Optimizer — minify & clean up SVG markup"
 description   = "Minify and clean SVG in your browser — collapse whitespace, strip comments, the XML prolog and Inkscape/Sodipodi metadata. Path data is untouched. Nothing uploaded."
 tags          = ["svg optimizer", "minify svg", "svg minifier", "clean svg", "svgo", "compress svg"]
 h1            = "SVG Optimizer"

--- a/blocks/svg-recolor/page/meta.toml
+++ b/blocks/svg-recolor/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "svg-recolor"
-title         = "SVG Recolor — remap fill & stroke colors in an SVG — gizza.ai"
+title         = "SVG Recolor — remap fill & stroke colors in an SVG"
 description   = "Recolor SVG online free — swap colors with from→to pairs or tint the whole icon monochrome; matches #fff, rgb() and named colors right in your browser."
 tags          = ["svg recolor", "recolor svg", "change svg color", "svg color replace", "monochrome svg", "tint svg icon"]
 h1            = "SVG Recolor"

--- a/blocks/svg-sprite-builder/page/meta.toml
+++ b/blocks/svg-sprite-builder/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "svg-sprite-builder"
-title         = "SVG Sprite Sheet Builder — gizza.ai"
+title         = "SVG Sprite Sheet Builder"
 description   = "Combine multiple SVG icons into one symbol sprite sheet referenced with <use href> — auto, id, or title naming and automatic viewBox. Free, in your browser."
 tags          = ["svg sprite", "svg symbol", "sprite sheet", "svg use", "icon sprite", "combine svg", "svg icons", "symbol id", "viewbox"]
 h1            = "SVG Sprite Sheet Builder"

--- a/blocks/syntax-highlighter/page/meta.toml
+++ b/blocks/syntax-highlighter/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "syntax-highlighter"
-title         = "Syntax Highlighter — code to styled HTML or ANSI — gizza.ai"
+title         = "Syntax Highlighter — code to styled HTML or ANSI"
 description   = "Syntax-highlight a code snippet to self-contained inline-styled HTML (or ANSI terminal colors) for 100+ languages and many themes, in your browser. Nothing is uploaded."
 tags          = ["syntax highlighter", "code highlighter", "highlight code", "code to html", "syntax highlighting", "ansi colors"]
 h1            = "Syntax Highlighter"

--- a/blocks/table-heatmap/page/meta.toml
+++ b/blocks/table-heatmap/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "table-heatmap"
-title         = "Table Heatmap — color-scale conditional formatting for CSV — gizza.ai"
+title         = "Table Heatmap — color-scale conditional formatting for CSV"
 description   = "Shade a CSV/table's numeric cells with a spreadsheet-style color scale and get a styled HTML table. Free, private, no upload."
 tags          = ["table heatmap", "conditional formatting", "csv color scale", "heatmap table", "html table generator"]
 h1            = "Table heatmap"

--- a/blocks/tail-lines/page/meta.toml
+++ b/blocks/tail-lines/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "tail-lines"
-title         = "Tail — Get the Last N Lines of Text | gizza.ai"
+title         = "Tail — Get the Last N Lines of Text"
 description   = "Get the last N lines of any text in your browser, like tail -n — skip footer rows and add original line numbers. Free, private, no sign-up."
 tags          = ["tail", "last lines", "last n lines", "tail -n", "bottom lines", "truncate lines", "line numbers", "text tool"]
 h1            = "Tail — Last N Lines"

--- a/blocks/task-list-summarizer/page/meta.toml
+++ b/blocks/task-list-summarizer/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "task-list-summarizer"
-title         = "Task List Summarizer — count done & pending Markdown tasks · gizza.ai"
+title         = "Task List Summarizer — count done & pending Markdown tasks"
 description   = "Summarize a Markdown task list — count done and pending checkboxes, get a completion percentage, or filter tasks — free and private in your browser."
 tags          = ["task list", "markdown checklist", "todo", "done pending count", "completion percentage", "checkbox", "gfm task list", "progress"]
 h1            = "Markdown Task List Summarizer"

--- a/blocks/text-diff/page/meta.toml
+++ b/blocks/text-diff/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "text-diff"
-title         = "Text Diff — gizza.ai"
+title         = "Text Diff"
 description   = "Compare two text blocks and highlight added, removed, and changed lines."
 tags          = ["text", "diff", "developer"]
 h1            = "Text Diff"

--- a/blocks/text-encrypt/page/meta.toml
+++ b/blocks/text-encrypt/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "text-encrypt"
-title         = "Text Encrypt — AES-256 encrypt/decrypt text with a passphrase — gizza.ai"
+title         = "Text Encrypt — AES-256 encrypt/decrypt text with a passphrase"
 description   = "Encrypt or decrypt text with a passphrase using AES-256-GCM, in your browser. Get a copy-pasteable token. Nothing is uploaded."
 tags          = ["text encryption", "aes", "encrypt text", "decrypt text", "passphrase", "privacy"]
 h1            = "Text encrypt"

--- a/blocks/text-statistics/page/meta.toml
+++ b/blocks/text-statistics/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "text-statistics"
-title         = "Text Statistics — Word, character & reading-time counter — gizza.ai"
+title         = "Text Statistics — Word, character & reading-time counter"
 description   = "Count words, characters, sentences, paragraphs and lines, and estimate reading time, in your browser. Nothing is uploaded."
 tags          = ["word counter", "character count", "reading time", "text statistics", "sentence count", "paragraph count"]
 h1            = "Text statistics"

--- a/blocks/text-to-table/page/meta.toml
+++ b/blocks/text-to-table/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "text-to-table"
-title         = "Text to Table — gizza.ai"
+title         = "Text to Table"
 description   = "Render delimited text (CSV, TSV, or custom-separated data) as an aligned ASCII or Markdown table."
 tags          = ["text", "csv", "table"]
 h1            = "Text to Table"

--- a/blocks/text-to-unicode/page/meta.toml
+++ b/blocks/text-to-unicode/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "text-to-unicode"
-title         = "Text to Unicode — gizza.ai"
+title         = "Text to Unicode"
 description   = "List each character's Unicode code point (U+XXXX), name, \\u escape sequence and UTF-8 bytes for any text."
 tags          = ["text", "unicode", "encoding"]
 h1            = "Text to Unicode"

--- a/blocks/text-wrap/page/meta.toml
+++ b/blocks/text-wrap/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "text-wrap"
-title         = "Text Wrap — Hard-Wrap Text to a Column Width | gizza.ai"
+title         = "Text Wrap — Hard-Wrap Text to a Column Width"
 description   = "Hard-wrap text to a fixed column width in your browser — keep indentation and blank lines, optionally break long words. Free, private, no sign-up."
 tags          = ["text wrap", "word wrap", "hard wrap", "line wrap", "reflow text", "column width", "wrap text 80 columns", "format paragraph"]
 h1            = "Text Wrap"

--- a/blocks/textrank-summarize/page/meta.toml
+++ b/blocks/textrank-summarize/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "textrank-summarize"
-title         = "TextRank Summarizer — Extractive text summary — gizza.ai"
+title         = "TextRank Summarizer — Extractive text summary"
 description   = "Summarize text by extracting its most important sentences with TextRank, in your browser. No AI model, nothing uploaded."
 tags          = ["text summarizer", "textrank", "extractive summary", "summarize text", "tldr"]
 h1            = "TextRank summarizer"

--- a/blocks/time-to-decimal-hours/page/meta.toml
+++ b/blocks/time-to-decimal-hours/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "time-to-decimal-hours"
-title         = "Time to Decimal Hours Converter — HH:MM to Decimal and Back — gizza.ai"
+title         = "Time to Decimal Hours Converter — HH:MM to Decimal and Back"
 description   = "Convert HH:MM to decimal hours (1:30 → 1.5) and back for timesheets, payroll and billing — plus total minutes and seconds. Free, private, in-browser."
 tags          = ["time to decimal", "hours and minutes to decimal", "decimal hours converter", "hh:mm to decimal", "timesheet calculator", "payroll hours", "minutes to decimal", "decimal to hours and minutes", "billable hours"]
 h1            = "Time to Decimal Hours Converter"

--- a/blocks/timesheet-calculator/page/meta.toml
+++ b/blocks/timesheet-calculator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "timesheet-calculator"
-title         = "Timesheet Calculator — Total Work Hours & Billable Amounts — gizza.ai"
+title         = "Timesheet Calculator — Total Work Hours & Billable Amounts"
 description   = "Paste a work log of start–stop times tagged by project and get total hours plus billable amounts with rates, rounding and overnight shifts."
 tags          = ["timesheet calculator", "billable hours calculator", "work hours calculator", "time card calculator", "hours worked calculator", "project time tracker", "freelance hours", "payroll hours"]
 h1            = "Timesheet Calculator"

--- a/blocks/timezone-convert/page/meta.toml
+++ b/blocks/timezone-convert/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "timezone-convert"
-title         = "Timezone Converter — Convert Time Between Time Zones | gizza.ai"
+title         = "Timezone Converter — Convert Time Between Time Zones"
 description   = "Convert a date and time across multiple timezones with correct DST handling and a 24-hour meeting planner grid. Full IANA database — free, private, in-browser."
 tags          = ["timezone converter", "time zone convert", "utc converter", "dst", "iana timezone", "world clock", "meeting planner", "convert time", "multi timezone"]
 h1            = "Timezone Converter & Meeting Planner"

--- a/blocks/toc-generator/page/meta.toml
+++ b/blocks/toc-generator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "toc-generator"
-title         = "Table of Contents Generator — gizza.ai"
+title         = "Table of Contents Generator"
 description   = "Generate a linked table of contents from Markdown or HTML headings — pick levels, bullets or numbers, Markdown or HTML output — free in your browser."
 tags          = ["table of contents generator", "markdown toc", "toc generator", "html table of contents", "markdown table of contents", "heading links", "github anchors", "readme toc"]
 h1            = "Table of Contents Generator"

--- a/blocks/todo-organizer/page/meta.toml
+++ b/blocks/todo-organizer/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "todo-organizer"
-title         = "To-do Organizer — Brain-dump to Prioritized Checklist — gizza.ai"
+title         = "To-do Organizer — Brain-dump to Prioritized Checklist"
 description   = "Turn a brain-dump into a prioritized Markdown checklist — tasks grouped High/Medium/Low by urgency keywords, with due-date hints. Free, in-browser."
 tags          = ["todo organizer", "task prioritizer", "brain dump to list", "markdown checklist", "to-do list maker"]
 h1            = "To-do Organizer"

--- a/blocks/token-counter/page/meta.toml
+++ b/blocks/token-counter/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "token-counter"
-title         = "LLM Token Counter — Count Tokens & Estimate Cost | gizza.ai"
+title         = "LLM Token Counter — Count Tokens & Estimate Cost"
 description   = "Paste text to count LLM tokens with real tiktoken BPE, then estimate the prompt cost and context-window usage for GPT, Claude, and Gemini. Free, private, in-browser."
 tags          = ["token counter", "llm tokens", "tiktoken", "openai tokenizer", "gpt token count", "claude tokens", "gemini tokens", "prompt cost", "context window", "o200k", "cl100k"]
 h1            = "LLM Token Counter & Cost Estimator"

--- a/blocks/totp-generator/page/meta.toml
+++ b/blocks/totp-generator/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "totp-generator"
-title         = "TOTP Generator — 2FA codes from a secret — gizza.ai"
+title         = "TOTP Generator — 2FA codes from a secret"
 description   = "Generate time-based one-time (2FA) codes from a TOTP secret, in your browser. The secret never leaves your device."
 tags          = ["totp", "2fa", "authenticator", "one-time password", "otp", "two-factor"]
 h1            = "TOTP generator"

--- a/blocks/trim-audio/page/meta.toml
+++ b/blocks/trim-audio/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "trim-audio"
-title         = "Trim Audio Online — gizza.ai"
+title         = "Trim Audio Online"
 description   = "Trim any audio file in your browser — keep or remove a start–end range, add edge fades, save as MP3, WAV, FLAC or M4A. Runs locally, nothing is uploaded."
 tags          = ["audio", "trim", "cut", "clip", "mp3", "ringtone", "crop", "splice"]
 h1            = "Trim an Audio File"

--- a/blocks/truncate-text/page/meta.toml
+++ b/blocks/truncate-text/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "truncate-text"
-title         = "Truncate Text — Shorten Text by Characters or Words | gizza.ai"
+title         = "Truncate Text — Shorten Text by Characters or Words"
 description   = "Truncate text to a character or word limit with word-safe cutting and a custom ellipsis. Free, private, runs in your browser, no sign-up."
 tags          = ["truncate text", "shorten text", "text ellipsis", "trim text to length", "limit characters", "limit words", "text snippet", "meta description length"]
 h1            = "Truncate Text"

--- a/blocks/tweet-thread-splitter/page/meta.toml
+++ b/blocks/tweet-thread-splitter/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "tweet-thread-splitter"
-title         = "Tweet Thread Splitter — Split Text into Numbered Tweets — gizza.ai"
+title         = "Tweet Thread Splitter — Split Text into Numbered Tweets"
 description   = "Split long text into a numbered tweet thread that never breaks mid-word — custom character limit, (i/N) counters, sentence-aware breaks. Free, in your browser."
 tags          = ["tweet thread", "twitter thread", "x thread", "thread maker", "tweet splitter", "280 characters", "character counter", "split text", "thread numbering"]
 h1            = "Tweet Thread Splitter"

--- a/blocks/unicode-to-text/page/meta.toml
+++ b/blocks/unicode-to-text/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "unicode-to-text"
-title         = "Unicode to Text — gizza.ai"
+title         = "Unicode to Text"
 description   = "Decode Unicode escape sequences back into readable text. Auto-detects \\uXXXX, \\u{X}, \\xXX, \\U00XXXXXX, U+XXXX and HTML &#nn; / &#xnn; in one pass."
 tags          = ["text", "unicode", "decode", "encoding", "unescape"]
 h1            = "Unicode to Text"

--- a/blocks/unit-converter/page/meta.toml
+++ b/blocks/unit-converter/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "unit-converter"
-title         = "Unit Converter — Length, Mass, Temperature & More — gizza.ai"
+title         = "Unit Converter — Length, Mass, Temperature & More"
 description   = "Convert between units of length, mass, temperature, volume, area, speed, data size, and time — instantly in your browser. Names and symbols accepted. Nothing is uploaded."
 tags          = ["unit converter", "measurement converter", "metric to imperial", "km to miles", "celsius to fahrenheit", "kg to pounds", "gb to mb", "convert units"]
 h1            = "Unit Converter"

--- a/blocks/unix-timestamp-converter/page/meta.toml
+++ b/blocks/unix-timestamp-converter/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "unix-timestamp-converter"
-title         = "Unix Timestamp Converter — epoch date converter — gizza.ai"
+title         = "Unix Timestamp Converter — epoch date converter"
 description   = "Convert Unix timestamps (seconds, milliseconds, microseconds, nanoseconds) to UTC dates, or parse human-readable dates back to epoch timestamps. Free, private, no upload."
 tags          = ["unix timestamp", "epoch converter", "timestamp to date", "date to timestamp", "utc time"]
 h1            = "Unix timestamp converter"

--- a/blocks/unwrap-text/page/meta.toml
+++ b/blocks/unwrap-text/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "unwrap-text"
-title         = "Unwrap Text — Rejoin hard-wrapped lines — gizza.ai"
+title         = "Unwrap Text — Rejoin hard-wrapped lines"
 description   = "Remove hard line breaks inside paragraphs to rejoin wrapped text into continuous lines, in your browser. Nothing is uploaded."
 tags          = ["unwrap text", "remove line breaks", "rejoin lines", "reflow text", "unwrap paragraphs"]
 h1            = "Unwrap text"

--- a/blocks/url-encode/page/meta.toml
+++ b/blocks/url-encode/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "url-encode"
-title         = "URL Encoder & Decoder — gizza.ai"
+title         = "URL Encoder & Decoder"
 description   = "Percent-encode or decode text and URLs in your browser — component, whole-URL, or form mode, batch per-line, and recursive decode. Free, private, no sign-up."
 tags          = ["url encode", "url decode", "percent encoding", "uri", "query string", "form urlencoded", "plus encoding", "batch", "double decode"]
 h1            = "URL Encoder / Decoder"

--- a/blocks/url-safety-inspect/page/meta.toml
+++ b/blocks/url-safety-inspect/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "url-safety-inspect"
-title         = "URL Safety Inspector — Phishing Risk Checker | gizza.ai"
+title         = "URL Safety Inspector — Phishing Risk Checker"
 description   = "Paste a URL to rate phishing risk from structural heuristics: IP hosts, @ tricks, deep subdomains, punycode and lookalike TLDs. Runs locally."
 tags          = ["url", "phishing", "security", "safety", "url-checker", "punycode", "typosquatting"]
 h1            = "URL Safety Inspector"

--- a/blocks/utm-link-builder/page/meta.toml
+++ b/blocks/utm-link-builder/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "utm-link-builder"
-title         = "UTM Link Builder — Campaign URL Tagger | gizza.ai"
+title         = "UTM Link Builder — Campaign URL Tagger"
 description   = "Free UTM link builder — add utm_source, utm_medium and utm_campaign tags plus GA4 fields to any URL, correctly encoded, right in your browser."
 tags          = ["utm builder", "utm link", "campaign url builder", "utm parameters", "url tagging", "google analytics", "utm_source", "utm_medium", "utm_campaign", "marketing"]
 h1            = "UTM Link Builder"

--- a/blocks/verify-checksum/page/meta.toml
+++ b/blocks/verify-checksum/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "verify-checksum"
-title         = "Checksum Verifier — Check MD5, SHA-256, SHA-3, BLAKE Hashes | gizza.ai"
+title         = "Checksum Verifier — Check MD5, SHA-256, SHA-3, BLAKE Hashes"
 description   = "Verify text or data against an expected checksum — auto-detects MD5, SHA-1, SHA-256, SHA-3, BLAKE2 or BLAKE3 from digest length. Free, private, in-browser."
 tags          = ["checksum", "verify", "hash", "md5", "sha1", "sha256", "sha512", "sha3", "blake2", "blake3", "integrity", "digest", "compare"]
 h1            = "Checksum Verifier"

--- a/blocks/video-aspect-pad/page/meta.toml
+++ b/blocks/video-aspect-pad/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-aspect-pad"
-title         = "Pad a Video to an Aspect Ratio Online — Letterbox to 9:16, 1:1, 16:9 — gizza.ai"
+title         = "Pad a Video to an Aspect Ratio Online — Letterbox to 9:16, 1:1, 16:9"
 description   = "Letterbox or pillarbox a video to 9:16, 1:1, 16:9 or any preset ratio with colored bars or a blurred background — free, in your browser, nothing is uploaded."
 tags          = ["video aspect ratio", "letterbox", "pillarbox", "pad video", "9:16", "reels", "shorts", "blur background", "ffmpeg"]
 h1            = "Pad a Video to an Aspect Ratio"

--- a/blocks/video-audio-denoise/page/meta.toml
+++ b/blocks/video-audio-denoise/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-audio-denoise"
-title         = "Remove Background Noise from a Video Online — gizza.ai"
+title         = "Remove Background Noise from a Video Online"
 description   = "Clean up hiss, hum and background noise in a video's audio right in your browser — pick a strength and denoiser. The picture is untouched. Nothing is uploaded, free."
 tags          = ["remove background noise video", "denoise video audio", "video noise reducer", "reduce hiss", "afftdn", "anlmdn", "ffmpeg"]
 h1            = "Remove Background Noise from a Video"

--- a/blocks/video-audio-gain/page/meta.toml
+++ b/blocks/video-audio-gain/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-audio-gain"
-title         = "Change a Video's Audio Volume Online — gizza.ai"
+title         = "Change a Video's Audio Volume Online"
 description   = "Make a video louder or quieter right in your browser — by decibels or a factor, with a clipping-safe limiter. The picture is untouched. Nothing is uploaded, free."
 tags          = ["video volume", "louder video", "quieter video", "audio gain", "boost video sound", "db", "ffmpeg"]
 h1            = "Change a Video's Audio Volume"

--- a/blocks/video-blur-region/page/meta.toml
+++ b/blocks/video-blur-region/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-blur-region"
-title         = "Blur or Pixelate a Region in a Video — gizza.ai"
+title         = "Blur or Pixelate a Region in a Video"
 description   = "Blur or pixelate a fixed rectangle — a license plate, name tag or logo — on every frame of a video, right in your browser. Nothing is uploaded, runs locally, free."
 tags          = ["video", "blur", "pixelate", "censor", "redact", "license plate", "privacy", "mosaic", "ffmpeg"]
 h1            = "Blur or Pixelate a Region in a Video"

--- a/blocks/video-caption-burner/page/content.md
+++ b/blocks/video-caption-burner/page/content.md
@@ -2,7 +2,7 @@
 
 Burn an SRT or WebVTT subtitle track directly into a video so the captions are part of the pixels, not a separate sidecar file. That makes the result reliable on social feeds, messaging apps, muted autoplay, and players that do not load subtitle tracks.
 
-Upload a video, paste the subtitle file contents, then choose the caption position, font size, text color, and optional background bar. Processing runs locally in your browser with ffmpeg; your source video is not uploaded to gizza.ai.
+Upload a video, paste the subtitle file contents, then choose the caption position, font size, text color, and optional background bar. Processing runs locally in your browser with ffmpeg; your source video is not uploaded anywhere.
 
 ### Worked example
 

--- a/blocks/video-caption-burner/page/meta.toml
+++ b/blocks/video-caption-burner/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-caption-burner"
-title         = "Burn Subtitles Into a Video Online — Free, In-Browser — gizza.ai"
+title         = "Burn Subtitles Into a Video Online — Free, In-Browser"
 description   = "Hard-burn an SRT or WebVTT subtitle track into your video so captions show even when muted — pick position, font size, color and a background bar. Free, in your browser."
 tags          = ["burn subtitles", "hardcode subtitles", "open captions", "srt to video", "vtt", "burn captions", "caption video", "hardsub", "reels", "shorts", "ffmpeg"]
 h1            = "Burn Subtitles Into a Video"

--- a/blocks/video-compress/page/meta.toml
+++ b/blocks/video-compress/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-compress"
-title         = "Compress a Video Online — gizza.ai"
+title         = "Compress a Video Online"
 description   = "Shrink a video's file size right in your browser — pick a quality (CRF). Re-encodes locally with ffmpeg to H.264/AAC, nothing is uploaded, free."
 tags          = ["video", "compress", "shrink", "file size", "crf", "reencode", "smaller"]
 h1            = "Compress a Video"

--- a/blocks/video-crop/page/meta.toml
+++ b/blocks/video-crop/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-crop"
-title         = "Crop a Video Online — gizza.ai"
+title         = "Crop a Video Online"
 description   = "Crop a video to any rectangle in your browser — set width, height, and an optional x/y offset (centered by default). Re-encodes locally with ffmpeg, free."
 tags          = ["video", "crop", "trim edges", "aspect ratio", "ffmpeg", "resize video"]
 h1            = "Crop a Video"

--- a/blocks/video-cut-segments/page/meta.toml
+++ b/blocks/video-cut-segments/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-cut-segments"
-title         = "Cut a Video into Segments Online — Keep or Remove Windows — gizza.ai"
+title         = "Cut a Video into Segments Online — Keep or Remove Windows"
 description   = "Cut a video to multiple time windows, keep or remove those clips, and export one joined MP4. Runs locally in your browser."
 tags          = ["cut video", "trim video", "remove section", "jump cut", "multi trim", "join clips", "ffmpeg"]
 h1            = "Cut a Video into Segments"

--- a/blocks/video-denoise/page/meta.toml
+++ b/blocks/video-denoise/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-denoise"
-title         = "Denoise a Video Online — gizza.ai"
+title         = "Denoise a Video Online"
 description   = "Remove noise, grain and sensor speckle from a video in your browser — choose a strength and denoiser. Local ffmpeg cleanup, nothing uploaded."
 tags          = ["video", "denoise", "noise reduction", "grain", "hqdn3d", "nlmeans", "clean up", "temporal", "spatial"]
 h1            = "Denoise a Video"

--- a/blocks/video-eq-adjust/page/meta.toml
+++ b/blocks/video-eq-adjust/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-eq-adjust"
-title         = "Adjust Video Brightness & Contrast Online — gizza.ai"
+title         = "Adjust Video Brightness & Contrast Online"
 description   = "Free online video color adjuster — tweak brightness, contrast, saturation, and gamma with live sliders. Re-encodes locally with ffmpeg in your browser, nothing uploaded."
 tags          = ["video", "brightness", "contrast", "saturation", "gamma", "color correction", "video editor", "ffmpeg", "exposure", "vivid"]
 h1            = "Adjust Video Brightness, Contrast & Color"

--- a/blocks/video-extract-audio-track/page/meta.toml
+++ b/blocks/video-extract-audio-track/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-extract-audio-track"
-title         = "Extract a Video's Audio Track Losslessly — gizza.ai"
+title         = "Extract a Video's Audio Track Losslessly"
 description   = "Demux a video's audio track in your browser with no re-encode — lossless stream-copy into MKA, M4A or OGG. Pick the track, keep the original codec, nothing uploaded."
 tags          = ["audio", "video", "extract", "demux", "stream-copy", "lossless", "no-reencode", "mka", "m4a", "ogg", "audio track"]
 h1            = "Extract a Video's Audio Track (Lossless)"

--- a/blocks/video-first-last-frame-extractor/page/meta.toml
+++ b/blocks/video-first-last-frame-extractor/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-first-last-frame-extractor"
-title         = "First & Last Frame Extractor — Video Start-vs-End Comparison — gizza.ai"
+title         = "First & Last Frame Extractor — Video Start-vs-End Comparison"
 description   = "Grab a video's first and last frame and stitch them into one before/after image — side by side or stacked. Free, in your browser with ffmpeg, nothing uploaded."
 tags          = ["first and last frame", "video first frame", "video last frame", "before after video", "start vs end frame", "video comparison image", "keyframe grab", "ffmpeg"]
 h1            = "Extract a Video's First & Last Frame"

--- a/blocks/video-fps/page/meta.toml
+++ b/blocks/video-fps/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-fps"
-title         = "Change Video Frame Rate Online — gizza.ai"
+title         = "Change Video Frame Rate Online"
 description   = "Change a video's frame rate right in your browser — set any fps (60→30, 24, 25). Frames are dropped or duplicated with ffmpeg locally, nothing is uploaded, free."
 tags          = ["video", "fps", "frame rate", "framerate", "60fps", "30fps", "convert", "reencode"]
 h1            = "Change a Video's Frame Rate"

--- a/blocks/video-frame-extract/page/meta.toml
+++ b/blocks/video-frame-extract/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-frame-extract"
-title         = "Extract a Frame from a Video — gizza.ai"
+title         = "Extract a Frame from a Video"
 description   = "Grab a single frame from any video as a PNG image, right in your browser — pick a timestamp in seconds. Runs locally with ffmpeg, nothing is uploaded, free."
 tags          = ["video", "frame", "extract", "screenshot", "thumbnail", "still", "png"]
 h1            = "Extract a Video Frame"

--- a/blocks/video-freeze-frame/page/meta.toml
+++ b/blocks/video-freeze-frame/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-freeze-frame"
-title         = "Freeze Frame Video Effect Online — Free, In-Browser — gizza.ai"
+title         = "Freeze Frame Video Effect Online — Free, In-Browser"
 description   = "Add a freeze-frame effect to a video: play up to a moment, hold that frame still for a set number of seconds, then continue. Free, in your browser."
 tags          = ["freeze frame", "freeze frame video", "still frame", "hold frame", "video effect", "pause frame", "stop motion", "reels", "shorts", "ffmpeg"]
 h1            = "Freeze Frame Video Effect"

--- a/blocks/video-hdr-to-sdr/page/meta.toml
+++ b/blocks/video-hdr-to-sdr/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-hdr-to-sdr"
-title         = "Convert HDR Video to SDR Online — gizza.ai"
+title         = "Convert HDR Video to SDR Online"
 description   = "Tone-map an HDR (PQ/HLG, BT.2020) video down to SDR BT.709 so it stops looking gray, dim or washed-out. Runs in your browser with ffmpeg — nothing is uploaded."
 tags          = ["video", "hdr", "sdr", "tone-mapping", "bt2020", "bt709", "pq", "hlg", "convert"]
 h1            = "Convert HDR Video to SDR"

--- a/blocks/video-mute/page/meta.toml
+++ b/blocks/video-mute/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-mute"
-title         = "Mute a Video Online — Remove Audio — gizza.ai"
+title         = "Mute a Video Online — Remove Audio"
 description   = "Remove the audio track from a video right in your browser — lossless, no re-encode. Nothing is uploaded, free, no sign-up."
 tags          = ["mute video", "remove audio", "silent video", "strip audio track", "ffmpeg"]
 h1            = "Mute a Video"

--- a/blocks/video-resize/page/meta.toml
+++ b/blocks/video-resize/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-resize"
-title         = "Resize a Video Online — Scale Resolution — gizza.ai"
+title         = "Resize a Video Online — Scale Resolution"
 description   = "Scale a video to a target resolution right in your browser — set width and/or height, aspect ratio preserved. Re-encodes locally with ffmpeg, nothing is uploaded, free."
 tags          = ["resize video", "scale video", "video resolution", "downscale video", "ffmpeg"]
 h1            = "Resize a Video"

--- a/blocks/video-rotate/page/meta.toml
+++ b/blocks/video-rotate/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-rotate"
-title         = "Rotate a Video Online — Rotate & Flip — gizza.ai"
+title         = "Rotate a Video Online — Rotate & Flip"
 description   = "Rotate a video 90/180/270 degrees or flip it horizontally/vertically, right in your browser. Re-encodes locally with ffmpeg, nothing is uploaded, free."
 tags          = ["rotate video", "flip video", "mirror video", "turn video", "ffmpeg"]
 h1            = "Rotate / Flip a Video"

--- a/blocks/video-target-filesize-encoder/page/meta.toml
+++ b/blocks/video-target-filesize-encoder/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-target-filesize-encoder"
-title         = "Compress Video to a Target File Size (MB) — gizza.ai"
+title         = "Compress Video to a Target File Size (MB)"
 description   = "Set an MB budget and it computes the H.264 bitrate from your clip's length to fit under it — for Discord, email or WhatsApp. Runs in your browser, nothing uploaded."
 tags          = ["video", "compress", "file size", "target size", "mb", "discord", "email", "bitrate", "mp4"]
 h1            = "Compress a Video to a Target File Size"

--- a/blocks/video-title-card/page/meta.toml
+++ b/blocks/video-title-card/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-title-card"
-title         = "Add a Title or Lower Third to a Video Online — Free, In-Browser — gizza.ai"
+title         = "Add a Title or Lower Third to a Video Online — Free, In-Browser"
 description   = "Add a styled title or lower-third caption to your video over a set time range — pick position, font size, color and a background bar. Free, in your browser."
 tags          = ["add text to video", "video title", "lower third", "caption video", "text overlay", "title card", "drawtext", "reels", "shorts", "ffmpeg"]
 h1            = "Add a Title or Lower Third to a Video"

--- a/blocks/video-to-gif/page/meta.toml
+++ b/blocks/video-to-gif/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-to-gif"
-title         = "Video to GIF Converter — gizza.ai"
+title         = "Video to GIF Converter"
 description   = "Turn any video into an animated GIF right in your browser. Pick a section, set fps and width — high-quality palette, runs locally, nothing is uploaded, free."
 tags          = ["video", "gif", "animated-gif", "convert", "video-to-gif", "clip", "loop", "share"]
 h1            = "Video to GIF"

--- a/blocks/video-to-h264/page/meta.toml
+++ b/blocks/video-to-h264/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-to-h264"
-title         = "Convert Video to H.264 MP4 Online — gizza.ai"
+title         = "Convert Video to H.264 MP4 Online"
 description   = "Force-transcode any video to universally-playable H.264 High-profile MP4 (yuv420p, faststart, AAC) in your browser. Make clips that won't play work everywhere."
 tags          = ["h264", "mp4", "video", "convert", "transcode", "yuv420p", "compatibility", "faststart", "aac", "webm", "hevc", "profile"]
 h1            = "Convert Video to H.264 MP4"

--- a/blocks/video-transcode/page/meta.toml
+++ b/blocks/video-transcode/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-transcode"
-title         = "Transcode a Video Online — gizza.ai"
+title         = "Transcode a Video Online"
 description   = "Convert any video to MP4 or WebM right in your browser — pick a target format and quality. Re-encodes locally with ffmpeg, nothing is uploaded, free."
 tags          = ["video", "transcode", "convert", "format", "mp4", "webm", "reencode"]
 h1            = "Transcode a Video"

--- a/blocks/video-trim/page/meta.toml
+++ b/blocks/video-trim/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "video-trim"
-title         = "Trim a Video Online — gizza.ai"
+title         = "Trim a Video Online"
 description   = "Cut a clip out of any video right in your browser — set a start time and duration. Stream-copy (no re-encode), runs locally, nothing is uploaded, free."
 tags          = ["video", "trim", "cut", "clip", "crop", "split", "start", "duration"]
 h1            = "Trim a Video"

--- a/blocks/voice-note-converter/page/meta.toml
+++ b/blocks/voice-note-converter/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "voice-note-converter"
-title         = "Voice Note Converter — gizza.ai"
+title         = "Voice Note Converter"
 description   = "Convert WhatsApp, Telegram, Signal and other Opus/Ogg voice notes to MP3 or WAV, or encode audio back to Opus voice notes in your browser."
 tags          = ["audio", "voice note", "opus", "ogg", "mp3", "wav", "whatsapp", "telegram"]
 h1            = "Convert a Voice Note"

--- a/blocks/waveform-image/page/meta.toml
+++ b/blocks/waveform-image/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "waveform-image"
-title         = "Audio Waveform Image Generator — gizza.ai"
+title         = "Audio Waveform Image Generator"
 description   = "Turn any audio file into a waveform PNG in your browser — pick the size, solid or gradient wave colors and background, or keep it transparent. Nothing is uploaded."
 tags          = ["audio", "waveform", "image", "png", "visualizer", "soundwave", "podcast", "banner", "gradient", "stereo", "transparent"]
 h1            = "Waveform Image from Audio"

--- a/blocks/weak-password-detector/page/meta.toml
+++ b/blocks/weak-password-detector/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "weak-password-detector"
-title         = "Weak Password Detector — Check Passwords Against Common & Breached Lists — gizza.ai"
+title         = "Weak Password Detector — Check Passwords Against Common & Breached Lists"
 description   = "Check whether a password is one of the most common or breached passwords. Detects case and leetspeak variants, offline in your browser — nothing is uploaded."
 tags          = ["weak password detector", "common password check", "breached password", "password blocklist", "is my password weak", "leetspeak password", "password checker", "worst passwords"]
 h1            = "Weak Password Detector"

--- a/blocks/word-count/page/meta.toml
+++ b/blocks/word-count/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "word-count"
-title         = "Word Counter — gizza.ai"
+title         = "Word Counter"
 description   = "Count the words, characters, and lines in any block of text. Free, instant, runs entirely in your browser — no sign-up required."
 tags          = ["word count", "character count", "text"]
 h1            = "Word Counter"

--- a/blocks/word-frequency/page/meta.toml
+++ b/blocks/word-frequency/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "word-frequency"
-title         = "Word Frequency Counter — Rank the most-used words — gizza.ai"
+title         = "Word Frequency Counter — Rank the most-used words"
 description   = "Count how often each word appears in your text and rank them by frequency, right in your browser. Skip short words, drop stop words, keep the top N. Free, private."
 tags          = ["word frequency", "word counter", "most common words", "term frequency", "keyword density", "word tally"]
 h1            = "Word frequency counter"

--- a/blocks/xml-formatter/page/meta.toml
+++ b/blocks/xml-formatter/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "xml-formatter"
-title         = "XML Formatter — Pretty-print & minify XML — gizza.ai"
+title         = "XML Formatter — Pretty-print & minify XML"
 description   = "Pretty-print or minify XML with indentation control and a well-formedness check, in your browser. Nothing is uploaded."
 tags          = ["xml formatter", "xml beautifier", "pretty print xml", "minify xml", "xml validator"]
 h1            = "XML formatter"

--- a/blocks/xml-to-csv/page/meta.toml
+++ b/blocks/xml-to-csv/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "xml-to-csv"
-title         = "XML to CSV — Convert XML to a CSV table — gizza.ai"
+title         = "XML to CSV — Convert XML to a CSV table"
 description   = "Flatten repeated XML elements into a CSV table, with columns inferred from child tags and attributes, in your browser. Free, private, no upload."
 tags          = ["xml to csv", "xml csv converter", "convert xml", "flatten xml", "xml to spreadsheet"]
 h1            = "XML to CSV"

--- a/blocks/xml-to-json/page/meta.toml
+++ b/blocks/xml-to-json/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "xml-to-json"
-title         = "XML to JSON — Convert XML to JSON online — gizza.ai"
+title         = "XML to JSON — Convert XML to JSON online"
 description   = "Convert an XML document into an equivalent JSON structure, preserving attributes and nesting, in your browser. Free, private, no upload."
 tags          = ["xml to json", "xml json converter", "convert xml to json", "xml parser", "xml to json online"]
 h1            = "XML to JSON"

--- a/blocks/xor-cipher/page/meta.toml
+++ b/blocks/xor-cipher/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "xor-cipher"
-title         = "XOR Cipher — Repeating-key XOR for text, hex, and Base64 — gizza.ai"
+title         = "XOR Cipher — Repeating-key XOR for text, hex, and Base64"
 description   = "XOR text, hex, or Base64 data against a repeating key and output hex, Base64, or UTF-8. Symmetric encrypt/decrypt in your browser."
 tags          = ["xor", "xor cipher", "xor encrypt", "xor decrypt", "repeating-key xor", "vigenere xor", "cryptopals", "hex xor", "base64 xor"]
 h1            = "XOR cipher"

--- a/blocks/xpath-query/page/meta.toml
+++ b/blocks/xpath-query/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "xpath-query"
-title         = "XPath Query — Evaluate XPath 1.0 on XML/XHTML — gizza.ai"
+title         = "XPath Query — Evaluate XPath 1.0 on XML/XHTML"
 description   = "Run an XPath 1.0 expression against XML or XHTML and return matching node values or serialized XML. Local browser WebAssembly tool."
 tags          = ["xpath", "xpath query", "xml xpath", "xhtml xpath", "xml query", "xpath tester", "xpath evaluator"]
 h1            = "XPath query"

--- a/blocks/z-score-normalize/page/meta.toml
+++ b/blocks/z-score-normalize/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "z-score-normalize"
-title         = "Z-Score Normalize — Z-Score, Min-Max, Max-Abs & Robust Scaling — gizza.ai"
+title         = "Z-Score Normalize — Z-Score, Min-Max, Max-Abs & Robust Scaling"
 description   = "Standardize a list of numbers with z-score, min-max, max-abs, or robust median/IQR scaling. Population or sample standard deviation, private and browser-local."
 tags          = ["z-score", "z-score normalization", "standardize", "standardization", "standard score", "min-max scaling", "max-abs scaling", "robust scaling", "median", "interquartile range", "feature scaling", "normalize numbers", "standard deviation", "rescale", "statistics", "machine learning"]
 h1            = "Z-Score Normalize"

--- a/blocks/zero-width-cleaner/page/meta.toml
+++ b/blocks/zero-width-cleaner/page/meta.toml
@@ -1,5 +1,5 @@
 slug          = "zero-width-cleaner"
-title         = "Zero-Width Character Cleaner — Remove invisible spaces, joiners & BOMs — gizza.ai"
+title         = "Zero-Width Character Cleaner — Remove invisible spaces, joiners & BOMs"
 description   = "Detect and strip invisible zero-width spaces, joiners, byte-order marks, bidi controls and soft hyphens from pasted text, in your browser. Nothing is uploaded."
 tags          = ["zero width space remover", "remove invisible characters", "strip zero width joiner", "remove byte order mark", "clean pasted text", "delete zero width space"]
 h1            = "Zero-width character cleaner"

--- a/scripts/check-tool-hygiene.py
+++ b/scripts/check-tool-hygiene.py
@@ -26,6 +26,12 @@ to real regressions:
   4. Summary drift. The wafer_block macro summary, `manifest.json` `summary`, and
      `wafer.toml` `summary` must agree (a trailing period is ignored).
 
+  8. Site branding. Pages must be generic: the site injects branding at render
+     time (`SiteConfig` `title_suffix`/header/footer — `tools/generator/src/site.rs`).
+     A literal `gizza.ai`/`gizza-ai.pages.dev` string in `page/meta.toml`,
+     `content.md`, `custom.js` or `custom.css` would leak the brand into the
+     public, MIT-licensed page sources themselves.
+
 Prose usability standards (see `.claude/skills/improve-tool/SKILL.md`) were being
 skipped silently because nothing failed the build. This turns the mechanically
 checkable ones into a gate.
@@ -44,8 +50,8 @@ aggregated advisory so CI stays green until the corpus is backfilled:
      require 50-170 chars (truncation starts ~160; shorter than 50 wastes the slot).
 
 Usage:
-  scripts/check-tool-hygiene.py                 # repo-wide: checks 1-4 gate, 5-7 advisory
-  scripts/check-tool-hygiene.py <slug> [<slug>] # per-slug STRICT: checks 1-7 all gate
+  scripts/check-tool-hygiene.py                 # repo-wide: checks 1-4+8 gate, 5-7 advisory
+  scripts/check-tool-hygiene.py <slug> [<slug>] # per-slug STRICT: checks 1-8 all gate
 
 Exit code 0 = clean, 1 = violations found (prints each), 2 = usage error.
 """
@@ -69,6 +75,7 @@ STR_LIT_RE = re.compile(r'"([^"]*)"')
 FAQ_HEADING_RE = re.compile(r"^#{1,6}\s*(faq|frequently asked)", re.IGNORECASE | re.MULTILINE)
 MACRO_SUMMARY_RE = re.compile(r'wafer_block\((?:.|\n)*?\bsummary\s*=\s*"((?:\\.|[^"\\])*)"')
 WAFER_SUMMARY_RE = re.compile(r'^\s*summary\s*=\s*"((?:\\.|[^"\\])*)"', re.MULTILINE)
+BRAND_RE = re.compile(r"gizza\.ai|gizza-ai\.pages\.dev", re.IGNORECASE)
 
 
 def norm_summary(s: str) -> str:
@@ -220,6 +227,19 @@ def check_block(slug_dir: Path) -> list[str]:
     if summaries and len({norm_summary(v) for v in summaries.values()}) > 1:
         detail = ", ".join(f"{k}={v!r}" for k, v in summaries.items())
         problems.append(f"{slug}: summary differs across {detail} — keep the three in sync (a trailing period is fine).")
+
+    # 8. Site branding. Pages must be generic: the site injects branding at
+    #    render time (SiteConfig title_suffix/header/footer). Domain strings
+    #    in page/ would leak the brand into the public, MIT-licensed pages.
+    for name in ("meta.toml", "content.md", "custom.js", "custom.css"):
+        f = slug_dir / "page" / name
+        if f.is_file():
+            m = BRAND_RE.search(f.read_text(encoding="utf-8", errors="replace"))
+            if m:
+                problems.append(
+                    f"{slug}: site branding {m.group(0)!r} in page/{name} "
+                    "— pages must be generic (branding is injected by the site config)"
+                )
 
     return problems
 

--- a/scripts/check-tool-hygiene.test.sh
+++ b/scripts/check-tool-hygiene.test.sh
@@ -182,4 +182,29 @@ EOF
 out2="$(python3 "$root/scripts/check-tool-hygiene.py" "$slug" 2>&1 || true)"
 grep -q 'summary differs' <<<"$out2" || { echo "FAIL: gate missed a summary inconsistency" >&2; exit 1; }
 
+# Restore a compliant manifest before testing check #8 in isolation.
+cat > "$dir/manifest.json" <<'EOF'
+{ "summary": "Encode or decode data.", "tool": { "parameters": { "properties": {
+  "mode": { "type": "string", "enum": ["encode", "decode"], "default": "encode" },
+  "text": { "type": "string" }
+} } } }
+EOF
+
+# Site branding (check #8): a page/meta.toml title carrying the literal site
+# suffix must fail — pages must be generic, the site injects branding at
+# render time via SiteConfig.
+sed -i 's/^slug        = "zzhygiene-scratch"$/slug        = "zzhygiene-scratch"\ntitle       = "X — gizza.ai"/' "$dir/page/meta.toml"
+out6="$(python3 "$root/scripts/check-tool-hygiene.py" "$slug" 2>&1)" && {
+  echo "FAIL: gate passed a block with site branding in page/meta.toml (should have failed)" >&2
+  exit 1
+}
+grep -q 'site branding' <<<"$out6" || { echo "FAIL: missing site-branding violation" >&2; exit 1; }
+
+# Fixing it (bare title, no brand string) must pass again.
+sed -i '/^title       = "X — gizza\.ai"$/d' "$dir/page/meta.toml"
+python3 "$root/scripts/check-tool-hygiene.py" "$slug" >/dev/null 2>&1 || {
+  echo "FAIL: gate rejected a block with no site branding" >&2
+  python3 "$root/scripts/check-tool-hygiene.py" "$slug" >&2 || true
+  exit 1; }
+
 echo "check-tool-hygiene.test.sh OK"

--- a/scripts/scaffold-tool.sh
+++ b/scripts/scaffold-tool.sh
@@ -175,7 +175,7 @@ EOF
 
 cat > "$dir/page/meta.toml" <<EOF
 slug          = "$slug"
-title         = "TODO — gizza.ai"
+title         = "TODO"
 description   = "TODO."
 tags          = []
 h1            = "TODO"
@@ -321,7 +321,7 @@ pub fn plan(in_name: &str) -> Result<(Vec<String>, String), String> {
 EOF
   cat > "$dir/page/meta.toml" <<EOF
 slug          = "$slug"
-title         = "TODO — gizza.ai"
+title         = "TODO"
 description   = "TODO."
 tags          = []
 h1            = "TODO"

--- a/site/site-config.toml
+++ b/site/site-config.toml
@@ -1,6 +1,6 @@
 base_url = "https://gizza.ai"
 brand_name = "gizza.ai"
-title_suffix = ""
+title_suffix = " — gizza.ai"
 header_html = "partials/header.html"
 footer_html = "partials/footer.html"
 head_extras_html = "partials/head-extras.html"

--- a/tools/generator/src/descriptor.rs
+++ b/tools/generator/src/descriptor.rs
@@ -22,7 +22,8 @@ struct Descriptor<'a> {
     /// Block version from `manifest.json`; omitted when the manifest is missing.
     #[serde(skip_serializing_if = "Option::is_none")]
     version: Option<String>,
-    title: &'a str,
+    /// `meta.title` (bare) + `cfg.title_suffix` — see `SiteConfig::title`.
+    title: String,
     description: &'a str,
     tags: &'a [String],
     /// Primary category slug (first taxonomy match — see `categories.rs`).
@@ -105,7 +106,7 @@ pub fn tool_descriptor(
             .and_then(|m| m.get("version"))
             .and_then(|v| v.as_str())
             .map(String::from),
-        title: &meta.title,
+        title: cfg.title(&meta.title),
         description: &meta.description,
         tags: &meta.tags,
         category: categories::primary_category(meta).slug,
@@ -131,14 +132,19 @@ mod tests {
     use serde_json::json;
 
     fn branded() -> SiteConfig {
-        SiteConfig { base_url: "https://gizza.ai".into(), brand_name: "gizza.ai".into(), ..Default::default() }
+        SiteConfig {
+            base_url: "https://gizza.ai".into(),
+            brand_name: "gizza.ai".into(),
+            title_suffix: " — gizza.ai".into(),
+            ..Default::default()
+        }
     }
 
     fn audio_tool() -> ToolMeta {
         ToolMeta::from_toml(
             r#"
 slug          = "audio-convert"
-title         = "Convert Audio — gizza.ai"
+title         = "Convert Audio"
 description   = "Convert audio between formats in your browser."
 tags          = ["audio"]
 h1            = "Convert Audio"
@@ -262,7 +268,7 @@ source = "field"
         let clock = ToolMeta::from_toml(
             r#"
 slug          = "clock"
-title         = "Clock — gizza.ai"
+title         = "Clock"
 description   = "The current time, live."
 h1            = "Clock"
 hero_subtitle = "Live time."

--- a/tools/generator/src/index.rs
+++ b/tools/generator/src/index.rs
@@ -8,7 +8,8 @@ use serde::Serialize;
 #[derive(Serialize)]
 struct IndexEntry<'a> {
     slug: &'a str,
-    title: &'a str,
+    /// `meta.title` (bare) + `cfg.title_suffix` — see `SiteConfig::title`.
+    title: String,
     description: &'a str,
     tags: &'a [String],
     /// Site-relative path of the tool's machine-readable descriptor
@@ -18,12 +19,12 @@ struct IndexEntry<'a> {
 
 /// Serialize `[{slug,title,description,tags,descriptor}]` for every tool, in
 /// the given order.
-pub fn tools_index_json(metas: &[ToolMeta]) -> String {
+pub fn tools_index_json(cfg: &SiteConfig, metas: &[ToolMeta]) -> String {
     let entries: Vec<IndexEntry> = metas
         .iter()
         .map(|m| IndexEntry {
             slug: &m.slug,
-            title: &m.title,
+            title: cfg.title(&m.title),
             description: &m.description,
             tags: &m.tags,
             descriptor: format!("/tools/{}/tool.json", m.slug),
@@ -98,7 +99,7 @@ mod tests {
         ToolMeta::from_toml(
             r#"
 slug          = "calculator"
-title         = "Free Online Calculator — gizza.ai"
+title         = "Free Online Calculator"
 description   = "Evaluate expressions instantly."
 tags          = ["math", "arithmetic"]
 h1            = "Free Online Calculator"
@@ -121,7 +122,9 @@ source      = "field"
 
     #[test]
     fn index_has_slug_title_description() {
-        let json = tools_index_json(&[calc()]);
+        // Bare `meta.title` + `cfg.title_suffix` (Task 3) round-trips to the
+        // historical suffixed title.
+        let json = tools_index_json(&branded(), &[calc()]);
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert!(v.is_array());
         assert_eq!(v[0]["slug"], "calculator");
@@ -136,20 +139,27 @@ source      = "field"
     }
 
     #[test]
+    fn default_config_renders_bare_unsuffixed_title() {
+        let json = tools_index_json(&SiteConfig::default(), &[calc()]);
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v[0]["title"], "Free Online Calculator", "unsuffixed generic title");
+    }
+
+    #[test]
     fn tags_default_to_empty_array_when_absent() {
         // A tool meta without a `tags` line still serializes `tags: []`.
         let m = ToolMeta::from_toml(
             "slug=\"x\"\ntitle=\"X\"\ndescription=\"d\"\nh1=\"h\"\nhero_subtitle=\"s\"\nwasm=\"w\"\nexport=\"e\"\noutput_label=\"o\"\nformat=\"text\"\n",
         )
         .unwrap();
-        let v: serde_json::Value = serde_json::from_str(&tools_index_json(&[m])).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&tools_index_json(&SiteConfig::default(), &[m])).unwrap();
         assert!(v[0]["tags"].is_array());
         assert_eq!(v[0]["tags"].as_array().unwrap().len(), 0);
     }
 
     #[test]
     fn empty_metas_is_empty_array() {
-        assert_eq!(tools_index_json(&[]), "[]");
+        assert_eq!(tools_index_json(&SiteConfig::default(), &[]), "[]");
     }
 
     #[test]
@@ -167,7 +177,12 @@ source      = "field"
     }
 
     fn branded() -> SiteConfig {
-        SiteConfig { base_url: "https://gizza.ai".into(), brand_name: "gizza.ai".into(), ..Default::default() }
+        SiteConfig {
+            base_url: "https://gizza.ai".into(),
+            brand_name: "gizza.ai".into(),
+            title_suffix: " — gizza.ai".into(),
+            ..Default::default()
+        }
     }
 
     #[test]

--- a/tools/generator/src/main.rs
+++ b/tools/generator/src/main.rs
@@ -209,7 +209,7 @@ fn run() -> Result<(), String> {
     // /tools/ so it is covered by the runtime SW's /tools/ bypass).
     fs::write(
         pkg_tools.join("_index.json"),
-        index::tools_index_json(&metas_only),
+        index::tools_index_json(&cfg, &metas_only),
     )
     .map_err(|e| format!("write tools/_index.json: {e}"))?;
 

--- a/tools/generator/src/markdown.rs
+++ b/tools/generator/src/markdown.rs
@@ -246,7 +246,7 @@ mod tests {
         ToolMeta::from_toml(
             r#"
 slug          = "calculator"
-title         = "Free Online Calculator — gizza.ai"
+title         = "Free Online Calculator"
 description   = "Evaluate expressions instantly."
 tags          = ["math"]
 h1            = "Free Online Calculator"
@@ -282,7 +282,7 @@ source      = "field"
         ToolMeta::from_toml(
             r#"
 slug          = "image-grayscale"
-title         = "Grayscale an Image — gizza.ai"
+title         = "Grayscale an Image"
 description   = "Convert an image to grayscale in your browser."
 h1            = "Grayscale an Image"
 hero_subtitle = "Upload an image."
@@ -306,7 +306,7 @@ accept = "image/*"
         ToolMeta::from_toml(
             r#"
 slug          = "clock"
-title         = "Clock — gizza.ai"
+title         = "Clock"
 description   = "The current time, live."
 h1            = "Clock"
 hero_subtitle = "Live time."

--- a/tools/generator/src/og.rs
+++ b/tools/generator/src/og.rs
@@ -276,7 +276,7 @@ mod tests {
         let meta = ToolMeta::from_toml(
             r#"
 slug          = "calculator"
-title         = "Free Online Calculator — gizza.ai"
+title         = "Free Online Calculator"
 description   = "Evaluate expressions instantly."
 h1            = "Free Online Calculator"
 hero_subtitle = "Type a math expression — result updates instantly."

--- a/tools/generator/src/pairs.rs
+++ b/tools/generator/src/pairs.rs
@@ -996,7 +996,7 @@ mod tests {
         ToolMeta::from_toml(
             r#"
 slug          = "audio-convert"
-title         = "Convert Audio Online — gizza.ai"
+title         = "Convert Audio Online"
 description   = "d"
 h1            = "Convert an Audio File"
 hero_subtitle = "s"
@@ -1014,7 +1014,7 @@ format        = "audio"
         ToolMeta::from_toml(
             r#"
 slug          = "image-convert"
-title         = "Convert an Image Online — gizza.ai"
+title         = "Convert an Image Online"
 description   = "d"
 h1            = "Convert an Image"
 hero_subtitle = "s"

--- a/tools/generator/src/template.rs
+++ b/tools/generator/src/template.rs
@@ -30,6 +30,9 @@ pub fn render_page(
 ) -> String {
     let canonical = cfg.abs(&format!("/tools/{}/", meta.slug));
     let og_image = cfg.abs(&format!("/tools/{}/og.png", meta.slug));
+    // `meta.title` is the bare per-tool title (Task 3: the literal site suffix
+    // moved out of `blocks/*/page/meta.toml` and into `cfg.title_suffix`).
+    let page_title = cfg.title(&meta.title);
     // Both JSON blobs below are emitted raw inside <script> via PreEscaped, so a
     // literal "</script>" in any value would break out of the element. serde_json
     // does not escape '/', so we neutralize the closing-tag sequence. Values are
@@ -95,7 +98,7 @@ pub fn render_page(
             head {
                 meta charset="utf-8";
                 meta name="viewport" content="width=device-width, initial-scale=1";
-                title { (meta.title) }
+                title { (page_title) }
                 meta name="description" content=(meta.description);
                 @if let Some(c) = &canonical {
                     link rel="canonical" href=(c);
@@ -103,7 +106,7 @@ pub fn render_page(
                 link rel="alternate" type="text/markdown" href="index.md";
                 link rel="alternate" type="application/json" href="tool.json";
                 meta property="og:type" content="website";
-                meta property="og:title" content=(meta.title);
+                meta property="og:title" content=(page_title);
                 meta property="og:description" content=(meta.description);
                 @if let Some(c) = &canonical {
                     meta property="og:url" content=(c);
@@ -112,10 +115,10 @@ pub fn render_page(
                     meta property="og:image" content=(img);
                     meta property="og:image:width" content="1200";
                     meta property="og:image:height" content="630";
-                    meta property="og:image:alt" content=(meta.title);
+                    meta property="og:image:alt" content=(page_title);
                 }
                 meta name="twitter:card" content="summary_large_image";
-                meta name="twitter:title" content=(meta.title);
+                meta name="twitter:title" content=(page_title);
                 meta name="twitter:description" content=(meta.description);
                 @if let Some(img) = &og_image {
                     meta name="twitter:image" content=(img);
@@ -780,17 +783,23 @@ mod tests {
     use crate::meta::ToolMeta;
 
     /// A branded config matching today's real `site/site-config.toml`
-    /// (`base_url`/`brand_name` set) — most existing assertions here check
-    /// the historical absolute `https://gizza.ai/...` links and chrome.
+    /// (`base_url`/`brand_name`/`title_suffix` set) — most existing assertions
+    /// here check the historical absolute `https://gizza.ai/...` links, chrome,
+    /// and suffixed `<title>` text.
     fn branded() -> SiteConfig {
-        SiteConfig { base_url: "https://gizza.ai".into(), brand_name: "gizza.ai".into(), ..Default::default() }
+        SiteConfig {
+            base_url: "https://gizza.ai".into(),
+            brand_name: "gizza.ai".into(),
+            title_suffix: " — gizza.ai".into(),
+            ..Default::default()
+        }
     }
 
     fn sample() -> ToolMeta {
         ToolMeta::from_toml(
             r#"
 slug          = "calculator"
-title         = "Free Online Calculator — gizza.ai"
+title         = "Free Online Calculator"
 description   = "Evaluate expressions instantly."
 h1            = "Free Online Calculator"
 hero_subtitle = "Type a math expression."
@@ -888,16 +897,12 @@ source      = "field"
 
     #[test]
     fn default_config_renders_generic_header_footer_no_brand() {
-        // `sample()`'s title carries a literal " — gizza.ai" suffix, mirroring
-        // every real `blocks/*/page/meta.toml` today (unmigrated data, Task 3's
-        // job — `meta.title` is rendered as-is regardless of `cfg`). Use an
-        // unsuffixed title here so this test isolates GENERATOR-introduced
-        // branding, not that known, pre-existing, out-of-scope data residue.
-        let mut meta = sample();
-        meta.title = "Free Online Calculator".to_string();
+        // `sample()`'s title is bare (Task 3: the site suffix moved out of
+        // `blocks/*/page/meta.toml` and into `cfg.title_suffix`), so the
+        // default (empty-suffix) config renders it completely unsuffixed.
         let html = render_page(
             &SiteConfig::default(),
-            &meta,
+            &sample(),
             "<h2>About</h2>",
             &ParamSchema::empty(),
             false,
@@ -1164,7 +1169,7 @@ placeholder = "640"
         ToolMeta::from_toml(
             r#"
 slug          = "age-calculator"
-title         = "Age Calculator — gizza.ai"
+title         = "Age Calculator"
 description   = "d"
 h1            = "Age Calculator"
 hero_subtitle = "s"


### PR DESCRIPTION
## Summary

- Strip the literal `" — gizza.ai"` site-brand suffix from every `blocks/*/page/meta.toml` `title` (369 files — see breakdown below, the corpus actually used three different separator characters for the same suffix).
- Neutralize the 2 `page/content.md` files that mentioned the domain in prose.
- Flip `site/site-config.toml` `title_suffix = " — gizza.ai"` on.
- Wire the per-tool `<title>`/`og:title`/`og:image:alt`/`twitter:title` (`template.rs`), `tool.json` `title` (`descriptor.rs`), and `_index.json` `title` (`index.rs`) through `SiteConfig::title()` instead of reading `meta.title` raw, so the branded render reproduces the historical suffixed title (this is `SiteConfig::title()`'s first real caller — the `dead_code` warning on it is gone).
- Add tool-hygiene **check 8** ("site branding"): `page/{meta.toml,content.md,custom.js,custom.css}` must never contain `gizza.ai`/`gizza-ai.pages.dev` — hard-gates in both repo-wide and per-slug modes, so branding can't silently re-enter `blocks/`. Self-test written first (confirmed failing before the check existed).
- `scaffold-tool.sh`'s `meta.toml` template no longer writes the suffix into scaffolded titles.

This is prep PR 3 of 4 ahead of the public/private repo split — `blocks/` ships in the public repo and must not carry site branding in its source; the site injects branding at render time via `SiteConfig`.

## Files neutralized (content.md prose mentions)

| File | Old | New |
|---|---|---|
| `blocks/audio-metadata-stripper/page/content.md` | "...but the page does not upload your file to gizza.ai." | "...but the page does not upload your file anywhere." |
| `blocks/video-caption-burner/page/content.md` | "...your source video is not uploaded to gizza.ai." | "...your source video is not uploaded anywhere." |

## Title suffix breakdown (369 files touched)

Investigating the corpus turned up **three different separator characters** used for the same site-brand suffix, not just the em dash:

| Separator | Count | Example (before) |
|---|---|---|
| em dash `" — gizza.ai"` | 323 | `Free Online Calculator — gizza.ai` |
| pipe `" \| gizza.ai"` | 45 | `Avro to JSON — Decode Apache Avro (.avro / OCF) to JSON \| gizza.ai` |
| middle dot `" · gizza.ai"` | 1 | `Task List Summarizer — count done & pending Markdown tasks · gizza.ai` |

All three are stripped identically (same meaning, just a different byte before "gizza.ai"). The 323 em-dash titles round-trip byte-for-byte through `title_suffix`. The 46 pipe/middle-dot titles do **not** round-trip byte-for-byte — their rendered `<title>` tail visibly normalizes from `\| gizza.ai` / `· gizza.ai` to the config's canonical `— gizza.ai`. This is intentional: once branding is centralized in one config value, every page should carry the *same* suffix, not three different historical spellings of it. Verified every affected `tool.json`/`<title>`/`_index.json` diff changes only the title tail, nothing else. Full list of the 46 normalized titles:

`avro-to-json, cidr-calculator, cmac-generate, column-math, context-trimmer, cron-next-runs, cumulative-sum, disposable-email-detector, email-normalizer, email-reply-cleaner, email-validator, file-tree-generator, gpx-privacy-scrubber, gzip-size-estimator, hash-all, hash-identifier, hash-text, head-lines, hmac-generate, ip-range-expand, ip-range-to-cidr, jsonata-query, keccak-hash, list-set-diff, markdown-section-extractor, page-weight-analyzer, parse-grpc-frame, parse-websocket-frame, phishing-header-inspector, protobuf-decode, sha3-hash, sql-dump-to-csv, srt-shift, srt-to-vtt, strip-ansi-codes, structured-data-validator, subtitle-merge, tail-lines, task-list-summarizer, text-wrap, timezone-convert, token-counter, truncate-text, url-safety-inspect, utm-link-builder, verify-checksum`

## Accepted title-parity exception: 25 tools that never had the suffix at all

Separately, 25 of the 394 real `blocks/*/page/meta.toml` titles **never carried the `gizza.ai` suffix in the first place** — a pre-existing corpus inconsistency (confirmed via `git log`/`git diff`: these files are untouched by the strip commit; their titles were always bare). Flipping `title_suffix` on applies it to *every* page uniformly, so these 25 gain the suffix for the first time, e.g. `CSV Cleaner — Trim, Dedupe & Fix Messy CSV Online` → `... — gizza.ai`. This is a real content change to those 25 live titles, not a bug this PR introduces — it fixes a real inconsistency (25/394 pages missing the sitewide suffix everything else had) by making branding uniform and config-driven instead of ad hoc per file. Flagging explicitly since it shows up in the parity diff and the task's default expectation was a byte-exact round trip:

`base-decoder, basic-auth-header-generator, csv-change-delimiter, csv-cleaner, csv-dedupe, csv-filter, csv-formula-eval, csv-group-by, csv-insert-column, csv-join, csv-pivot, csv-query, csv-sort, dotenv-manager, ip-log-anonymizer, krutidev-unicode-converter, metadata-privacy-linter, mt940-statement-parse, readability-extractor, resume-builder, safelink-decoder, sql-playground, url-cleaner, vcard-deduplicate, vcard-to-json`

## Parity evidence

Golden baseline captured fresh from `main` (`58b7182f`) before branching:

```
cargo run --manifest-path chrome/Cargo.toml --bin emit_partials -- site/partials
cargo run --manifest-path tools/generator/Cargo.toml -- . --site-config site/site-config.toml
cp -r pkg/tools /tmp/claude-parity-before
```

After all changes, rebuilt the same way and diffed:

```
diff -rq /tmp/claude-parity-before pkg/tools
```

147 diff lines total, fully accounted for:
- 71 tools × (`index.html` + `tool.json`) = 142 lines — title-only changes (46 separator-normalized + 25 newly-suffixed above). Verified programmatically that every `tool.json` diff is exactly the `"title"` key and nothing else, and every `index.html` diff touches exactly the 4 known title occurrences (`<title>`, `og:title`, `og:image:alt`, `twitter:title`).
- 2 tools × (`index.html` + `index.md`) = 4 lines — the content.md neutralizations above, confirmed to be *only* the neutralized sentence (titles for these two are byte-identical old vs new).
- `_index.json` = 1 line (aggregate file) — confirmed programmatically that exactly 71 entries changed and every changed entry's only differing key is `title`.
- All hub pages, the landing page, pair pages, and `og.png` assets: zero diffs.

Generic (fully unbranded) render is clean of the brand string:
```
cargo run --manifest-path tools/generator/Cargo.toml -- . --out /tmp/claude-generic-tools
grep -rl 'gizza\.ai' /tmp/claude-generic-tools --include='*.html' --include='*.json' --include='*.md' | wc -l
# => 0
```

Repo-wide hygiene gate (all 8 checks, including the new check 8):
```
python3 scripts/check-tool-hygiene.py
# => tool-hygiene: OK — 558 tool(s) clean.
```

## TDD evidence (check 8)

RED — added the check-8 case to `scripts/check-tool-hygiene.test.sh` first, ran it against the not-yet-implemented check:
```
$ bash scripts/check-tool-hygiene.test.sh
FAIL: gate passed a block with site branding in page/meta.toml (should have failed)
```

GREEN — after implementing check 8 in `scripts/check-tool-hygiene.py`'s `check_block`:
```
$ bash scripts/check-tool-hygiene.test.sh
check-tool-hygiene.test.sh OK
```

## Test plan

- [x] `bash scripts/check-tool-hygiene.test.sh` — OK (includes new check-8 case)
- [x] `python3 scripts/check-tool-hygiene.py` (repo-wide) — exit 0, 558 tools clean
- [x] `cargo test --manifest-path tools/generator/Cargo.toml` — 117 passed
- [x] `bash scripts/scaffold-tool.test.sh` — OK
- [x] `npm test` — 51 passed
- [x] Parity diff fully explained (see above)
- [x] No `Cargo.lock` diffs introduced

Not merging — this is a review-only PR per the split-prep program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
