### PR TITLE
feat: configurable blocks dir (GIZZA_BLOCKS_DIR / BLOCKS_DIR) for post-split site builds

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,9 @@ fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR");
 
-    let blocks_dir = PathBuf::from(&manifest_dir).join("blocks");
+    let blocks_dir_name = env::var("GIZZA_BLOCKS_DIR").unwrap_or_else(|_| "blocks".to_string());
+    let blocks_dir = PathBuf::from(&manifest_dir).join(&blocks_dir_name);
+    println!("cargo:rerun-if-env-changed=GIZZA_BLOCKS_DIR");
     // Do NOT `include_bytes!` block wasm anymore: baking every block into the
     // app cdylib grew `gizza_ai_bg.wasm` ~0.5 MiB per tool and blew past
     // Cloudflare Pages' hard 25 MiB/file limit once ~47 blocks accumulated
@@ -32,7 +34,7 @@ fn main() {
             entries.push((slug, manifest));
         }
     }
-    println!("cargo:rerun-if-changed=blocks");
+    println!("cargo:rerun-if-changed={}", blocks_dir_name);
 
     // Sort by slug for deterministic output.
     entries.sort_by(|a, b| a.0.cmp(&b.0));

--- a/scripts/gen-seo.sh
+++ b/scripts/gen-seo.sh
@@ -12,6 +12,15 @@ GIZZA="${GIZZA:-gizza}"
 REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
 BLOCKS_DIR="${BLOCKS_DIR:-$REPO_ROOT/blocks}"
 
+# Git repo containing the blocks tree (post-split this is the pinned gizza-ai
+# checkout, a different repo from $REPO_ROOT) + the blocks dir's path inside it.
+BLOCKS_GIT_ROOT="$(git -C "$BLOCKS_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -n "$BLOCKS_GIT_ROOT" ]; then
+  BLOCKS_GIT_PREFIX="$(realpath --relative-to="$BLOCKS_GIT_ROOT" "$BLOCKS_DIR")"
+else
+  BLOCKS_GIT_ROOT="$REPO_ROOT"; BLOCKS_GIT_PREFIX="blocks"   # non-git fixture dirs (tests)
+fi
+
 PKG_DIR="$REPO_ROOT/pkg"
 mkdir -p "$PKG_DIR"
 
@@ -52,17 +61,37 @@ is_page_slug() {
   return 1
 }
 
-# Last commit date (ISO 8601) touching a path — used for sitemap <lastmod>.
-# Empty when history is unavailable (shallow clone, no git); the tag is then
-# omitted rather than emitting a wrong date.
+# Last commit date (ISO 8601) touching a path in $REPO_ROOT — used for
+# sitemap <lastmod> on site (non-blocks) paths. Empty when history is
+# unavailable (shallow clone, no git); the tag is then omitted rather than
+# emitting a wrong date.
 git_lastmod() {
   git -C "$REPO_ROOT" log -1 --format=%cI -- "$1" 2>/dev/null || true
 }
 
-# First commit touching a path as "unixtime<TAB>iso8601" — used to order and
-# date the Atom feed entries. Empty when history is unavailable.
+# First commit touching a path in $REPO_ROOT as "unixtime<TAB>iso8601" — used
+# to order and date the Atom feed entries. Empty when history is unavailable.
 git_first_commit() {
   git -C "$REPO_ROOT" log --format='%ct%x09%cI' --reverse -- "$1" 2>/dev/null | head -n1 || true
+}
+
+# blocks_* variants of the two helpers above, rooted at $BLOCKS_GIT_ROOT with
+# paths relative to $BLOCKS_GIT_PREFIX rather than $REPO_ROOT — the blocks
+# tree can live in a different git repo from $REPO_ROOT (post-split: a pinned
+# checkout). $1 = path *inside* the blocks dir (e.g. "$slug/page"), or omitted
+# for the blocks dir itself.
+blocks_lastmod() {
+  git -C "$BLOCKS_GIT_ROOT" log -1 --format=%cI -- "$BLOCKS_GIT_PREFIX${1:+/$1}" 2>/dev/null || true
+}
+
+blocks_first_commit() {
+  git -C "$BLOCKS_GIT_ROOT" log --format='%ct%x09%cI' --reverse -- "$BLOCKS_GIT_PREFIX${1:+/$1}" 2>/dev/null | head -n1 || true
+}
+
+# Combined "unixtime iso8601" for a blocks path in one git invocation — used
+# by the feed to compare <updated> across entries by unix time.
+blocks_lastmod_ts() {
+  git -C "$BLOCKS_GIT_ROOT" log -1 --format='%ct %cI' -- "$BLOCKS_GIT_PREFIX${1:+/$1}" 2>/dev/null || true
 }
 
 # Escape text for XML content and attribute values (&, <, >, quotes).
@@ -87,7 +116,7 @@ site_mod="$(git_lastmod site)"
 {
   printf '<?xml version="1.0" encoding="UTF-8"?>\n'
   printf '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
-  blocks_mod="$(git_lastmod blocks)"
+  blocks_mod="$(blocks_lastmod)"
   emit_url "$BASE_URL/" "$site_mod"
   emit_url "$BASE_URL/chat" "$site_mod"
   emit_url "$BASE_URL/tools/" "$blocks_mod"
@@ -102,7 +131,7 @@ site_mod="$(git_lastmod site)"
     done < <(jq -r '.[].slug' "$hubs_json")
   fi
   for slug in "${page_slugs[@]}"; do
-    emit_url "$BASE_URL/tools/$slug/" "$(git_lastmod "blocks/$slug/page")"
+    emit_url "$BASE_URL/tools/$slug/" "$(blocks_lastmod "$slug/page")"
   done
   # "X to Y" conversion pair pages (/tools/<parent>/<src>-to-<tgt>/) from the
   # generator's _pairs.json. Skipped gracefully when the file is missing
@@ -113,7 +142,7 @@ site_mod="$(git_lastmod site)"
     while IFS= read -r pair_path; do
       [[ -z "$pair_path" ]] && continue
       parent="${pair_path%%/*}"
-      emit_url "$BASE_URL/tools/$pair_path/" "$(git_lastmod "blocks/$parent/page")"
+      emit_url "$BASE_URL/tools/$pair_path/" "$(blocks_lastmod "$parent/page")"
     done < <(jq -r '.[].path' "$pairs_json")
   fi
   printf '</urlset>\n'
@@ -131,7 +160,7 @@ site_mod="$(git_lastmod site)"
 # no git) skip the feed with a warning rather than emitting undated entries.
 feed_rows=()
 for slug in "${page_slugs[@]}"; do
-  first="$(git_first_commit "blocks/$slug/page")"
+  first="$(blocks_first_commit "$slug/page")"
   [[ -z "$first" ]] && continue
   feed_rows+=("$first"$'\t'"$slug")
 done
@@ -149,7 +178,7 @@ else
   feed_updated_ts=0
   for row in "${feed_newest[@]}"; do
     IFS=$'\t' read -r _ published slug <<< "$row"
-    read -r updated_ts updated <<< "$(git -C "$REPO_ROOT" log -1 --format='%ct %cI' -- "blocks/$slug/page" 2>/dev/null || true)"
+    read -r updated_ts updated <<< "$(blocks_lastmod_ts "$slug/page")"
     if [[ -z "$updated" ]]; then
       updated="$published"
       updated_ts=0

--- a/scripts/gen-seo.sh
+++ b/scripts/gen-seo.sh
@@ -10,6 +10,7 @@ GIZZA="${GIZZA:-gizza}"
 
 # Allow passing an explicit repo root for testing; default to script's parent dir
 REPO_ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+BLOCKS_DIR="${BLOCKS_DIR:-$REPO_ROOT/blocks}"
 
 PKG_DIR="$REPO_ROOT/pkg"
 mkdir -p "$PKG_DIR"
@@ -34,12 +35,12 @@ meta_field() {
 page_slugs=()
 while IFS= read -r meta_file; do
   [[ -z "$meta_file" ]] && continue
-  slug="${meta_file#"$REPO_ROOT/blocks/"}"
+  slug="${meta_file#"$BLOCKS_DIR/"}"
   slug="${slug%/page/meta.toml}"
   page_slugs+=("$slug")
 done < <(
-  [[ -d "$REPO_ROOT/blocks" ]] &&
-    find "$REPO_ROOT/blocks" -mindepth 3 -maxdepth 3 -path '*/page/meta.toml' -type f | sort
+  [[ -d "$BLOCKS_DIR" ]] &&
+    find "$BLOCKS_DIR" -mindepth 3 -maxdepth 3 -path '*/page/meta.toml' -type f | sort
 )
 
 # Membership lookup for page slugs (used when emitting llms.txt)
@@ -171,7 +172,7 @@ else
     printf '  <author><name>gizza.ai</name></author>\n'
     for row in "${feed_entries[@]}"; do
       IFS=$'\t' read -r published updated slug <<< "$row"
-      meta="$REPO_ROOT/blocks/$slug/page/meta.toml"
+      meta="$BLOCKS_DIR/$slug/page/meta.toml"
       title="$(meta_field "$meta" title)"
       [[ -z "$title" ]] && title="$slug"
       summary="$(meta_field "$meta" description)"
@@ -219,7 +220,7 @@ printf '%s' "$INDEXNOW_KEY" > "$PKG_DIR/$INDEXNOW_KEY.txt"
     if is_page_slug "$slug"; then
       # Fall back to meta.toml when gizza has no entry (or a null description)
       if [[ -z "$desc" || "$desc" == "null" ]]; then
-        meta="$REPO_ROOT/blocks/$slug/page/meta.toml"
+        meta="$BLOCKS_DIR/$slug/page/meta.toml"
         desc="$(meta_field "$meta" description)"
         [[ -z "$desc" ]] && desc="$(meta_field "$meta" title)"
       fi

--- a/scripts/gen-seo.test.sh
+++ b/scripts/gen-seo.test.sh
@@ -4,7 +4,7 @@ root="$(cd "$(dirname "$0")/.." && pwd)"
 
 # Create a temp dir that mirrors the repo structure expected by gen-seo.sh
 tmpdir="$(mktemp -d)"
-cleanup() { rm -rf "$tmpdir"; }
+cleanup() { rm -rf "$tmpdir" "${tmpdir2:-}"; }
 trap cleanup EXIT
 
 # Create the stub gizza binary
@@ -128,6 +128,42 @@ if ! grep -qF "https://example.test/tools/ghost-tool/index.md" "$llmstxt"; then
 fi
 if ! grep -qF "A tool only present on disk" "$llmstxt"; then
   echo "FAIL: llms.txt missing ghost-tool fallback description from meta.toml"
+  exit 1
+fi
+
+
+# --- BLOCKS_DIR in a SEPARATE git repo (post-split site build) ---
+# Regression test: the blocks tree's git history lives in whatever repo
+# contains $BLOCKS_DIR, which post-split is a different repo from $REPO_ROOT
+# (e.g. BLOCKS_DIR=gizza-ai/blocks, a pinned checkout with its own .git).
+# git-history lookups that hardcode `-C "$REPO_ROOT"` silently return nothing
+# in that layout, and sitemap <lastmod>/feed.xml go empty.
+tmpdir2="$(mktemp -d)"
+repo_root2="$tmpdir2/site-repo"
+blocks_repo="$tmpdir2/blocks-repo"
+mkdir -p "$repo_root2/pkg" "$blocks_repo/blocks/foreign-tool/page"
+
+printf 'title = "Foreign Tool"\ndescription = "Lives in a separate git repo"\n' \
+  > "$blocks_repo/blocks/foreign-tool/page/meta.toml"
+
+git -C "$blocks_repo" init -q
+git -C "$blocks_repo" add -A
+git -C "$blocks_repo" \
+  -c user.email=test@example.com -c user.name=test \
+  commit -q -m "add foreign-tool"
+
+BASE_URL="https://example.test" \
+GIZZA="$tmpdir/bin/gizza" \
+BLOCKS_DIR="$blocks_repo/blocks" \
+  bash "$root/scripts/gen-seo.sh" "$repo_root2"
+
+foreign_sitemap="$repo_root2/pkg/sitemap.xml"
+if ! grep -qF "https://example.test/tools/foreign-tool/" "$foreign_sitemap"; then
+  echo "FAIL: foreign-repo sitemap missing foreign-tool URL"
+  exit 1
+fi
+if ! grep -A1 "https://example.test/tools/foreign-tool/</loc>" "$foreign_sitemap" | grep -qF "<lastmod>"; then
+  echo "FAIL: foreign-repo sitemap missing <lastmod> for foreign-tool (BLOCKS_DIR git history lookup did not follow BLOCKS_DIR into its own repo)"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Makes the blocks directory configurable via environment variables (`GIZZA_BLOCKS_DIR` in build.rs, `BLOCKS_DIR` in scripts/gen-seo.sh) to support post-split site repo builds against pinned gizza-ai/blocks checkouts. Defaults to current behavior (root `blocks/` directory) when env vars are unset.

This is Phase 1 prep for repo split forward-compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)