### PR TITLE
docs: update tool-factory skills for the post-split public repo

### DIFF
--- a/.claude/skills/create-next-tool/SKILL.md
+++ b/.claude/skills/create-next-tool/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-next-tool
-description: "Use when the user wants to build the next un-built gizza tool from the tools-to-build.csv backlog. Picks the next tool whose blocks/<slug>/ folder doesn't exist yet, builds it with the /new-tool procedure, fully enhances + verifies it with the /improve-tool procedure (competitor research + 3-surface checks), then commits and pushes on the current branch. No new branch, no PR. One tool per run."
+description: "Use when the user wants to build the next un-built gizza tool from the tools-to-build.csv backlog. Picks the next tool whose blocks/<slug>/ folder doesn't exist yet, builds it with the /new-tool procedure, fully enhances + verifies it with the /improve-tool procedure (competitor research + CLI/page checks), then commits and pushes on the current branch. No new branch, no PR. One tool per run."
 ---
 
 # create-next-tool — build the next backlog tool end to end
@@ -19,11 +19,17 @@ already hit; read the relevant one BEFORE implementing.
 
 Follow these steps in order:
 
-0. **Toolchain.** This skill needs `cargo`, `wafer`, `wasm-pack`, `impresspress`, `gizza`, Playwright,
-   and `ffmpeg`. If any is missing, bootstrap once with `scripts/bootstrap-toolchain.sh` (details +
-   gotchas in `docs/TOOLCHAIN-SETUP.md`); the very first run also needs a baseline `impresspress build`
-   so every existing block has its `target/block.wasm` + `web/pkg/` (else the generator hard-aborts
-   and `gizza list` is incomplete).
+0. **Toolchain.** This is the public toolkit repo (blocks + `gizza` CLI + the generic tool-page
+   generator; no app, no branding, no deploy — those live in a private site repo that consumes this
+   one at a pin). This skill needs `cargo`, `wasm-pack`, `gizza`, Playwright, and `ffmpeg`; the
+   `wafer` CLI is OPTIONAL (a convenience wrapper around `cargo build --target wasm32-wasip1
+   --release`, only buildable from a sibling `wafer-run` checkout — not required here, and CI never
+   uses it). If any required tool is missing, bootstrap once with `scripts/bootstrap-toolchain.sh`
+   (details + gotchas in `docs/TOOLCHAIN-SETUP.md`); the very first run also needs a baseline pass
+   building every existing block's `target/block.wasm` (`cargo build --target wasm32-wasip1
+   --release` per block, copied in) + `web/pkg/` (`wasm-pack build blocks/<slug>/web --target web
+   --release --out-dir pkg` per block) — else the generator skips blocks missing `web/pkg/` and
+   `gizza list` is incomplete.
 
 1. **Pick the next tool.** From the gizza-ai repo root:
    ```bash
@@ -53,18 +59,20 @@ Follow these steps in order:
    after `cargo install --path cli`, run `python3 scripts/sync-tool-manifest.py <slug>` (see
    "Manifest sync + hygiene gate" below).
 
-   **Throughput note (verified):** the per-tool validation is `cd blocks/<slug> && cargo test
-   --workspace` + `wafer build` (validates the chat block.wasm) + `wasm-pack build blocks/<slug>/web`
-   + `cargo run --manifest-path tools/generator/Cargo.toml -- .` (renders the page) + `gizza tool`
-   (CLI) + Playwright. These are minutes. The full **`impresspress build` rebuilds the whole app wasm
-   (`-Oz`+lto, ~25 min on 2 CPUs) and is the loop bottleneck** — a new block changes only its own
-   block.wasm, which `wafer build` already validated, and CI runs `impresspress build` on deploy. So for
-   loop throughput, run `impresspress build` **once at the start (baseline) and not on every tool**; if you
-   skip it per-tool, say so in the report. The generator step still needs every block's `web/pkg/`
-   (built once in the baseline; only the new tool's is added per run).
+   **Throughput note (verified):** the per-tool validation is `cd blocks/<slug> && cargo build
+   --target wasm32-wasip1 --release` (then copy the produced wasm to `target/block.wasm` — exactly
+   what CI's "Build changed skill wasms" step runs) + `cargo test --workspace` + `wasm-pack build
+   blocks/<slug>/web --target web --release --out-dir pkg` + `cargo run --manifest-path
+   tools/generator/Cargo.toml -- .` (renders the page, GENERIC — no site config here) + `gizza tool`
+   (CLI) + Playwright. These are all minutes, and there is no whole-app build to amortize in this
+   repo — that bottleneck belonged to the site repo (which consumes this one at a pin and builds its
+   own branded app separately); each tool's page is fully standalone under `pkg/tools/<slug>/`. The
+   generator step still needs every OTHER block's `web/pkg/` to already exist (built once in the
+   toolchain baseline) so it doesn't skip them — only the new tool's `web/pkg/` is added per run.
 
-3. **Improve** — follow the FULL `/improve-tool` **Phases 1–5** on `<slug>`: verify the 3 surfaces
-   (chat/LLM API, CLI, page query-params) + fix any breakage → research the top-5 competitors → diff +
+3. **Improve** — follow the FULL `/improve-tool` **Phases 1–5** on `<slug>`: verify the 2
+   locally-verifiable surfaces (CLI, page query-params — the live chat UI lives in the private site
+   repo and can't be exercised here; see `/improve-tool` Phase 1) + fix any breakage → research the top-5 competitors → diff +
    rank gaps (fit-to-model) → close every in-model capability/copy/UX/visual gap → regenerate the
    drift-guard → re-run the full test matrix. Write the competitor-analysis snapshot to
    `docs/checks/<YYYY-MM-DD>-improve-<slug>-competitor-analysis.md`. **SKIP** `/improve-tool`'s "Gather
@@ -79,6 +87,9 @@ Follow these steps in order:
    git commit -m "feat(<slug>): competitor improvements + analysis"
    git push
    ```
+   Publication is a separate, out-of-scope step: this push doesn't reach gizza.ai by itself — the
+   private site repo consumes this repo at a pin, so the new tool goes live only after that repo's
+   pin is bumped past this commit (a PR there, not here).
 
 **Honesty + cleanup gate:** if the build (step 2) or verification (step 3 Phase 1) fails
 unrecoverably (≤3 fix attempts per the sibling skills), **STOP, run `git clean -fd blocks/<slug>` to
@@ -115,14 +126,17 @@ python3 scripts/check-tool-hygiene.py <slug>
 ```
 
 must exit 0 before committing — per-slug mode is STRICT: enum→manifest sync, FAQ as `<details>`
-accordions (blank line inside each), no scaffold TODOs, summary consistency, plus placeholders on
-text/number fields, ≥3 FAQ entries, and meta description length. CI runs the same gate repo-wide.
+accordions (blank line inside each), no scaffold TODOs, summary consistency, page copy stays
+GENERIC (no `gizza.ai`/`gizza-ai.pages.dev` string anywhere under `page/` — check 8; this repo
+renders unbranded, the private site repo injects branding at ITS build time, not here), plus
+placeholders on text/number fields, ≥3 FAQ entries, and meta description length. CI runs the same
+gate repo-wide.
 
 ## References (read the relevant one BEFORE implementing)
 
 - `references/wasm-crates.md` — proven wasm-safe crates with full recipes (crypto, PGP,
   ECDSA/Ed25519, EPUB/ZIP, mail parsing, GIF encoding, misc). Check here before adding ANY
-  dependency — an engine crate must INSTANTIATE under `wafer build`, not just compile.
+  dependency — an engine crate must INSTANTIATE, not just compile.
 - `references/page-patterns.md` — how params render on the page (select/checkbox/textarea),
   boolean checkbox defaults, drift-guard `N.0` gotcha, clocks across surfaces, recurring tool
   shapes, page output formats (incl. audio), what's un-buildable (audio-input, multi-input ffmpeg).

--- a/.claude/skills/create-next-tool/references/ops.md
+++ b/.claude/skills/create-next-tool/references/ops.md
@@ -10,9 +10,11 @@ with: `for d in blocks/*/target; do find "$d" -mindepth 1 -maxdepth 1 ! -name bl
 which is correct; do not additionally `rm -rf` any `web/pkg`. If a pkg does go missing, rebuild it with
 `wasm-pack build blocks/<slug>/web --target web --release --out-dir pkg` before re-running the generator.
 
-**cwd gotcha:** `wafer build` must run from inside `blocks/<slug>/`; `cargo install --path cli` and
-`wasm-pack build blocks/<slug>/web …` must run from the repo ROOT — after any `/tmp` command the shell
-cwd resets, so always cd to the absolute repo path before those.
+**cwd gotcha:** `cargo build --target wasm32-wasip1 --release` (the block-wasm build; optional
+equivalent shorthand `wafer build` if you have the `wafer` CLI installed from a sibling `wafer-run`
+checkout — not required in this repo) must run from inside `blocks/<slug>/`; `cargo install --path
+cli` and `wasm-pack build blocks/<slug>/web …` must run from the repo ROOT — after any `/tmp` command
+the shell cwd resets, so always cd to the absolute repo path before those.
 
 **CLI verification fetch is SSRF-guarded:** `gizza tool … url=…` only fetches PUBLIC http(s); `data:`
 URLs and localhost are rejected ("request to private/internal address is not allowed"), and GitHub
@@ -37,8 +39,10 @@ pre-read remaining budget from disk; it must react to a limit error (back off / 
   does), NOT `npm ci` (which hard-requires a lockfile and fails).
 - `cargo install --path cli` embeds only the blocks whose `target/block.wasm` exists. A fresh
   checkout has just the ~33 COMMITTED wasm fixtures, so the install produces (and globally
-  overwrites `~/.cargo/bin/gizza` with) a CLI missing most tools. Either run the baseline
-  `impresspress build` first, or reinstall from the full checkout when done.
+  overwrites `~/.cargo/bin/gizza` with) a CLI missing most tools. Either run the baseline per-block
+  build loop first (`for dir in blocks/*/; do (cd "$dir" && cargo build --target wasm32-wasip1
+  --release && mkdir -p target && cp target/wasm32-wasip1/release/*.wasm target/block.wasm); done` —
+  see `docs/TOOLCHAIN-SETUP.md` step 7), or reinstall from the full checkout when done.
 - The page generator prints a "web/pkg not found (skipping WASM copy)" warning per block whose
   wasm-pack output is missing — in a fresh checkout that's ~300 warnings. Harmless for the tool
   you're building (its own page still renders); noisy but expected without the baseline build.

--- a/.claude/skills/create-next-tool/references/wasm-crates.md
+++ b/.claude/skills/create-next-tool/references/wasm-crates.md
@@ -1,7 +1,10 @@
 # Proven wasm-safe crates + recipes (wafer wasm32-wasip1 / wasm-pack wasm32-unknown-unknown)
 
 Read this before adding ANY new dependency. An engine crate must INSTANTIATE, not just compile —
-`wafer build` is the gate; watch for `cannot find import
+building the block wasm (`cargo build --target wasm32-wasip1 --release`; the optional `wafer build`
+does the same thing if that CLI is installed) then actually invoking it via `cargo install --path
+cli --force && gizza tool <slug> …` is the gate (the CLI embeds the same wafer-run wasmi runtime
+chat would use); watch for `cannot find import
 wasi_snapshot_preview1::{poll_oneoff,path_open,fd_close}`.
 
 **Crypto / encoding crates that instantiate in wafer (wasm32-wasip1):** `rsa` 0.9 (sign: pkcs1v15 +
@@ -75,7 +78,8 @@ metadata on both wafer and wasm-pack, but the browser `wasm32-unknown-unknown` b
 `getrandom` transitively through crypto crates even when the code only parses keys. Add
 `getrandom = { version = "0.2", features = ["js"] }` in the core crate so
 `wasm-pack --target web` doesn't fail with "wasm*-unknown-unknown targets are not supported by
-default". The same crate still builds under `wafer build` for `wasm32-wasip1`.
+default". The same crate still builds for `wasm32-wasip1` (`cargo build --target wasm32-wasip1
+--release`, or `wafer build` if that optional CLI is installed).
 
 **Misc proven crates:** `toml = "0.8"` (config; TOML needs a table root + has no null),
 `color_quant = "1"` (NeuQuant palette quantization to N colors), `kamadak-exif = "0.6"` (EXIF/TIFF read —
@@ -91,8 +95,8 @@ xml-formatter) can't parse it. A forgiving quote-aware tag scanner (`scan_tag` s
 VOID elements don't indent; pre/textarea/script/style are emitted verbatim.
 
 **Writing .xlsx workbooks (csv-to-xlsx):** `rust_xlsxwriter = "0.79"` (default features `[]`; its `zip`
-dep uses pure-Rust `deflate`/miniz_oxide) writes real Office Open XML workbooks and INSTANTIATES under
-`wafer build` (wasm32-wasip1). Native cell types: `write_number`/`write_boolean`/`write_string`(`_with_format`),
+dep uses pure-Rust `deflate`/miniz_oxide) writes real Office Open XML workbooks and INSTANTIATES
+under `cargo build --target wasm32-wasip1 --release` (wasm32-wasip1). Native cell types: `write_number`/`write_boolean`/`write_string`(`_with_format`),
 `Format::new().set_bold()`, `set_freeze_panes(1,0)`, `worksheet.autofit()`, `workbook.save_to_buffer()`.
 **Browser gotcha:** every `Workbook::new()` stamps a creation timestamp via `ExcelDateTime::utc_now()` →
 `SystemTime::now()`, which **panics at runtime on wasm32-unknown-unknown** (no std clock) even though it's

--- a/.claude/skills/create-tool-loop/SKILL.md
+++ b/.claude/skills/create-tool-loop/SKILL.md
@@ -59,13 +59,15 @@ Working context (DERIVE at dispatch time — never hardcode; boxes and branches 
 This is the ONLY copy of the builder prompt; `create-next-tool/SKILL.md` points here. Edit it
 here or nowhere (a second copy WILL drift — it did once, re-introducing banned background builds).
 
-> Build the next gizza backlog tool end-to-end. Working dir `<REPO>` (a gizza-ai checkout), branch
-> `<BRANCH>`. Use absolute paths; `source $HOME/.cargo/env` in every bash command; `wafer build`
-> runs from INSIDE blocks/<slug>/; cwd resets after /tmp commands.
+> Build the next gizza backlog tool end-to-end. Working dir `<REPO>` (a gizza-ai checkout — the
+> public MIT toolkit: blocks + `gizza` CLI + the generic tool-page generator; no app, no branding, no
+> deploy — those live in a private site repo that consumes this one at a pin), branch `<BRANCH>`.
+> Use absolute paths; `source $HOME/.cargo/env` in every bash command; `cargo build --target
+> wasm32-wasip1 --release` runs from INSIDE blocks/<slug>/; cwd resets after /tmp commands.
 >
 > CRITICAL — NO BACKGROUND JOBS / NO TASK LEAKS: Run every build in the FOREGROUND with a generous
-> timeout (the Bash tool supports timeout up to 600000 ms = 10 min; cargo test / wafer build /
-> wasm-pack each finish well under that). Do NOT use run_in_background and do NOT spawn `sleep`/poll
+> timeout (the Bash tool supports timeout up to 600000 ms = 10 min; cargo test / cargo build --target
+> wasm32-wasip1 --release / wasm-pack each finish well under that). Do NOT use run_in_background and do NOT spawn `sleep`/poll
 > loops or `while` wait-loops — they leak as orphan background tasks. If for any reason you do start
 > a background job, you MUST kill it before returning (e.g. `kill $(jobs -p) 2>/dev/null`). Do NOT
 > end your turn while any build is still running. There is no external monitor.
@@ -95,12 +97,17 @@ here or nowhere (a second copy WILL drift — it did once, re-introducing banned
 >    control kinds (slider/color/tag-list/date/time, `[input.labels]`, `[[example]]` preset chips —
 >    see create-next-tool references/page-patterns.md) — the right control at build time, chips
 >    whenever competitors ship presets. Fill EVERY scaffold TODO.
-> 6. **Verify (all foreground):** `cargo test --workspace` (in blocks/<slug>/) → `wafer build` (in
->    blocks/<slug>/) → `wasm-pack build blocks/<slug>/web --target web --release --out-dir pkg` →
+> 6. **Verify (all foreground):** `cargo test --workspace` (in blocks/<slug>/) → `cargo build
+>    --target wasm32-wasip1 --release && mkdir -p target && cp target/wasm32-wasip1/release/*.wasm
+>    target/block.wasm` (in blocks/<slug>/ — exactly what CI's "Build changed skill wasms" step
+>    runs; `wafer build` is an optional equivalent shorthand if the `wafer` CLI happens to be
+>    installed) → `wasm-pack build blocks/<slug>/web --target web --release --out-dir pkg` →
 >    `cargo install --path cli` → `python3 scripts/sync-tool-manifest.py <slug>` (generates
 >    manifest.json tool.* from the live descriptor — never hand-edit those) → `cargo run
->    --manifest-path tools/generator/Cargo.toml -- .` → CLI (`gizza tool <slug> …`, incl. one
->    exact-output case) → Playwright (`cd tests && xvfb-run npx playwright test
+>    --manifest-path tools/generator/Cargo.toml -- .` (renders the page GENERIC — no site config in
+>    this repo; the private site repo that consumes this one at a pin renders its own branded copy
+>    at ITS build time) → CLI (`gizza tool <slug> …`, incl. one
+>    exact-output case) → Playwright (`cd tests && npx playwright test
 >    tool-page-<slug>.spec.ts`). The page spec MUST assert real output — exact text for pure tools;
 >    for media decode the result and assert dimensions/pixels (new-tool/reference.md §media
 >    correctness) — plus one `?param=` deep-link case. Advertised-values matrix: one real run per
@@ -108,14 +115,19 @@ here or nowhere (a second copy WILL drift — it did once, re-introducing banned
 >    while argv tests passed), ≥1 NON-default checkbox state, the exact cap boundary, ≥1 secondary
 >    input format for media tools. Copy-paste-run the page's generated CLI example VERBATIM (pure:
 >    succeeds; file tools: args parse + graceful fetch error).
-> 7. **Hygiene gate:** `python3 scripts/check-tool-hygiene.py <slug>` must exit 0 (per-slug strict
->    mode also enforces placeholders, FAQ count, and meta description length).
+> 7. **Hygiene gate:** `python3 scripts/check-tool-hygiene.py <slug>` must exit 0 — this also
+>    hard-fails any `gizza.ai`/`gizza-ai.pages.dev` string under `page/` (check 8: page copy must
+>    stay GENERIC/brand-free — this repo renders unbranded, the private site repo injects branding
+>    at ITS build time) (per-slug strict mode also enforces placeholders, FAQ count, and meta
+>    description length).
 > 8. **Honesty gate:** can't build+verify in ≤3 fix attempts → `git clean -fd blocks/<slug>`,
 >    skiplist or report FAILED. NEVER commit broken.
 > 9. **Cleanup:** `for d in blocks/*/target; do find "$d" -mindepth 1 -maxdepth 1 ! -name
 >    block.wasm -exec rm -rf {} + ; done`. NEVER delete any web/pkg.
 > 10. **Ship:** ONE commit for the tool + wasm artifacts + spec (a separate commit for the
 >    competitor-analysis doc is fine); `git add -A && git commit && git push origin <BRANCH>`.
+>    (This does not publish to gizza.ai — that's a separate pin-bump PR in the private site repo,
+>    out of scope here.)
 >
 > Return ONE line only (no summary paragraphs): `<slug>: built+pushed <short-sha>` OR
 > `skiplisted <slug>: <reason>` OR `FAILED <slug>: <reason>`.

--- a/.claude/skills/improve-tool/SKILL.md
+++ b/.claude/skills/improve-tool/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: improve-tool
-description: "Use when the user wants to improve/upgrade an existing gizza tool. Takes a tool slug, verifies its three surfaces (chat/LLM API, CLI, page query-params) and fixes any breakage, researches the top 5 competitor tools in parallel, closes every in-model capability/copy/UX/visual gap, re-runs the full test matrix, and opens a review-only PR with a competitor-analysis summary. Fully autonomous; never copies competitor copy or branding; never merges."
+description: "Use when the user wants to improve/upgrade an existing gizza tool. Takes a tool slug, verifies its two locally-verifiable surfaces (CLI, page query-params — the descriptor/schema tests also validate what the chat surface would consume) and fixes any breakage, researches the top 5 competitor tools in parallel, closes every in-model capability/copy/UX/visual gap, re-runs the full test matrix, and opens a review-only PR with a competitor-analysis summary. Fully autonomous; never copies competitor copy or branding; never merges."
 ---
 
 # improve-tool — upgrade an existing gizza tool end to end
@@ -31,11 +31,14 @@ Follow these phases in order:
    (freshly built on a tool-loop branch): then branch from THAT branch and pass it as the
    PR base (`gh pr create --base <branch>`) so the PR diff shows only the improvements.
 
-2. **Phase 1 — Verify the three surfaces, fix any breakage (known-good baseline).** The
-   descriptor single-sources chat/CLI/page/query-params; verify all three live. See
-   reference.md §"Phase 1":
-   - **API** (LLM/chat schema + invoke): `cd blocks/<slug> && cargo test --workspace`; run
-     the wafer `tests/*.json` fixtures; confirm `descriptor()`/`info()` emits the schema.
+2. **Phase 1 — Verify what's locally verifiable, fix any breakage (known-good baseline).** The
+   descriptor single-sources the chat schema/CLI/page/query-params, but only TWO of those surfaces
+   can actually be exercised in THIS repo — **CLI** and **page (query-params)**. The live chat UI
+   is the private site repo's job (it consumes this repo at a pin; chat verification happens on
+   gizza.ai after that repo bumps its pin, not here). See reference.md §"Phase 1":
+   - **Descriptor/schema** (what chat would consume): `cd blocks/<slug> && cargo test --workspace`
+     (incl. the drift-guard); the wafer `tests/*.json` fixtures if the optional `wafer` CLI is
+     installed; confirm `descriptor()`/`info()` emits the schema.
    - **CLI:** `cargo install --path cli --force` then `gizza tool <slug> "<args>"`.
    - **Query params:** Playwright `/tools/<slug>/?<param>=<value>` → field pre-fills + output
      computes.
@@ -92,24 +95,31 @@ Follow these phases in order:
         belong on the page — users shouldn't discover them via an error.
      9. **Errors say what was expected.** "expected X, got Y at Z" — never a bare "error"/
         "invalid input".
-   - **Visual design:** page styling, consistent with the shared `gizza-chrome`. Original only.
+   - **Visual design:** page styling, via the shared `tools/generator/assets/runtime/tool.css` +
+     the generic chrome (`tools/generator/src/site.rs`'s `GENERIC_HEADER`/`GENERIC_FOOTER`) — this
+     repo renders unbranded and page copy must stay that way (a literal `gizza.ai`/
+     `gizza-ai.pages.dev` string under `page/` hard-fails the hygiene gate's check 8); the private
+     site repo re-skins via its own `--site-config` at ITS build time. Original design only.
    - **Drift-guard:** REGENERATE the `authored` schema literal in the block's drift-guard test
      to the new descriptor (do NOT keep the old). Record the before→after schema diff for the
      PR. Keep `manifest.json` `tool.*` consistent with the new `descriptor()`.
 
 6. **Phase 5 — Re-test (the "did we improve it" gate).** Re-run the full matrix
-   (reference.md §"Phase 5"): unit + drift-guard (regenerated) + wafer fixtures + Playwright
-   page **incl. the query-param deep-link** + CLI smoke + `wafer build` / `wasm-pack` /
-   generator / `impresspress build`. Hard gates: pre-existing behavior tests stay GREEN; **each new
-   capability ships with its own test**; API/CLI/query all pass post-edit. ≤3 fix attempts per
-   failure, then escalate (Honesty gate).
+   (reference.md §"Phase 5"): unit + drift-guard (regenerated) + wafer fixtures (if the optional
+   `wafer` CLI is installed) + Playwright page **incl. the query-param deep-link** + CLI smoke +
+   `cargo build --target wasm32-wasip1 --release` / `wasm-pack` / generator. There is no whole-app
+   build here to also run (that belongs to the private site repo). Hard gates: pre-existing
+   behavior tests stay GREEN; **each new capability ships with its own test**; CLI/query all pass
+   post-edit. ≤3 fix attempts per failure, then escalate (Honesty gate).
 
 7. **Phase 6 — Ship (review-only).** Commit; `git push -u origin feat/improve-<slug>`;
    `gh pr create` with the body template in reference.md §"Phase 6" (competitor-analysis
    summary · before→after schema diff · per-dimension change list · Phase-1 fixes ·
    out-of-model features considered · tested+results · limitations). Commit a
    `docs/checks/<YYYY-MM-DD>-improve-<slug>-competitor-analysis.md` snapshot. Run `/code-review`
-   on the diff and post findings as a PR comment. **Do NOT merge.**
+   on the diff and post findings as a PR comment. **Do NOT merge.** Merging (later, by a human)
+   still doesn't publish the change to gizza.ai — the private site repo consumes this repo at a
+   pin, so a pin-bump PR there is the actual publication step (out of scope for this skill).
 
 **Honesty gate:** if a build/test fails unrecoverably (≤3 attempts), STOP and report the
 failure with the error — never open a "done" PR for a broken tool. If fewer than 5 real

--- a/.claude/skills/improve-tool/reference.md
+++ b/.claude/skills/improve-tool/reference.md
@@ -1,23 +1,31 @@
 # improve-tool — reference (per-phase recipes, commands, templates)
 
-Each `blocks/<slug>/` and `tools/generator` are SEPARATE cargo workspaces → `cd` into the
-dir; do NOT use `-p <crate>` from repo root. `wafer build` runs from INSIDE `blocks/<slug>/`.
+This is the public toolkit repo (blocks + `gizza` CLI + the generic tool-page generator; no app,
+no branding, no deploy — those live in a private site repo that consumes this one at a pin). Each
+`blocks/<slug>/` and `tools/generator` are SEPARATE cargo workspaces → `cd` into the dir; do NOT
+use `-p <crate>` from repo root. `cargo build --target wasm32-wasip1 --release` runs from INSIDE
+`blocks/<slug>/` (the optional `wafer build` is an equivalent shorthand if that CLI happens to be
+installed from a sibling `wafer-run` checkout — not required here).
 
-## Phase 1 — verify the three surfaces
+## Phase 1 — verify the two locally-verifiable surfaces (+ the schema tests that gate chat)
 
-The descriptor (`src/lib.rs` `descriptor()`) single-sources the chat schema, CLI, page, and
-URL query-params. Verify all three live, from a known-good baseline:
+The descriptor (`src/lib.rs` `descriptor()`) single-sources the chat schema, CLI, page, and URL
+query-params — but the live chat UI is the private site repo's job (it consumes this repo at a
+pin; chat verification happens on gizza.ai after that repo bumps its pin, not here). What IS fully
+verifiable in THIS repo, from a known-good baseline:
 
-- **API (LLM/chat schema + invoke):**
+- **Descriptor/schema** (what chat would consume):
   - `cd blocks/<slug> && cargo test --workspace` (core + block units, incl. the drift-guard).
     The drift-guard lives in the *block* crate (`gizza-ai-<slug>-block`); a `tail`'d output can
     scroll it off — grep for the test name to confirm it actually ran.
   - `cd blocks/<slug> && wafer test` runs the `tests/*.json` fixtures (each a
-    `{"kind":"invoke","data":[…bytes…],"meta":[]}` invoke payload). It is a no-crash/handles-input
-    smoke gate, NOT an output assertion — assert exact outputs via the CLI + Playwright instead.
-  - Confirm `descriptor()`/`info()` emits the tool schema (it's what the chat LLM sees).
+    `{"kind":"invoke","data":[…bytes…],"meta":[]}` invoke payload) — only if the optional `wafer`
+    CLI is installed (needs a sibling `wafer-run` checkout; not required in this repo — if it's
+    missing, say so and skip, it isn't CI-enforced). It is a no-crash/handles-input smoke gate, NOT
+    an output assertion — assert exact outputs via the CLI + Playwright instead.
+  - Confirm `descriptor()`/`info()` emits the tool schema (it's what the chat LLM would see).
 - **CLI:** `cargo install --path cli --force`, then `gizza tool <slug> "<args>"` returns a
-  correct result (same wasmi runtime + block + schema as chat).
+  correct result (same wasmi runtime + block + schema chat would use).
 - **Query params (page deep-link):** Playwright navigate `/tools/<slug>/?<param>=<value>` and
   assert the field pre-fills and the output computes. (The page reads descriptor params from
   the URL query string.)
@@ -94,7 +102,9 @@ design** (page styling).
   worked examples; layout stability; one-click reset; FAQ accordions; state the limits;
   actionable errors). Shared chrome (dev-group cards, CLI copy buttons, scrollbar styling) lives
   in `tools/generator/src/template.rs` + `tools/generator/assets/runtime/tool.css` — improve it THERE so all tools get it.
-- **Visual design** — page styling consistent with `gizza-chrome`. Original; no competitor assets.
+- **Visual design** — page styling via the shared `tools/generator/assets/runtime/tool.css` + the
+  generic chrome (`tools/generator/src/site.rs`'s `GENERIC_HEADER`/`GENERIC_FOOTER`); this repo
+  renders unbranded and stays that way. Original; no competitor assets.
 
 ### param types across surfaces (GOTCHA — bit me on url-encode)
 
@@ -135,9 +145,10 @@ The block has a unit test pinning `derived == authored` (e.g. url-encode's
 `/improve-tool` schema change is INTENTIONAL, so:
 
 **Ordering (bit two runs):** after any descriptor change run, in this order, before trusting
-manifest state: (0) `cd blocks/<slug> && wafer build` — the sync script reads the descriptor
-embedded in the BUILT wasm/CLI, so syncing against stale wasm reports a silent "already in
-sync"; (1) `cargo install --path cli --force`; (2) `python3 scripts/sync-tool-manifest.py
+manifest state: (0) `cd blocks/<slug> && cargo build --target wasm32-wasip1 --release` (copy the
+wasm to `target/block.wasm`; `wafer build` is an equivalent optional shorthand) — the sync script
+reads the descriptor embedded in the BUILT wasm/CLI, so syncing against stale wasm reports a silent
+"already in sync"; (1) `cargo install --path cli --force`; (2) `python3 scripts/sync-tool-manifest.py
 <slug>` **from the repo root** (it resolves paths relative to cwd). Those are the only three
 CLI-reinstall/sync points — Phase 1 baseline, post-descriptor-change, and Phase 5 re-test all
 reuse this same sequence.
@@ -168,21 +179,26 @@ Do NOT delete the drift-guard test — it stays as the migration guard for the N
 - `cd blocks/<slug> && cargo test --workspace` — unit + drift-guard (regenerated) + core.
 - wafer fixtures — the `tests/*.json` invokes (add one per new capability), IF the family has
   them: pure families do; the ffmpeg family has NONE (family norm — note it, don't invent
-  fixtures that can't run ffmpeg).
+  fixtures that can't run ffmpeg). Run via `wafer test`, only if the optional `wafer` CLI is
+  installed (sibling `wafer-run` checkout); otherwise say so and skip — not CI-enforced.
   Recipe: `python3 -c "import json;print(list(json.dumps({'<param>':'<v>'}).encode()))"` →
   the byte list goes in `{"kind":"invoke","data":[…],"meta":[]}`.
-- `cd blocks/<slug> && wafer build` — wasm32 chat block (from INSIDE the dir; no path arg).
+- `cd blocks/<slug> && cargo build --target wasm32-wasip1 --release && mkdir -p target && cp
+  target/wasm32-wasip1/release/*.wasm target/block.wasm` — wasm32 chat block (from INSIDE the dir;
+  exactly what CI's "Build changed skill wasms" step runs; `wafer build` is an optional equivalent
+  shorthand if that CLI happens to be installed).
 - `wasm-pack build blocks/<slug>/web --target web --release --out-dir pkg` (from repo root).
-- `cargo run --manifest-path tools/generator/Cargo.toml -- .` — renders `pkg/tools/<slug>/`.
-  The generator WARNS AND SKIPS a tool whose `web/pkg/` is missing (as of 2026-07: it no longer
-  hard-aborts — three runs tripped on the stale hard-abort note here). Check the warning list:
-  if YOUR slug was skipped, `wasm-pack build blocks/<slug>/web …` and re-run.
-- `impresspress build` — rebuild app + blocks into `pkg/`. GOTCHA: it iterates+validates EVERY block
-  and aborts on the first that fails — which may be a PRE-EXISTING, unrelated broken block (e.g. a
-  `wasi_snapshot_preview1::sched_yield` validation error), not your tool. Confirm with
-  `cd blocks/<that-block> && wafer build`; if it's unrelated and pre-existing, do NOT fix it here —
-  validate YOUR tool with `cd blocks/<slug> && wafer build` and note the blocked full-app build in
-  the PR (honesty gate). Do not claim `impresspress build` passed if it didn't.
+- `cargo run --manifest-path tools/generator/Cargo.toml -- .` — renders `pkg/tools/<slug>/`,
+  GENERIC (no `--site-config`; this repo has none — the private site repo that consumes this one
+  at a pin renders its own branded copy at ITS build time). The generator WARNS AND SKIPS a tool
+  whose `web/pkg/` is missing (as of 2026-07: it no longer hard-aborts — three runs tripped on the
+  stale hard-abort note here). Check the warning list: if YOUR slug was skipped, `wasm-pack build
+  blocks/<slug>/web …` and re-run.
+- There is no whole-app build to run here anymore (that belonged to the site repo, which consumes
+  this repo at a pin and builds its own branded app separately) — validating YOUR tool's block wasm
+  (above) + the generator run IS the full local build gate; CI's per-PR job builds/tests only the
+  changed blocks the same way, and there's no "aborts on an unrelated pre-existing broken block"
+  failure mode to route around anymore.
 - **Playwright** `tests/tool-page-<slug>.spec.ts` (import from `./fixtures`) — drive
   `/tools/<slug>/`, AND a `?<param>=<value>` deep-link assertion. Add a case per new capability.
 - **CLI** `cargo install --path cli --force` then `gizza tool <slug> "<args>"` — incl. a new
@@ -195,16 +211,22 @@ Do NOT delete the drift-guard test — it stays as the migration guard for the N
 - **Hygiene gate** `python3 scripts/check-tool-hygiene.py <slug>` — MUST exit 0. Enforces the
   standards that silently regressed before: enum params synced into `manifest.json` (run
   `scripts/sync-tool-manifest.py <slug>` after any descriptor change — never hand-sync), FAQ as
-  `<details>` accordions, no scaffold TODOs, summary consistency; per-slug strict mode also gates
-  placeholders, FAQ count, and meta description length. CI runs it repo-wide.
-- Hard gates: pre-existing behavior tests GREEN; every new capability has a test; API/CLI/query
-  pass; hygiene gate exits 0. ≤3 fix attempts per failure, else escalate.
+  `<details>` accordions, no scaffold TODOs, summary consistency, and NO `gizza.ai`/
+  `gizza-ai.pages.dev` string anywhere under `page/` (check 8 — page copy must stay generic;
+  branding is injected site-side, not here); per-slug strict mode also gates placeholders, FAQ
+  count, and meta description length. CI runs it repo-wide.
+- Hard gates: pre-existing behavior tests GREEN; every new capability has a test; CLI/query pass;
+  hygiene gate exits 0. ≤3 fix attempts per failure, else escalate.
 
 ### Known constraints (state in the PR when relevant)
 - **chat ffmpeg is non-functional** — the chat runtime is a Service Worker where `import()`/
   `Worker` are forbidden; ffmpeg tools work via the standalone PAGE + CLI only.
 - **gpu/imagine** — no headless GPU; build the chat block only, no page; CLI is
   `unsupported_in_cli`.
+- **The live chat UI can't be exercised in this repo at all** — it lives in the private site repo
+  that consumes this one at a pin. The descriptor/schema tests (`cargo test --workspace`, the
+  drift-guard) validate the same schema chat would consume; actual chat verification happens on
+  gizza.ai after that repo bumps its pin, not as part of this skill.
 
 ## Phase 6 — ship (review-only)
 
@@ -247,4 +269,6 @@ Do NOT delete the drift-guard test — it stays as the migration guard for the N
 = the 5 paraphrased competitor-profiles + screenshots + the gap list (the archive record).
 
 Then: `gh pr create` (review-only) → `/code-review` on the diff → post findings as a PR
-comment → **do NOT merge**.
+comment → **do NOT merge**. Note in the PR that even once merged, this doesn't publish to
+gizza.ai — the private site repo consumes this repo at a pin, so a separate pin-bump PR there
+(out of scope for this skill) is what actually ships the change.

--- a/.claude/skills/new-tool/SKILL.md
+++ b/.claude/skills/new-tool/SKILL.md
@@ -49,7 +49,11 @@ the build/test/PR commands. Follow these steps in order:
    - `web/src/lib.rs` — the export (pure: `run`; ffmpeg: `build_argv` returning the
      shared `gizza_ai_block_utils::ArgvPlan { argv, out_name }` — already wired by the scaffold).
    - `page/meta.toml` + `page/content.md` — real title/desc/tags/inputs (field ORDER must
-     match the `build_argv` param order for ffmpeg); + `tests/*.json` wafer fixtures.
+     match the `build_argv` param order for ffmpeg); + `tests/*.json` wafer fixtures. **Page copy
+     must stay GENERIC/brand-free** — this repo renders pages unbranded (no `--site-config`); a
+     literal `gizza.ai`/`gizza-ai.pages.dev` string anywhere under `page/` hard-fails the hygiene
+     gate (check 8). Branding (title suffix, header/footer chrome) is injected by the private site
+     repo at ITS build time, not here.
      **Right control for the data, at build time:** check the generator's CURRENT declarative
      kinds (`tools/generator/src/control.rs` + create-next-tool references/page-patterns.md) —
      `kind = "slider"` for bounded numeric ranges, `kind = "color"` for color params (hybrid
@@ -61,7 +65,7 @@ the build/test/PR commands. Follow these steps in order:
      NOT plain `## FAQ` markdown — keep a BLANK LINE inside each `<details>` so the answer's
      markdown renders and wraps in `<p>` (see `blocks/age-calculator`). Plain-markdown FAQ is
      a hard-fail in the hygiene gate.
-   - `manifest.json` — the scaffold generates it (build.rs needs it; `wafer build` does
+   - `manifest.json` — the scaffold generates it (build.rs needs it; building the block wasm does
      NOT). **`tool.parameters` is LOAD-BEARING for the page**: the page form
      (`tools/generator/src/control.rs`) reads the MANIFEST (not the live descriptor) to pick
      each field's control — a param renders as a `<select>` only if its manifest property
@@ -73,20 +77,26 @@ the build/test/PR commands. Follow these steps in order:
      **Summaries:** write ONE clean one-line summary in the macro (no vestigial `"… skill"`
      suffix) — the sync script owns the other two copies. Fill every scaffold `TODO` (title,
      h1, hero, descriptions); the gate fails on any leftover `TODO`.
-7. **Build (in this order):** `wafer build` (from `blocks/<slug>/`); `cargo test --workspace`
-   (from `blocks/<slug>/`); `wasm-pack build blocks/<slug>/web --target web --release --out-dir pkg`;
-   `cargo install --path cli --force`; `python3 scripts/sync-tool-manifest.py <slug>` (regenerates
-   manifest `tool.*` + summaries from the live descriptor — required BEFORE the generator, which
-   reads the manifest); `cargo run --manifest-path tools/generator/Cargo.toml -- .`;
-   `impresspress build` (may be SKIPPED per the create-next-tool throughput rule — `wafer build`
-   already validated this block's wasm and CI runs the full build on deploy; say so in the PR
-   if skipped); and `python3 scripts/check-tool-hygiene.py <slug>` (the hard gate CI
-   enforces — per-slug mode is strict: drifted manifest, plain-markdown FAQ, scaffold TODOs,
-   summary drift, missing placeholders, <3 FAQs, bad meta description length). Fix
-   compile/test failures (≤3 attempts) before escalating. (No SKILL.md to regenerate —
-   the root SKILL.md is static and points agents at `gizza list`/`gizza describe`.)
+7. **Build (in this order):** `cd blocks/<slug> && cargo build --target wasm32-wasip1 --release`
+   then `mkdir -p target && cp target/wasm32-wasip1/release/*.wasm target/block.wasm` (exactly what
+   CI's "Build changed skill wasms" step runs; `wafer build` is an optional equivalent shorthand
+   only if you have the `wafer` CLI installed from a sibling `wafer-run` checkout — not required
+   here); `cargo test --workspace` (from `blocks/<slug>/`); `wasm-pack build blocks/<slug>/web
+   --target web --release --out-dir pkg` (from repo root); `cargo install --path cli --force`;
+   `python3 scripts/sync-tool-manifest.py <slug>` (regenerates manifest `tool.*` + summaries from
+   the live descriptor — required BEFORE the generator, which reads the manifest); `cargo run
+   --manifest-path tools/generator/Cargo.toml -- .` (renders the page GENERIC — no `--site-config`,
+   no branding; this repo has none, the private site repo that consumes this one at a pin renders
+   its own branded copy at ITS build time); and `python3 scripts/check-tool-hygiene.py <slug>` (the
+   hard gate CI enforces — per-slug mode is strict: drifted manifest, plain-markdown FAQ, scaffold
+   TODOs, summary drift, a `gizza.ai`/`gizza-ai.pages.dev` string leaking into `page/` (check 8),
+   missing placeholders, <3 FAQs, bad meta description length). Fix compile/test failures (≤3
+   attempts) before escalating. (No SKILL.md to regenerate — the root SKILL.md is static and points
+   agents at `gizza list`/`gizza describe`.)
 8. **Test (type-aware)** — see reference.md:
-   - unit (always) + wafer fixtures (always);
+   - unit (always) + wafer fixtures (`tests/*.json`, via the optional `wafer test` — if the `wafer`
+     CLI isn't installed, say so and skip; it isn't CI-enforced, `cargo test --workspace` + CLI +
+     Playwright are the load-bearing local checks);
    - **Playwright** the page (pure + ffmpeg): add a spec in `tests/` driving `/tools/<slug>/`.
      The spec MUST assert real output correctness — exact text for pure tools; for media,
      decode the result and assert dimensions/pixels (reference.md §media correctness) — plus
@@ -112,7 +122,10 @@ the build/test/PR commands. Follow these steps in order:
 9. **Ship:** commit, `git push -u origin feat/tool-<slug>`, `gh pr create` with a body that
    states: the tool type, the derived assumptions, what was tested + results, and any
    limitation (e.g. "gpu: no page, no headless verification"; "ffmpeg: chat path is
-   non-functional — runs only on the standalone page / CLI, see the SW-ffmpeg note").
+   non-functional — runs only on the standalone page / CLI, see the SW-ffmpeg note"). Merging this
+   PR doesn't publish the tool to gizza.ai by itself — the private site repo consumes this repo at
+   a pin, so it goes live only after that repo bumps its pin past this commit (a separate PR there,
+   out of scope for this skill).
 10. **Code review:** run `/code-review` on the diff and post the findings as a PR comment.
     Do NOT merge.
 

--- a/.claude/skills/new-tool/reference.md
+++ b/.claude/skills/new-tool/reference.md
@@ -1,11 +1,21 @@
 # new-tool — reference (per-type files, commands, gotchas)
 
 ## Build + test commands (each blocks/<slug>/ and tools/generator are SEPARATE cargo workspaces)
+
+This is the public toolkit repo — no app, no branding, no deploy (those live in a private site
+repo that consumes this one at a pin). Building/testing here never touches that repo.
+
 - `cd blocks/<slug> && cargo test --workspace` — core + block unit tests
-- `cd blocks/<slug> && wafer build` — wasm32 chat block → target/block.wasm (run from INSIDE the dir; NO path arg). It does NOT generate/update `manifest.json` — that file is scaffold-generated and hand-synced (build.rs requires it).
+- `cd blocks/<slug> && cargo build --target wasm32-wasip1 --release && mkdir -p target && cp
+  target/wasm32-wasip1/release/*.wasm target/block.wasm` — wasm32 chat block → target/block.wasm
+  (run from INSIDE the dir; exactly what CI's "Build changed skill wasms" step runs). It does NOT
+  generate/update `manifest.json` — that file is scaffold-generated and hand-synced (build.rs
+  requires it). (Optional equivalent shorthand: `wafer build`, only if you have the `wafer` CLI
+  installed from a sibling `wafer-run` checkout — not required in this repo.)
 - `wasm-pack build blocks/<slug>/web --target web --release --out-dir pkg` — from repo root → web/pkg/<wasm>.js + _bg.wasm
-- `cargo run --manifest-path tools/generator/Cargo.toml -- .` — renders pkg/tools/<slug>/
-- `impresspress build` — rebuild app + all blocks into pkg/
+- `cargo run --manifest-path tools/generator/Cargo.toml -- .` — renders pkg/tools/<slug>/, GENERIC
+  (no `--site-config`; this repo has none — the private site repo renders its own branded copy at
+  ITS build time).
 - `cargo install --path cli --force` then `gizza tool <slug> <args>` — CLI test
 - `python3 scripts/sync-tool-manifest.py <slug>` — AFTER the CLI install: regenerates
   `manifest.json` `tool.parameters`/`tool.description` from the installed CLI's live descriptor
@@ -14,8 +24,10 @@
 - `python3 scripts/check-tool-hygiene.py <slug>` — hard gate (CI runs it repo-wide): fails on a
   manifest whose `tool.parameters` drifted from the descriptor (page renders text not `<select>`), a
   `page/content.md` FAQ written as plain markdown instead of `<details>` accordions, scaffold TODOs,
-  or summary drift. Per-slug mode is STRICT and additionally fails on missing field placeholders,
-  fewer than 3 FAQ entries, and a meta description outside 50–170 chars.
+  summary drift, or a `gizza.ai`/`gizza-ai.pages.dev` string anywhere under `page/` (check 8 — page
+  copy must stay generic; branding is injected site-side, not here). Per-slug mode is STRICT and
+  additionally fails on missing field placeholders, fewer than 3 FAQ entries, and a meta description
+  outside 50–170 chars.
 
 ## Per-type file checklist (fill the scaffold's TODO/stub files)
 
@@ -122,5 +134,9 @@ size via the element (`media.duration > 0`) after `loadedmetadata` — not just 
 - `f64` not `i64` for wasm-bindgen numeric params (else a JS BigInt error at runtime).
 - ffmpeg: meta.toml field order = `build_argv` param order.
 - Each `blocks/<slug>/` and `tools/generator` are separate workspaces → `cd` into the dir; do NOT use `-p <crate>` from the repo root.
-- `wafer build` is run from INSIDE `blocks/<slug>/`.
+- `cargo build --target wasm32-wasip1 --release` (or the optional `wafer build`) is run from INSIDE `blocks/<slug>/`.
 - **CHAT ffmpeg is non-functional**: the runtime runs in a Service Worker where `import()` and `Worker` are spec-forbidden, so ffmpeg can't run in-chat. ffmpeg tools work via their standalone PAGE + the CLI only. State this in ffmpeg tool PRs.
+- **The chat UI itself can't be exercised in this repo** — it lives in the private site repo that
+  consumes this one at a pin. What's verifiable here is the descriptor/schema (`cargo test
+  --workspace`, incl. the drift-guard — the same schema chat would consume), the CLI, and the page.
+  Live chat verification happens on gizza.ai after that repo bumps its pin.


### PR DESCRIPTION
## Summary

Updates `.claude/skills/{create-next-tool,create-tool-loop,improve-tool,new-tool}` (8 of 9 files;
`create-next-tool/references/page-patterns.md` needed no changes) so they describe the post-split
reality of this repo: the public MIT toolkit (blocks + `gizza` CLI + generic tool-page generator),
with the chat app/branding/deploy now living in a private site repo that consumes this one at a pin.

### Per-file changes

- **`create-next-tool/SKILL.md`** — toolchain step: dropped `impresspress`, marked `wafer`
  optional; step 2 throughput note: replaced the "`impresspress build` is the ~25min bottleneck"
  paragraph (no whole-app build exists here anymore) with the real per-tool cargo/wasm-pack/generator
  sequence; step 3 + frontmatter: "3 surfaces (chat/CLI/page)" → "2 locally-verifiable surfaces
  (CLI/page)"; added the genericity rule (check 8) to the hygiene-gate enumeration; added a
  publication note (pin-bump PR in the private site repo, out of scope) to the commit/push step.
- **`create-next-tool/references/{ops,wasm-crates}.md`** — `wafer build`/`impresspress build` →
  `cargo build --target wasm32-wasip1 --release` (+ copy to `target/block.wasm`), `wafer build`
  kept as a noted-optional shorthand; the wasm-instantiation "gate" reframed as the CLI's embedded
  wafer-run/wasmi runtime (`gizza tool ...`), not a standalone `wafer build`.
- **`create-tool-loop/SKILL.md`** — BUILDER PROMPT: same build-command fixes, dropped `xvfb-run`
  from the Playwright command, added check 8 to the hygiene-gate step, added the publication note
  to the ship step. Historical "Operational findings log" entries left untouched (they're incident
  records, not current instructions).
- **`improve-tool/SKILL.md` + `reference.md`** — Phase 1 fully reframed: "three surfaces (chat/LLM
  API, CLI, page query-params)" → "two locally-verifiable surfaces (CLI, page query-params)" +
  the descriptor/schema tests reframed as validating "what chat would consume" rather than being a
  chat surface itself (chat verification is site-side, post pin-bump); Phase 4 visual-design bullet:
  `gizza-chrome` (dependency dropped in #203) → `tools/generator/assets/runtime/tool.css` +
  `site.rs`'s `GENERIC_HEADER`/`GENERIC_FOOTER`; Phase 5: dropped `wafer build`/`impresspress build`,
  **removed** the "`impresspress build` aborts on an unrelated pre-existing broken block" gotcha
  entirely (that failure mode no longer exists — there's no whole-app build); added check 8 to the
  hygiene gate; Phase 6: added the publication note.
- **`new-tool/SKILL.md` + `reference.md`** — this skill never claimed a chat surface (already
  page+CLI only), so no surface-matrix rewrite needed. Added the genericity rule to the page-copy
  step; build step: `wafer build` → `cargo build --target wasm32-wasip1 --release` as primary
  (optional shorthand noted); **dropped the `impresspress build` step entirely** (previously claimed
  "CI runs the full build on deploy" — false, no app/deploy exists in this repo); added check 8 to
  the hygiene gate; added the publication note to the ship step; added a gotcha stating the chat UI
  can't be exercised in this repo at all.

### Grounding

Cross-checked every command against `.github/workflows/test.yml` (CI's actual "Build changed skill
wasms" step), `docs/TOOLCHAIN-SETUP.md` (already updated in the parent commit to mark `wafer`/
`impresspress` optional/absent), `tools/generator/src/site.rs` (`SiteConfig::default()` = generic,
unbranded render), and `cli/src/runtime.rs` (the CLI embeds the wafer-run wasmi runtime directly, so
`gizza tool ...` is what actually gates wasm-instantiation compatibility now).

## Test plan

- [x] `grep -rn 'impresspress\|— gizza\.ai\|site/tool\.\|dist/' .claude/skills/` → clean (verified
      before and after every edit)
- [x] `cargo run --manifest-path tools/generator/Cargo.toml -- . 2>&1 | tail -5` → succeeded,
      rendered generic hub pages
- [x] `python3 scripts/check-tool-hygiene.py` (repo-wide) → `tool-hygiene: OK — 558 tool(s) clean.`
- [x] `python3 scripts/pick-next-tool.py` → returned a valid next-tool line
- [x] Every path/script/exemplar-block referenced by the edited skills confirmed present via
      `git ls-files`
- [ ] Did not run a full block build or Playwright (out of scope per the task) — their exact
      invocation was cross-checked verbatim against CI instead

Full report (per-file diff rationale, grep evidence, flagged concerns):
`.superpowers/sdd/task-10-skills-report.md` (local, gitignored — not part of this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)