### PR TITLE
docs: post-split accuracy fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ public, MIT-licensed toolkit that powers it: the tool implementations
 - `cli/` — the `gizza` binary: runs any block headlessly via the wasmi runtime.
 - `tools/generator/` — renders each block's `page/` into a static, standalone
   HTML page (`pkg/tools/<slug>/`).
-- `js/`, `site/` — small runtime JS/CSS shared by the generated tool pages.
+- `js/` — small runtime JS/CSS shared by the generated tool pages.
 - `tests/` — Playwright end-to-end specs for generated tool pages, plus a few
   `node --test` unit suites (`js/*.test.js`).
 - `scripts/` — toolchain bootstrap, the tool-hygiene gate, and the
@@ -89,7 +89,10 @@ gizza tool calculator "2*2" --json-out               # full {_for_llm,_for_ui} e
 Exit codes: `0` ok · `1` tool error · `2` usage/bad args · `3` unsupported in the
 CLI. Image/video tools shell out to the system `ffmpeg` (install it to use them);
 GPU-only tools (e.g. `imagine`) need a browser GPU and so return an
-`unsupported_in_cli` error here.
+`unsupported_in_cli` error here. `gizza list`/`gizza tool` only cover blocks
+with a committed `target/block.wasm` artifact — currently a subset of
+`blocks/`; blocks without committed wasm still ship pages but aren't yet
+runnable from the CLI.
 
 ### MCP server
 

--- a/site/tools-index.js
+++ b/site/tools-index.js
@@ -1,1 +1,0 @@
-../tools/generator/assets/runtime/tools-index.js

--- a/tools/generator/assets/runtime/header.js
+++ b/tools/generator/assets/runtime/header.js
@@ -1,7 +1,11 @@
 // header.js — mega-menu open/close behavior + Tools search for the shared
-// site chrome rendered by the gizza-chrome crate.
+// site chrome.
 //
-// DOM contract (ids come from chrome/src/lib.rs header()):
+// DOM contract (ids come from the site's header partial, supplied via the
+// generator's `--site-config` `header_html` fragment — see
+// tools/generator/src/site.rs). The default `GENERIC_HEADER` used when no
+// site config (or an empty `header_html`) is set does not contain these
+// elements, so this module simply finds nothing and no-ops:
 //   #explore-trigger  — <button> that opens/closes the mega-menu
 //   #explore-panel    — the <div class="mega-menu"> panel
 //   #explore-search   — <input type="search"> inside the mega-menu

--- a/tools/generator/src/site.rs
+++ b/tools/generator/src/site.rs
@@ -80,15 +80,19 @@ impl SiteConfig {
         if self.footer.is_empty() { GENERIC_FOOTER } else { &self.footer }
     }
 
-    /// Suffix a generator-owned title (landing/hub/pair pages and similar
-    /// synthesized strings — as opposed to per-tool `meta.toml` titles, which
-    /// still carry their own literal " — gizza.ai" until a later migration
-    /// finishes moving them onto `title_suffix` too) with `brand_name` when
-    /// set, unsuffixed otherwise. Deliberately independent of `title_suffix`:
-    /// during the rollout `title_suffix` must stay "" so it doesn't
-    /// double-append onto still-suffixed meta titles, but these
-    /// generator-owned strings have no such legacy suffix to collide with and
-    /// must still reproduce their historical branded text byte-for-byte.
+    /// Suffix a generator-owned title (landing/hub/feed/pair pages and
+    /// similar synthesized strings, as opposed to per-tool `meta.toml`
+    /// titles) with `brand_name` when set, unsuffixed otherwise.
+    ///
+    /// Block `page/meta.toml` titles are brand-free by construction — hygiene
+    /// check 8 rejects any domain string in `page/`, and `title()` above
+    /// appends `title_suffix` to them at render time. `brand_title` is a
+    /// separate mechanism for the generator's own synthesized titles, which
+    /// have no `meta.toml` to hold a suffix and so derive their suffix
+    /// straight from `brand_name` instead of `title_suffix`. Keeping the two
+    /// independent means a site config can set `title_suffix` for per-tool
+    /// titles without also affecting (or being required for) these
+    /// generator-owned titles, and vice versa.
     pub fn brand_title(&self, base: &str) -> String {
         if self.brand_name.is_empty() {
             base.to_string()


### PR DESCRIPTION
## Summary

Three small doc/comment accuracy fixes left over from the wafer-run/impresspress split:

1. **`tools/generator/src/site.rs`** — `brand_title` doc comment described a pre-migration state ("meta.toml titles still carry their own literal ' — gizza.ai'", "title_suffix must stay ''") that no longer exists. Rewritten to describe current behavior: block `page/meta.toml` titles are brand-free (hygiene check 8 enforces it) and get `title_suffix` at render time via `title()`; `brand_title` is a separate mechanism for generator-owned titles (landing/hub/feed/pair pages) that have no `meta.toml` to hold a suffix, so it derives its suffix from `brand_name` independently — avoiding double-suffixing.
2. **`tools/generator/assets/runtime/header.js`** — header comment claimed the DOM contract ids came from a `gizza-chrome` crate (`chrome/src/lib.rs`) that doesn't exist in this repo. Rewritten: the ids come from the site's header partial, injected via the generator's `--site-config` `header_html` fragment; with the default generic header these elements are absent and the module no-ops.
3. **`README.md`** — Layout section listed `site/` as holding runtime JS/CSS shared by generated tool pages, but the only tracked file under `site/` was a vestigial symlink (`site/tools-index.js`) with zero consumers (the js test and `header.js` both import the canonical `tools/generator/assets/runtime/tools-index.js` path directly). Removed the symlink, dropped the `site/` line from Layout, and added a sentence to the CLI section noting `gizza list`/`gizza tool` only cover blocks with a committed `target/block.wasm` artifact (currently 130 of 558 blocks; blocks without committed wasm still ship pages).

## Test plan

- [x] `npm test` — 13/13 green (proves nothing imported the removed symlink)
- [x] `cargo test --manifest-path tools/generator/Cargo.toml` — 117/117 green (doc-comment edit compiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)