### PR TITLE
ci: share one CARGO_TARGET_DIR across per-block builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,14 @@ concurrency:
 
 env:
   CARGO_HTTP_MULTIPLEXING: false
+  # One shared target dir for every cargo invocation in the job. Each
+  # blocks/<slug>/ is a standalone crate; with per-crate target/ dirs a
+  # bulk PR (tool batches, cross-cutting block edits) recompiles the
+  # common dependency tree once per block and needs ~250MB of disk per
+  # block — a 100+-block PR exceeds the runner's disk and the job time
+  # limit. One shared dir compiles common deps once and reuses them
+  # across blocks (mirrors the local-dev shared-target setup).
+  CARGO_TARGET_DIR: /tmp/shared-cargo-target
 
 jobs:
   test:
@@ -125,6 +133,10 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: .
+          # rust-cache follows CARGO_TARGET_DIR; the shared dir for a bulk
+          # block PR runs to tens of GB, which would thrash the 10GB repo
+          # cache quota. Cache the registry/git checkouts only.
+          cache-targets: false
 
       - name: Audit missing skill wasm artifacts
         if: github.event_name != 'pull_request'
@@ -151,8 +163,12 @@ jobs:
             echo "Building changed block: $block"
             (
               cd "blocks/$block"
-              cargo build --target wasm32-wasip1 --release
-              wasm="$(find target/wasm32-wasip1/release -maxdepth 1 -type f -name '*.wasm' | head -n 1)"
+              # With the shared CARGO_TARGET_DIR the artifact no longer lands
+              # under the block's own target/ — take its path from cargo's
+              # JSON message stream instead of find(1).
+              wasm="$(cargo build --target wasm32-wasip1 --release --message-format=json \
+                | jq -r 'select(.reason=="compiler-artifact") | .filenames[] | select(endswith(".wasm"))' \
+                | tail -n 1)"
               if [ -z "$wasm" ]; then
                 echo "No wasm artifact produced for blocks/$block" >&2
                 exit 1


### PR DESCRIPTION
## Summary
Each `blocks/<slug>/` is a standalone crate, so CI's per-block builds recompiled the whole common dependency tree once per changed block (~250MB disk + minutes of compile each). Small tool-batch PRs absorbed that; a bulk cross-cutting block PR — the upcoming SEC-02 capability-declaration migration touches 194 blocks — exceeds the runner's disk and the job time limit.

- Job-wide `CARGO_TARGET_DIR=/tmp/shared-cargo-target`: common deps compile once, all blocks reuse them (mirrors the local-dev shared-target setup in the gitignored `.cargo/config.toml`).
- The changed-block wasm artifact path now comes from cargo's JSON message stream — with a shared target dir it no longer lands under the block's own `target/`.
- `cache-targets: false` on rust-cache: it follows `CARGO_TARGET_DIR`, and the shared dir on a bulk PR runs to tens of GB, which would thrash the 10GB repo cache quota. Registry/git caching stays.

## Testing
- YAML validated locally.
- The real proof will be the follow-up 194-block SEC-02 migration PR running on this workflow; this PR's own run exercises the no-changed-blocks path plus cli/generator/block-utils tests under the shared dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)