### PR TITLE
test(detect-file-type): fix malformed ZIP local-header fixtures

### DIFF
--- a/blocks/detect-file-type/core/src/lib.rs
+++ b/blocks/detect-file-type/core/src/lib.rs
@@ -409,25 +409,23 @@ mod tests {
 
     #[test]
     fn zip_and_ooxml() {
-        // Bare zip with a generic first entry name.
-        let mut z = vec![0x50, 0x4B, 0x03, 0x04];
-        z.extend_from_slice(&[0u8; 24]); // pad so indices 26,27 exist
-        // name_len at 26..28
-        let name = b"hello.txt";
-        z[26] = name.len() as u8;
-        z[27] = 0;
-        z.extend_from_slice(name);
-        assert_eq!(ext_of(&z), "zip");
-
-        // DOCX: first entry under word/
-        let mk_ooxml = |first: &[u8]| {
+        // Minimal ZIP local file header: 30 bytes, name_len at 26..28 (LE),
+        // extra_len at 28..30, entry name from offset 30.
+        let mk_zip = |first: &[u8]| {
             let mut v = vec![0x50, 0x4B, 0x03, 0x04];
-            v.extend_from_slice(&[0u8; 24]);
+            v.extend_from_slice(&[0u8; 26]); // rest of the 30-byte header
             v[26] = first.len() as u8;
             v[27] = 0;
+            // 28..30 (extra_len) stay 0
             v.extend_from_slice(first);
             v
         };
+
+        // Bare zip with a generic first entry name.
+        assert_eq!(ext_of(&mk_zip(b"hello.txt")), "zip");
+
+        // OOXML: first entry under word/ (resp. xl/, ppt/).
+        let mk_ooxml = mk_zip;
         assert_eq!(ext_of(&mk_ooxml(b"word/document.xml")), "docx");
         assert_eq!(ext_of(&mk_ooxml(b"xl/workbook.xml")), "xlsx");
         assert_eq!(ext_of(&mk_ooxml(b"ppt/presentation.xml")), "pptx");


### PR DESCRIPTION
## Summary
`zip_and_ooxml` fails on main: the fixtures build a 28-byte ZIP local header (4-byte magic + 24 pad) so the entry name starts at offset 28, overwriting where `extra_len` belongs — while `detect_zip_payload` correctly reads the name from offset 30 per the ZIP spec. The OOXML assertions see `rd/document.xml` and fall through to plain `zip`; the bare-zip assertion passes only by accident.

Fix the fixtures to build the full 30-byte header (name_len at 26..28 LE, extra_len zeroed at 28..30, name from offset 30). The detection code is untouched — it was right all along.

Surfaced while running all 194 block test suites for the upcoming SEC-02 capability-declaration migration PR, which this pre-existing red would have blocked.

## Testing
- `cargo test --manifest-path blocks/detect-file-type/core/Cargo.toml` — 12/12 pass (was 11 passed / 1 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)