### PR TITLE
fix(cli): grant WRAP network egress in boot_full — network tools never worked on the native CLI path

### DIFF
--- a/cli/src/runtime.rs
+++ b/cli/src/runtime.rs
@@ -196,6 +196,19 @@ pub async fn boot_full() -> Result<ToolRuntime> {
         )
         .map_err(|e| anyhow::anyhow!("register network: {e}"))?;
 
+    // WRAP host grant for network egress. WRAP default-denies typed service
+    // resources unless the HOST grants them — block-declared capabilities are
+    // a separate, second gate. Without this grant every network-using tool
+    // dies with `WRAP: access denied (type: Network)` before its capability
+    // is even consulted. The CLI is a local single-user tool: invoking
+    // `gizza tool web-fetch url=…` IS the user's authorization for that
+    // egress, so grant network to all blocks; per-block capability
+    // declarations still decide which blocks may use it.
+    wafer.add_wrap_grants(vec![wafer_block::types::ResourceGrant::read_write(
+        "*", "*",
+    )
+    .typed(wafer_block::types::ResourceType::Network)]);
+
     // --- Skill WASMs (same loop as boot_minimal) ---
     let mut names = Vec::new();
     let mut metas = Vec::new();

--- a/cli/tests/network_grant.rs
+++ b/cli/tests/network_grant.rs
@@ -1,0 +1,32 @@
+//! The full runtime must authorize skill network egress at the WRAP layer.
+//!
+//! WRAP default-denies typed service resources unless the host grants them;
+//! `boot_full` installs a network grant so tools like web-fetch can reach the
+//! network service at all. These tests don't need working internet: a DNS
+//! failure on an RFC 2606 `.invalid` host proves the request got PAST
+//! authorization and into the network stack.
+
+use gizza_cli::runtime;
+
+/// Error text that would indicate the WRAP grant or capability gate fired.
+fn is_authorization_failure(text: &str) -> bool {
+    text.contains("WRAP") || text.contains("PermissionDenied") || text.contains("permission")
+}
+
+#[tokio::test]
+async fn web_fetch_egress_is_wrap_authorized() {
+    let rt = runtime::boot_full().await.expect("boot");
+    let body = rt
+        .run_tool(
+            "gizza-ai/web-fetch",
+            serde_json::json!({"url": "http://gizza-wrap-grant-test.invalid/"}),
+        )
+        .await
+        .expect("call");
+    let text = String::from_utf8_lossy(&body);
+    // The fetch must fail in the network stack (DNS), not at authorization.
+    assert!(
+        !is_authorization_failure(&text),
+        "network egress was denied at the authorization layer: {text}"
+    );
+}


### PR DESCRIPTION
## Summary
WRAP default-denies typed service resources unless the **host** installs a `ResourceGrant` — block-declared capabilities are a separate, second gate. `boot_full` registered the `wafer-run/network` service block but never granted anything, so every network-using tool failed with `WRAP: access denied … type: Some(Network)` before its capability was even consulted.

This is pre-existing (reproduced on the current `wafer-run-pin.txt` rev and on main's committed wasms) — it's not caused by the SEC-02 migration (#211). It never surfaced because the CLI's e2e tests only exercise pure-compute tools, and the chat/tool-page paths use a different network bridge.

**Fix:** `boot_full` installs `ResourceGrant::read_write("*", "*").typed(Network)`. Rationale: the CLI is a local single-user tool — invoking `gizza tool web-fetch url=…` *is* the user's authorization for that egress. Per-block capabilities still decide which blocks may use the network (and post-#211 those are declared per block, fail-closed).

## Testing
- New `cli/tests/network_grant.rs`: boots the full runtime and fetches an RFC 2606 `.invalid` host — must fail in the network stack (DNS), not at authorization. No internet needed in CI.
- Full `cli` test suite green (41 tests).
- Live verification: `gizza tool web-fetch url=https://example.com` → `{"status":200, …}` (first working native-CLI network fetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)