### PR TITLE
Security quick-wins: decompressor caps + CI comment fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,8 +53,11 @@ jobs:
           set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             # Keep PR feedback fast: validate blocks touched by the PR head commit
-            # (checkout uses github.event.pull_request.head.sha). The full
-            # all-block build still runs on pushes to main.
+            # (checkout uses github.event.pull_request.head.sha).
+            # NOTE: on push to main the block list is empty (see the else branch
+            # below), so per-block cargo tests run ONLY on PRs — there is no
+            # all-block sweep on main yet. A nightly full `cargo test` over
+            # blocks/ is tracked separately in REMEDIATION_PLAN.md (item 2.2).
             if git rev-parse --verify HEAD^ >/dev/null 2>&1; then
               diff_base="HEAD^"
             else

--- a/blocks/7z-extract/core/src/lib.rs
+++ b/blocks/7z-extract/core/src/lib.rs
@@ -22,7 +22,7 @@ use zip::CompressionMethod;
 
 /// Safety caps to avoid decompression bombs.
 const MAX_ENTRIES: usize = 10_000;
-const MAX_TOTAL_BYTES: u64 = 256 * 1024 * 1024; // 256 MiB uncompressed
+const MAX_TOTAL_BYTES: u64 = 16 * 1024 * 1024; // 16 MiB uncompressed (below the 64 MiB wasm sandbox)
 
 /// The 7z file signature: `7z\xBC\xAF\x27\x1C`.
 const SEVENZ_MAGIC: [u8; 6] = [0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C];

--- a/blocks/archive-extractor/core/src/lib.rs
+++ b/blocks/archive-extractor/core/src/lib.rs
@@ -24,7 +24,7 @@ use zip::CompressionMethod;
 
 /// Safety caps to avoid decompression bombs.
 const MAX_ENTRIES: usize = 10_000;
-const MAX_TOTAL_BYTES: u64 = 256 * 1024 * 1024; // 256 MiB uncompressed
+const MAX_TOTAL_BYTES: u64 = 16 * 1024 * 1024; // 16 MiB uncompressed (below the 64 MiB wasm sandbox)
 
 /// The archive / compression format detected from the leading bytes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/blocks/extract-tar/core/src/lib.rs
+++ b/blocks/extract-tar/core/src/lib.rs
@@ -31,7 +31,7 @@ pub struct Extracted {
 
 /// Safety caps to avoid decompression bombs.
 const MAX_ENTRIES: usize = 10_000;
-const MAX_TOTAL_BYTES: u64 = 256 * 1024 * 1024; // 256 MiB uncompressed
+const MAX_TOTAL_BYTES: u64 = 16 * 1024 * 1024; // 16 MiB uncompressed (below the 64 MiB wasm sandbox)
 
 /// Normalize a tar member path to a safe, relative ZIP entry name: strip a
 /// leading `/`, drop `.`/`..` components and Windows drive prefixes. Returns

--- a/blocks/gunzip/core/src/lib.rs
+++ b/blocks/gunzip/core/src/lib.rs
@@ -7,8 +7,10 @@ use std::io::Read;
 
 use flate2::read::GzDecoder;
 
-/// Max decompressed size (guards against gzip bombs).
-const MAX_OUTPUT_BYTES: u64 = 256 * 1024 * 1024; // 256 MiB
+/// Max decompressed size (guards against gzip bombs). Kept well below the
+/// 64 MiB wasm sandbox so a bomb returns a clean error instead of OOM-trapping
+/// while the decompressed bytes are base64-encoded into the output envelope.
+const MAX_OUTPUT_BYTES: u64 = 16 * 1024 * 1024; // 16 MiB
 
 /// Decompress a single-member gzip stream. Returns the decompressed bytes and
 /// the original filename embedded in the gzip header (FNAME), if any.

--- a/blocks/lz4-decompress/core/src/lib.rs
+++ b/blocks/lz4-decompress/core/src/lib.rs
@@ -7,8 +7,10 @@ use std::io::Read;
 
 use lz4_flex::frame::FrameDecoder;
 
-/// Max decompressed size (guards against LZ4 decompression bombs).
-const MAX_OUTPUT_BYTES: u64 = 256 * 1024 * 1024; // 256 MiB
+/// Max decompressed size (guards against LZ4 decompression bombs). Kept well
+/// below the 64 MiB wasm sandbox so a bomb returns a clean error instead of
+/// OOM-trapping while the bytes are base64-encoded into the output envelope.
+const MAX_OUTPUT_BYTES: u64 = 16 * 1024 * 1024; // 16 MiB
 
 /// Decompress an LZ4 **frame** stream. Validates the LZ4 frame magic number
 /// (0x184D2204, little-endian on the wire: `04 22 4D 18`) up front so a wrong

--- a/blocks/lzma-decompress/core/src/lib.rs
+++ b/blocks/lzma-decompress/core/src/lib.rs
@@ -17,6 +17,11 @@ use std::io::Read;
 
 use lzma_rust2::{LzmaReader, XzReader};
 
+/// Max decompressed size (guards against xz/lzma decompression bombs). Kept well
+/// below the 64 MiB wasm sandbox so a bomb returns a clean error instead of
+/// OOM-trapping while the bytes are base64-encoded into the output envelope.
+const MAX_OUTPUT_BYTES: u64 = 16 * 1024 * 1024; // 16 MiB
+
 /// The `.xz` stream-header magic: `FD '7' 'z' 'X' 'Z' 00`.
 const XZ_MAGIC: [u8; 6] = [0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00];
 
@@ -64,8 +69,13 @@ fn decode_xz(data: &[u8]) -> Result<Vec<u8>, String> {
     // allow_multiple_streams = true → concatenated .xz streams decode as one.
     let mut dec = XzReader::new(std::io::Cursor::new(data), true);
     let mut out = Vec::new();
-    dec.read_to_end(&mut out)
+    (&mut dec)
+        .take(MAX_OUTPUT_BYTES + 1)
+        .read_to_end(&mut out)
         .map_err(|e| format!("xz decompression failed: {e}"))?;
+    if out.len() as u64 > MAX_OUTPUT_BYTES {
+        return Err("decompressed data is too large".into());
+    }
     Ok(out)
 }
 
@@ -74,8 +84,13 @@ fn decode_lzma_alone(data: &[u8]) -> Result<Vec<u8>, String> {
     let mut dec = LzmaReader::new_mem_limit(std::io::Cursor::new(data), u32::MAX, None)
         .map_err(|e| format!("invalid .lzma header: {e}"))?;
     let mut out = Vec::new();
-    dec.read_to_end(&mut out)
+    (&mut dec)
+        .take(MAX_OUTPUT_BYTES + 1)
+        .read_to_end(&mut out)
         .map_err(|e| format!("lzma decompression failed: {e}"))?;
+    if out.len() as u64 > MAX_OUTPUT_BYTES {
+        return Err("decompressed data is too large".into());
+    }
     Ok(out)
 }
 
@@ -112,6 +127,17 @@ mod tests {
         let (out, fmt) = lzma_decompress(&xz).unwrap();
         assert!(out.is_empty());
         assert_eq!(fmt, Format::Xz);
+    }
+
+    #[test]
+    fn rejects_decompression_bomb() {
+        // A highly compressible payload expands past the cap; must error cleanly
+        // rather than grow linear memory until the wasm sandbox OOM-traps.
+        let data = vec![0u8; MAX_OUTPUT_BYTES as usize + 1];
+        let xz = xz_compress(&data);
+        assert!(xz.len() < 1024 * 1024, "bomb input should stay tiny");
+        let err = lzma_decompress(&xz).unwrap_err();
+        assert!(err.contains("too large"), "got: {err}");
     }
 
     #[test]

--- a/blocks/lzma-decompress/core/src/lib.rs
+++ b/blocks/lzma-decompress/core/src/lib.rs
@@ -80,8 +80,15 @@ fn decode_xz(data: &[u8]) -> Result<Vec<u8>, String> {
 }
 
 fn decode_lzma_alone(data: &[u8]) -> Result<Vec<u8>, String> {
-    // new_mem_limit parses the .lzma header (props + dict + size). No memory cap.
-    let mut dec = LzmaReader::new_mem_limit(std::io::Cursor::new(data), u32::MAX, None)
+    // Cap the decoder's dictionary allocation. `new_mem_limit` sizes the
+    // dictionary from the .lzma header's declared dict-size field; with no cap a
+    // crafted header can declare a multi-GB dictionary that gets allocated up
+    // front — before any output — and OOM-traps the 64 MiB wasm sandbox, which
+    // the output `.take()` cap below cannot guard. 32 MiB comfortably covers any
+    // dictionary a file actually decodable within the sandbox could use; a larger
+    // declaration is rejected here as a clean error instead of trapping.
+    const MAX_DICT_BYTES: u32 = 32 * 1024 * 1024;
+    let mut dec = LzmaReader::new_mem_limit(std::io::Cursor::new(data), MAX_DICT_BYTES, None)
         .map_err(|e| format!("invalid .lzma header: {e}"))?;
     let mut out = Vec::new();
     (&mut dec)

--- a/blocks/raw-inflate/core/src/lib.rs
+++ b/blocks/raw-inflate/core/src/lib.rs
@@ -13,12 +13,22 @@ use std::io::Read;
 
 use flate2::read::DeflateDecoder;
 
+/// Max decompressed size (guards against DEFLATE decompression bombs). Kept well
+/// below the 64 MiB wasm sandbox so a bomb returns a clean error instead of
+/// OOM-trapping while the bytes are base64-encoded into the output envelope.
+const MAX_OUTPUT_BYTES: u64 = 16 * 1024 * 1024; // 16 MiB
+
 /// Inflate a raw (headerless) DEFLATE stream back to its original bytes.
 pub fn inflate(data: &[u8]) -> Result<Vec<u8>, String> {
     let mut dec = DeflateDecoder::new(data);
     let mut out = Vec::new();
-    dec.read_to_end(&mut out)
+    (&mut dec)
+        .take(MAX_OUTPUT_BYTES + 1)
+        .read_to_end(&mut out)
         .map_err(|e| format!("not a valid raw DEFLATE stream: {e}"))?;
+    if out.len() as u64 > MAX_OUTPUT_BYTES {
+        return Err("decompressed data is too large".into());
+    }
     Ok(out)
 }
 
@@ -47,6 +57,17 @@ mod tests {
         let raw = deflate(&data, 9);
         assert!(raw.len() < data.len() / 10);
         assert_eq!(inflate(&raw).unwrap(), data);
+    }
+
+    #[test]
+    fn rejects_decompression_bomb() {
+        // A few KiB of deflate expands past the cap; must error cleanly rather
+        // than grow linear memory until the wasm sandbox OOM-traps.
+        let data = vec![0u8; MAX_OUTPUT_BYTES as usize + 1];
+        let raw = deflate(&data, 9);
+        assert!(raw.len() < 1024 * 1024, "bomb input should stay tiny");
+        let err = inflate(&raw).unwrap_err();
+        assert!(err.contains("too large"), "got: {err}");
     }
 
     #[test]


### PR DESCRIPTION
Security quick-wins from the AUDIT.md / GIZZA_AI_DEEP_DIVE.md review. Each finding was re-verified against the code before fixing.

## Changes
- **Cap decompressor output below the wasm sandbox.** The 7 decompressor blocks capped only compressed *input*. `raw-inflate` and `lzma-decompress` had no output guard; the other 5 capped at 256 MiB (4× the 64 MiB sandbox), so a crafted small archive OOM-trapped instead of returning a clean error. All output caps lowered to 16 MiB; missing `.take()` guards added; bomb-regression tests added to the two previously-unguarded cores.
- **Correct the false CI comment** claiming the all-block build runs on main (it doesn't — per-block tests are PR-gated).

## Verification
Built with Rust 1.97.0. `cargo test` passes on all 7 cores, including the new `rejects_decompression_bomb` tests (raw-inflate 6/6, lzma 7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)