### PR TITLE
CI hardening + script portability (Phase 2/5)

### DIFF
--- a/.github/workflows/nightly-blocks.yml
+++ b/.github/workflows/nightly-blocks.yml
@@ -1,0 +1,174 @@
+name: Nightly blocks
+
+# The on-PR/on-main "Test" workflow only runs per-block cargo tests for blocks a
+# PR touched (on push to main the changed-block list is empty), and only runs
+# calculator+clock through Playwright. So the full block cargo suite (~6k tests
+# across ~560 crates) and the full standalone tool-page suite (~393 specs) never
+# run on main. This nightly job sweeps both, sharded to stay tractable.
+
+on:
+  schedule:
+    # 03:00 UTC daily — off-peak, after the day's merges have landed on main.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-blocks-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_HTTP_MULTIPLEXING: false
+  # One shared target dir per job (mirrors test.yml): compiles the common block
+  # dependency tree once and reuses it across every block crate in the shard,
+  # instead of a per-crate target/ that would blow the runner's disk.
+  CARGO_TARGET_DIR: /tmp/shared-cargo-target
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Full block cargo-test sweep, sharded across N runners. Each shard tests a
+  # deterministic slice of blocks/<slug>/ (and its core/ crate when present),
+  # mirroring the per-block invocation in test.yml's "Changed block Cargo tests".
+  # ---------------------------------------------------------------------------
+  block-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 10 shards. Bump SHARD_TOTAL and this list together to rebalance.
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    env:
+      SHARD_INDEX: ${{ matrix.shard }}
+      SHARD_TOTAL: 10
+    steps:
+      - name: Free Disk Space
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
+          df -h
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown,wasm32-wasip1
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: .
+          # The shared target dir grows to tens of GB across a shard's blocks;
+          # cache only the registry/git checkouts (matches test.yml).
+          cache-targets: false
+          # Keep shard caches from colliding.
+          key: nightly-block-tests-${{ matrix.shard }}
+
+      - name: Block cargo tests (shard ${{ matrix.shard }}/10)
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t slugs < <(find blocks -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
+          echo "Total blocks: ${#slugs[@]} — this shard: ${SHARD_INDEX}/${SHARD_TOTAL}"
+          i=0
+          ran=0
+          for slug in "${slugs[@]}"; do
+            if [ "$((i % SHARD_TOTAL))" -eq "$SHARD_INDEX" ]; then
+              [ -f "blocks/$slug/Cargo.toml" ] || { i=$((i + 1)); continue; }
+              echo "::group::block $slug"
+              if [ -f "blocks/$slug/core/Cargo.toml" ]; then
+                cargo test --manifest-path "blocks/$slug/core/Cargo.toml"
+              fi
+              cargo test --manifest-path "blocks/$slug/Cargo.toml"
+              echo "::endgroup::"
+              ran=$((ran + 1))
+            fi
+            i=$((i + 1))
+          done
+          echo "Shard ${SHARD_INDEX} tested ${ran} block(s)."
+
+  # ---------------------------------------------------------------------------
+  # Full standalone tool-page Playwright sweep, sharded. Each shard builds the
+  # web wasm for its slice of blocks, regenerates the tool pages, and runs that
+  # slice's tool-page-*.spec.ts under playwright.tool-pages.config.ts (parallel
+  # workers, 60s per-test timeout).
+  # ---------------------------------------------------------------------------
+  tool-pages-playwright:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+    env:
+      SHARD_INDEX: ${{ matrix.shard }}
+      SHARD_TOTAL: 8
+    steps:
+      - name: Free Disk Space
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
+          df -h
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown,wasm32-wasip1
+
+      - name: Install wasm-pack
+        uses: jetli/wasm-pack-action@v0.4.0
+        with:
+          version: 'v0.15.0'
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: .
+          cache-targets: false
+          key: nightly-tool-pages-${{ matrix.shard }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build pages + run tool-page specs (shard ${{ matrix.shard }}/8)
+        working-directory: ${{ github.workspace }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t slugs < <(find blocks -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
+          i=0
+          specs=()
+          for slug in "${slugs[@]}"; do
+            if [ "$((i % SHARD_TOTAL))" -eq "$SHARD_INDEX" ]; then
+              if [ -f "tests/tool-page-$slug.spec.ts" ]; then
+                if [ -d "blocks/$slug/web" ]; then
+                  echo "Building web wasm for $slug"
+                  wasm-pack build "blocks/$slug/web" --target web --release --out-dir pkg
+                fi
+                specs+=("tool-page-$slug.spec.ts")
+              fi
+            fi
+            i=$((i + 1))
+          done
+          if [ "${#specs[@]}" -eq 0 ]; then
+            echo "Shard ${SHARD_INDEX} has no tool-page specs; nothing to do."
+            exit 0
+          fi
+          # Regenerate every tool page into pkg/tools/<slug>/. The generator only
+          # emits interactive pages for tools whose web/pkg exists (built above);
+          # this shard only runs the specs it built, so that is sufficient.
+          cargo run --manifest-path tools/generator/Cargo.toml -- .
+          # Playwright + its deps live in tests/package.json (see test.yml).
+          cd tests
+          npm install --no-audit --no-fund
+          npx playwright install --with-deps chromium
+          npx playwright test --config=playwright.tool-pages.config.ts "${specs[@]}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,16 +55,19 @@ jobs:
             # Keep PR feedback fast: validate blocks touched by the PR head commit
             # (checkout uses github.event.pull_request.head.sha).
             # NOTE: on push to main the block list is empty (see the else branch
-            # below), so per-block cargo tests run ONLY on PRs — there is no
-            # all-block sweep on main yet. A nightly full `cargo test` over
-            # blocks/ is tracked separately in REMEDIATION_PLAN.md (item 2.2).
-            if git rev-parse --verify HEAD^ >/dev/null 2>&1; then
-              diff_base="HEAD^"
-            else
-              base_ref="${{ github.base_ref }}"
-              git fetch origin "$base_ref" --depth=1
-              diff_base="origin/$base_ref"
-            fi
+            # below), so per-block cargo tests run ONLY on PRs — this workflow does
+            # no all-block sweep on main. The full block cargo suite (and the full
+            # tool-page Playwright suite) is swept nightly, sharded, by
+            # .github/workflows/nightly-blocks.yml.
+            # Diff against the MERGE-BASE of the PR target branch and HEAD, not
+            # HEAD^. HEAD^ only sees the PR's final commit, so on a multi-commit
+            # PR block changes made in earlier commits escape detection (and their
+            # blocks never get rebuilt/re-tested). fetch-depth:0 (checkout above)
+            # gives full head history; fetch the base branch too (no --depth, so
+            # the common ancestor is reachable) and take the merge-base.
+            base_ref="${{ github.base_ref }}"
+            git fetch --no-tags origin "$base_ref"
+            diff_base="$(git merge-base "origin/$base_ref" HEAD)"
             # Only rebuild/re-test a block's wasm when a file that affects the
             # compiled output or its cargo tests changed. Doc/metadata edits —
             # page/ (rendered by tools/generator) and manifest.json (consumed by
@@ -198,6 +201,36 @@ jobs:
           if [ "$ran" -eq 0 ]; then
             echo "No block changes detected; skipping block-specific Cargo tests."
           fi
+
+      - name: Tool descriptor drift check
+        # scripts/sync-tool-manifest.py --check flags a block whose manifest.json
+        # tool.description / tool.parameters / summary has drifted from the LIVE
+        # descriptor (what chat and the page form actually consume). The tool
+        # hygiene gate above does NOT cover tool.description drift, so this is the
+        # only gate for it. Scoped to the PR's changed blocks: the corpus still
+        # carries pre-existing description drift, so a repo-wide gate would be red
+        # until it is backfilled — gating the changed blocks stops NEW/regressed
+        # drift from landing. `gizza describe` reads the descriptor embedded in
+        # the CLI (build.rs statically includes blocks/*/target/block.wasm), so we
+        # build it AFTER "Build changed skill wasms" copied the fresh wasm.
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          slugs=()
+          while IFS= read -r block; do
+            [ -n "$block" ] || continue
+            slugs+=("$block")
+          done <<< "${{ steps.changed.outputs.blocks }}"
+          if [ "${#slugs[@]}" -eq 0 ]; then
+            echo "No changed blocks; skipping descriptor drift check."
+            exit 0
+          fi
+          # Build the CLI (reusing the shared cargo target/registry cache) and put
+          # the `gizza` binary on PATH; the sync script shells out to `gizza`.
+          cargo build --release --manifest-path cli/Cargo.toml
+          export PATH="$CARGO_TARGET_DIR/release:$PATH"
+          python3 scripts/sync-tool-manifest.py --check "${slugs[@]}"
 
       - name: CLI tests
         run: cargo test --manifest-path cli/Cargo.toml

--- a/scripts/check-tool-hygiene.test.sh
+++ b/scripts/check-tool-hygiene.test.sh
@@ -2,6 +2,16 @@
 # Self-test for scripts/check-tool-hygiene.py — asserts the gate FAILS on a block
 # with a drifted manifest + plain-markdown FAQ, and PASSES once both are fixed.
 set -euo pipefail
+
+# Portable in-place sed (GNU `sed -i` has no BSD/macOS equivalent: `sed -i`
+# without a suffix consumes the next arg on BSD). Write to a temp file and move
+# it back — identical behavior on GNU and BSD sed.
+sed_inplace() {
+  local expr="$1" file="$2" tmp
+  tmp="$(mktemp)"
+  sed "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+}
+
 root="$(cd "$(dirname "$0")/.." && pwd)"
 slug="zzhygiene-scratch"
 dir="$root/blocks/$slug"
@@ -115,17 +125,17 @@ python3 "$root/scripts/check-tool-hygiene.py" "$slug" >/dev/null 2>&1 || {
 # Repo-wide mode must NOT gate on the strict checks (advisory only): break a
 # strict rule and confirm per-slug fails while the same block passes repo-wide
 # scanning. (Repo-wide still gates checks 1-4.)
-sed -i 's/placeholder = "hello world"/placeholder = ""/' "$dir/page/meta.toml"
+sed_inplace 's/placeholder = "hello world"/placeholder = ""/' "$dir/page/meta.toml"
 out3="$(python3 "$root/scripts/check-tool-hygiene.py" "$slug" 2>&1 || true)"
 grep -q 'NO placeholder' <<<"$out3" || { echo "FAIL: strict mode missed a missing placeholder" >&2; exit 1; }
-sed -i 's/placeholder = ""$/placeholder = "hello world"/' "$dir/page/meta.toml"
+sed_inplace 's/placeholder = ""$/placeholder = "hello world"/' "$dir/page/meta.toml"
 # ^ also gives `mode` a placeholder — harmless, it renders as a <select> (enum)
 
 # Too-short SERP description fails strict.
-sed -i 's/^description = .*/description = "Too short."/' "$dir/page/meta.toml"
+sed_inplace 's/^description = .*/description = "Too short."/' "$dir/page/meta.toml"
 out4="$(python3 "$root/scripts/check-tool-hygiene.py" "$slug" 2>&1 || true)"
 grep -q 'SERP snippet' <<<"$out4" || { echo "FAIL: strict mode missed a bad description length" >&2; exit 1; }
-sed -i 's/^description = .*/description = "Encode or decode data instantly in your browser — free, private, and offline-capable."/' "$dir/page/meta.toml"
+sed_inplace 's/^description = .*/description = "Encode or decode data instantly in your browser — free, private, and offline-capable."/' "$dir/page/meta.toml"
 
 # Fewer than 3 FAQ accordions fails strict.
 cat > "$dir/page/content.md" <<'EOF'
@@ -193,7 +203,8 @@ EOF
 # Site branding (check #8): a page/meta.toml title carrying the literal site
 # suffix must fail — pages must be generic, the site injects branding at
 # render time via SiteConfig.
-sed -i 's/^slug        = "zzhygiene-scratch"$/slug        = "zzhygiene-scratch"\ntitle       = "X — gizza.ai"/' "$dir/page/meta.toml"
+sed_inplace 's/^slug        = "zzhygiene-scratch"$/slug        = "zzhygiene-scratch"\
+title       = "X — gizza.ai"/' "$dir/page/meta.toml"
 out6="$(python3 "$root/scripts/check-tool-hygiene.py" "$slug" 2>&1)" && {
   echo "FAIL: gate passed a block with site branding in page/meta.toml (should have failed)" >&2
   exit 1
@@ -201,7 +212,7 @@ out6="$(python3 "$root/scripts/check-tool-hygiene.py" "$slug" 2>&1)" && {
 grep -q 'site branding' <<<"$out6" || { echo "FAIL: missing site-branding violation" >&2; exit 1; }
 
 # Fixing it (bare title, no brand string) must pass again.
-sed -i '/^title       = "X — gizza\.ai"$/d' "$dir/page/meta.toml"
+sed_inplace '/^title       = "X — gizza\.ai"$/d' "$dir/page/meta.toml"
 python3 "$root/scripts/check-tool-hygiene.py" "$slug" >/dev/null 2>&1 || {
   echo "FAIL: gate rejected a block with no site branding" >&2
   python3 "$root/scripts/check-tool-hygiene.py" "$slug" >&2 || true

--- a/scripts/scaffold-tool.sh
+++ b/scripts/scaffold-tool.sh
@@ -4,6 +4,15 @@
 # Usage: scripts/scaffold-tool.sh <slug> <pure|ffmpeg>
 set -euo pipefail
 
+# Portable in-place sed (GNU `sed -i` has no BSD/macOS equivalent: `sed -i`
+# without a suffix consumes the next arg on BSD). Write to a temp file and move
+# it back — identical behavior on GNU and BSD sed.
+sed_inplace() {
+  local expr="$1" file="$2" tmp
+  tmp="$(mktemp)"
+  sed "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+}
+
 slug="${1:?usage: scaffold-tool.sh <slug> <pure|ffmpeg>}"
 type="${2:?usage: scaffold-tool.sh <slug> <pure|ffmpeg>}"
 # kebab-case [a-z0-9-]; may start with a digit (e.g. 7z-extract) but not a hyphen,
@@ -343,6 +352,6 @@ fi
 
 # The quoted ('EOF') heredocs above can't expand $slug, so their templates use a
 # literal __SLUG__ token — substitute it everywhere in one pass here.
-grep -rl '__SLUG__' "$dir" | while read -r f; do sed -i "s/__SLUG__/${slug}/g" "$f"; done
+grep -rl '__SLUG__' "$dir" | while read -r f; do sed_inplace "s/__SLUG__/${slug}/g" "$f"; done
 
 echo "scaffolded blocks/$slug ($type). Next: implement core/src/lib.rs, src/lib.rs (skill schema), web/src/lib.rs, page/meta.toml, page/content.md."

--- a/tests/playwright.tool-pages.config.ts
+++ b/tests/playwright.tool-pages.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from '@playwright/test';
+
+// Config for the FULL standalone tool-page suite (tool-page-*.spec.ts, ~393
+// specs). The default playwright.config.ts inherited workers:1 /
+// fullyParallel:false / timeout:20min from a WebLLM smoke test whose model
+// download needs those; running the whole tool-page corpus under it is serial
+// and effectively untestable in CI, so only calculator+clock (tool_pages.spec.ts)
+// ran on main. These are fast, pure in-browser compute pages with no model
+// download, so give them real parallelism and a tight per-test timeout.
+//
+// Used by the nightly workflow (.github/workflows/nightly-blocks.yml). The
+// on-PR / on-main lightweight Playwright runs keep using playwright.config.ts.
+export default defineConfig({
+  testDir: '.',
+  // Only the per-tool page specs — never the WebLLM/tool_pages smoke specs.
+  testMatch: /tool-page-.*\.spec\.ts$/,
+  timeout: 60_000, // per test — these pages compute locally in well under a second.
+  expect: { timeout: 15_000 },
+  fullyParallel: true,
+  // A fixed, override-able worker count. GitHub's ubuntu-latest runner has a
+  // handful of vCPUs; 4 keeps each worker responsive without oversubscribing.
+  workers: process.env.PW_WORKERS ? Number(process.env.PW_WORKERS) : 4,
+  use: {
+    baseURL: 'http://localhost:8001',
+    headless: true,
+  },
+  webServer: {
+    // serve_pkg.py sends Cache-Control: no-store so workers never run stale JS
+    // after a page regen. One server is shared across all workers.
+    command: 'python3 serve_pkg.py ../pkg 8001',
+    port: 8001,
+    timeout: 60_000,
+    reuseExistingServer: true,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+});


### PR DESCRIPTION
Phase 2/5 CI + dev-tooling hardening from the remediation plan. Stacked on `security/quick-wins` (PR #217).

## CI (verification layer)
- **Merge-base change detection** — PR diff now against `merge-base(base, HEAD)` not `HEAD^`, so block edits in earlier commits of a multi-commit PR are no longer missed.
- **Tool-description drift gate** — new PR-scoped `sync-tool-manifest.py --check` step fails when a changed block's `src/lib.rs` description drifts from `manifest.json`. Scoped to changed blocks (repo-wide would be red on the ~105-block existing backlog).
- **Nightly sweeps** (`nightly-blocks.yml`) — a 10-shard `cargo test` over all `blocks/` (nothing ran on main before) and an 8-shard full tool-page Playwright run.
- **Parallel Playwright config** (`playwright.tool-pages.config.ts`) — `fullyParallel` + `workers:4` + 60s timeout for the ~393 tool-page specs, instead of the WebLLM smoke test's serial config.

## Scripts
- **Portable `sed`** — GNU-only `sed -i` (fails on macOS/BSD) replaced with a `sed_inplace` temp-file helper in `scaffold-tool.sh` + `check-tool-hygiene.test.sh`; also fixed a latent `\n`-in-replacement BSD bug.

## Verification
Both workflow YAMLs parse; `bash -n` passes on both scripts; the BSD-sed fix was demonstrated on this macOS box. (Nightly workflow logic reviewed, not executed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)