### PR TITLE
chore: gitignore .data/ (local-dev runtime db + storage)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ blocks/*/web/target/
 
 # Playwright MCP debug artifacts (console logs + page snapshots)
 .playwright-mcp/
+
+# Local-dev runtime data (`gizza` serve/chat creates .data/ with a dev db + storage)
+.data/


### PR DESCRIPTION
Running the app locally creates `.data/` (dev sqlite db + storage dir), which then sits untracked in every working copy. Ignore it like the other local-dev artifacts in the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)