### PR TITLE
ci: fix the nightly tool-page sweep (broken 8+ days) and 4 stale specs

### DIFF
--- a/.github/workflows/nightly-blocks.yml
+++ b/.github/workflows/nightly-blocks.yml
@@ -34,6 +34,7 @@ jobs:
   # ---------------------------------------------------------------------------
   block-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 240
     strategy:
       fail-fast: false
       matrix:
@@ -100,6 +101,7 @@ jobs:
   # ---------------------------------------------------------------------------
   tool-pages-playwright:
     runs-on: ubuntu-latest
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
@@ -165,12 +167,40 @@ jobs:
             echo "Shard ${SHARD_INDEX} has no tool-page specs; nothing to do."
             exit 0
           fi
+          # Retry the network steps and bound anything that can hang: this job
+          # runs unattended at 03:00, so a stalled apt mirror or npm registry
+          # burns runner-hours before anyone looks (test.yml carries the same
+          # helpers for the same reason).
+          retry() {
+            local n=1
+            until "$@"; do
+              if [ "$n" -ge 3 ]; then
+                echo "::error::failed after $n attempts: $*"
+                return 1
+              fi
+              echo "attempt $n failed, retrying in 15s: $*"
+              n=$((n + 1))
+              sleep 15
+            done
+          }
+          # The generator copies the @huggingface/transformers runtime out of
+          # the ROOT node_modules for model-backed tool pages and hard-errors
+          # without it. tests/package.json is a different dependency set, and
+          # its install below is too late anyway — every shard of this job has
+          # failed here nightly since the generator gained that requirement.
+          retry npm install --no-audit --no-fund
           # Regenerate every tool page into pkg/tools/<slug>/. The generator only
           # emits interactive pages for tools whose web/pkg exists (built above);
           # this shard only runs the specs it built, so that is sufficient.
           cargo run --manifest-path tools/generator/Cargo.toml -- .
           # Playwright + its deps live in tests/package.json (see test.yml).
           cd tests
-          npm install --no-audit --no-fund
-          npx playwright install --with-deps chromium
+          retry npm install --no-audit --no-fund
+          # --with-deps shells out to apt-get; fall back to the browser-only
+          # install, since the runner image already ships chromium's libraries.
+          install_chromium() {
+            timeout 300s npx playwright install --with-deps chromium \
+              || timeout 300s npx playwright install chromium
+          }
+          retry install_chromium
           npx playwright test --config=playwright.tool-pages.config.ts "${specs[@]}"

--- a/tests/tool-page-audio-waveform-video.spec.ts
+++ b/tests/tool-page-audio-waveform-video.spec.ts
@@ -42,6 +42,21 @@ async function frameStats(page: Page, dataUrl: string, time: number): Promise<St
       await new Promise<void>((res) => {
         v.onseeked = () => res();
       });
+      // onseeked can fire before the seeked frame has actually been painted, and
+      // drawImage then captures an unpainted (black) canvas. That is the flake
+      // that made video-aspect-pad report r=0 on bar pixels in one nightly and
+      // pass unchanged in the next. Wait for a presented frame, fall back to a
+      // rAF pair where requestVideoFrameCallback is unavailable, and always time
+      // out so a stalled decode fails the assertion rather than hanging.
+      await new Promise<void>((res) => {
+        const anyV = v as any;
+        if (typeof anyV.requestVideoFrameCallback === 'function') {
+          anyV.requestVideoFrameCallback(() => res());
+        } else {
+          requestAnimationFrame(() => requestAnimationFrame(() => res()));
+        }
+        setTimeout(() => res(), 2000);
+      });
       const c = document.createElement('canvas');
       c.width = v.videoWidth;
       c.height = v.videoHeight;

--- a/tests/tool-page-plist-viewer.spec.ts
+++ b/tests/tool-page-plist-viewer.spec.ts
@@ -22,8 +22,8 @@ test('plist-viewer converts XML plist to JSON', async ({ page }) => {
 test('plist-viewer tree output and sorted keys', async ({ page }) => {
   await page.goto('/tools/plist-viewer/');
   await page.fill('#in-input', XML);
-  await page.fill('#in-format', 'tree');
-  await page.fill('#in-sort_keys', 'true');
+  await page.selectOption('#in-format', 'tree');
+  await page.setChecked('#in-sort_keys', true);
 
   const out = page.locator('#tool-output');
   await expect(out).toContainText('"Count" => 3', { timeout: 15_000 });

--- a/tests/tool-page-podcast-feed-parser.spec.ts
+++ b/tests/tool-page-podcast-feed-parser.spec.ts
@@ -39,7 +39,7 @@ test('podcast-feed-parser limit and oldest order', async ({ page }) => {
   await page.goto('/tools/podcast-feed-parser/');
   await page.fill('#in-feed', FEED);
   await page.fill('#in-limit', '1');
-  await page.fill('#in-order', 'oldest');
+  await page.selectOption('#in-order', 'oldest');
 
   const out = page.locator('#tool-output');
   await expect(out).toContainText('"episode_count": 1', { timeout: 15_000 });

--- a/tests/tool-page-remove-whitespace.spec.ts
+++ b/tests/tool-page-remove-whitespace.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from './fixtures';
 
 // /tools/remove-whitespace/ trims, collapses, or strips whitespace in-browser (pure wasm).
-// text is a multiline <textarea>; mode + collapse_blank_lines are plain fields.
+// text is a multiline <textarea>; mode is a <select> (its schema is an enum) and
+// collapse_blank_lines is a checkbox.
 
 test('remove-whitespace page trims line edges (default mode)', async ({ page }) => {
   await page.goto('/tools/remove-whitespace/');
@@ -13,13 +14,13 @@ test('remove-whitespace page trims line edges (default mode)', async ({ page }) 
 test('remove-whitespace page collapses internal runs', async ({ page }) => {
   await page.goto('/tools/remove-whitespace/');
   await page.fill('#in-text', 'foo   bar\t\tbaz');
-  await page.fill('#in-mode', 'collapse');
+  await page.selectOption('#in-mode', 'collapse');
   await expect(page.locator('#tool-output')).toHaveText('foo bar baz', { timeout: 15000 });
 });
 
 test('remove-whitespace page strips all whitespace', async ({ page }) => {
   await page.goto('/tools/remove-whitespace/');
   await page.fill('#in-text', 'a b\tc\nd');
-  await page.fill('#in-mode', 'strip');
+  await page.selectOption('#in-mode', 'strip');
   await expect(page.locator('#tool-output')).toHaveText('abcd', { timeout: 15000 });
 });

--- a/tests/tool-page-seconds-to-hms.spec.ts
+++ b/tests/tool-page-seconds-to-hms.spec.ts
@@ -9,26 +9,31 @@ test('seconds-to-hms page converts seconds to default hms', async ({ page }) => 
 test('seconds-to-hms page supports days, iso, words, and fractional seconds', async ({ page }) => {
   await page.goto('/tools/seconds-to-hms/');
   await page.fill('#in-seconds', '90061');
-  await page.fill('#in-format', 'dhms');
+  await page.selectOption('#in-format', 'dhms');
   await expect(page.locator('#tool-output')).toContainText('1:01:01:01', { timeout: 15000 });
 
-  await page.fill('#in-format', 'iso');
+  await page.selectOption('#in-format', 'iso');
   await expect(page.locator('#tool-output')).toContainText('P1DT1H1M1S');
 
-  await page.fill('#in-format', 'words');
+  await page.selectOption('#in-format', 'words');
   await expect(page.locator('#tool-output')).toContainText('1 day, 1 hour, 1 minute, 1 second');
 
   await page.fill('#in-seconds', '90.5');
-  await page.fill('#in-format', 'hms');
+  await page.selectOption('#in-format', 'hms');
   await page.fill('#in-decimals', '1');
   await expect(page.locator('#tool-output')).toContainText('00:01:30.5');
 });
 
-test('seconds-to-hms page supports query-param deep links and validation errors', async ({ page }) => {
+test('seconds-to-hms page supports query-param deep links', async ({ page }) => {
   await page.goto('/tools/seconds-to-hms/?seconds=61&format=auto&decimals=0');
   await expect(page.locator('#in-seconds')).toHaveValue('61');
+  // the deep link also hydrates the <select>, not just the text inputs
+  await expect(page.locator('#in-format')).toHaveValue('auto');
   await expect(page.locator('#tool-output')).toContainText('01:01', { timeout: 15000 });
-
-  await page.fill('#in-format', 'bogus');
-  await expect(page.locator('#tool-output')).toContainText('invalid format');
 });
+
+// An out-of-enum format is unreachable from this page: format renders as a
+// <select>, and applyField() in tool.js assigns el.value, which a <select>
+// rejects when no option matches. The rejection path is covered where it can
+// actually be driven — core's rejects_unknown_format asserts "invalid format".
+

--- a/tests/tool-page-timezone-convert.spec.ts
+++ b/tests/tool-page-timezone-convert.spec.ts
@@ -114,13 +114,14 @@ test('timezone-convert supports multi-target planner', async ({ page }) => {
 test('timezone-convert page has smart defaults on load', async ({ page }) => {
   await page.goto('/tools/timezone-convert/');
 
-  // Datetime input should be pre-filled and match the format YYYY-MM-DDTHH:MM
-  const dtVal = await page.inputValue('#in-datetime');
-  expect(dtVal).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+  // Meta defaults are applied by tool.js only after `await import(cfg.module)`
+  // resolves the tool's wasm, so they are not present the instant goto()
+  // returns. Assert with the auto-retrying matchers rather than a one-shot
+  // inputValue() read, which races that import and reads "".
+  await expect(page.locator('#in-datetime')).toHaveValue(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
 
   // From input should default to browser timezone or fallback
-  const fromVal = await page.inputValue('#in-from');
-  expect(fromVal.length).toBeGreaterThan(0);
+  await expect(page.locator('#in-from')).not.toHaveValue('');
 
   // The tag list should display UTC initially (hidden #in-to carries the value)
   await expect(page.locator('.tool-tag-pill')).toContainText('UTC');

--- a/tests/tool-page-video-aspect-pad.spec.ts
+++ b/tests/tool-page-video-aspect-pad.spec.ts
@@ -32,6 +32,21 @@ async function decodeFrame(
       await new Promise<void>((res) => {
         v.onseeked = () => res();
       });
+      // onseeked can fire before the seeked frame has actually been painted, and
+      // drawImage then captures an unpainted (black) canvas. That is the flake
+      // that made video-aspect-pad report r=0 on bar pixels in one nightly and
+      // pass unchanged in the next. Wait for a presented frame, fall back to a
+      // rAF pair where requestVideoFrameCallback is unavailable, and always time
+      // out so a stalled decode fails the assertion rather than hanging.
+      await new Promise<void>((res) => {
+        const anyV = v as any;
+        if (typeof anyV.requestVideoFrameCallback === 'function') {
+          anyV.requestVideoFrameCallback(() => res());
+        } else {
+          requestAnimationFrame(() => requestAnimationFrame(() => res()));
+        }
+        setTimeout(() => res(), 2000);
+      });
       const c = document.createElement('canvas');
       c.width = v.videoWidth;
       c.height = v.videoHeight;

--- a/tests/tool-page-video-caption-burner.spec.ts
+++ b/tests/tool-page-video-caption-burner.spec.ts
@@ -33,6 +33,21 @@ async function frameStats(page: Page, dataUrl: string, time: number) {
       });
       v.currentTime = time;
       await new Promise<void>((res) => { v.onseeked = () => res(); });
+      // onseeked can fire before the seeked frame has actually been painted, and
+      // drawImage then captures an unpainted (black) canvas. That is the flake
+      // that made video-aspect-pad report r=0 on bar pixels in one nightly and
+      // pass unchanged in the next. Wait for a presented frame, fall back to a
+      // rAF pair where requestVideoFrameCallback is unavailable, and always time
+      // out so a stalled decode fails the assertion rather than hanging.
+      await new Promise<void>((res) => {
+        const anyV = v as any;
+        if (typeof anyV.requestVideoFrameCallback === 'function') {
+          anyV.requestVideoFrameCallback(() => res());
+        } else {
+          requestAnimationFrame(() => requestAnimationFrame(() => res()));
+        }
+        setTimeout(() => res(), 2000);
+      });
       const c = document.createElement('canvas');
       c.width = v.videoWidth;
       c.height = v.videoHeight;

--- a/tests/tool-page-video-fade.spec.ts
+++ b/tests/tool-page-video-fade.spec.ts
@@ -47,6 +47,21 @@ async function decode(
         await new Promise<void>((res) => {
           v.onseeked = () => res();
         });
+        // onseeked can fire before the seeked frame has actually been painted, and
+        // drawImage then captures an unpainted (black) canvas. That is the flake
+        // that made video-aspect-pad report r=0 on bar pixels in one nightly and
+        // pass unchanged in the next. Wait for a presented frame, fall back to a
+        // rAF pair where requestVideoFrameCallback is unavailable, and always time
+        // out so a stalled decode fails the assertion rather than hanging.
+        await new Promise<void>((res) => {
+          const anyV = v as any;
+          if (typeof anyV.requestVideoFrameCallback === 'function') {
+            anyV.requestVideoFrameCallback(() => res());
+          } else {
+            requestAnimationFrame(() => requestAnimationFrame(() => res()));
+          }
+          setTimeout(() => res(), 2000);
+        });
         ctx.drawImage(v, 0, 0);
         const d = ctx.getImageData(0, 0, c.width, c.height).data;
         let total = 0;

--- a/tests/tool-page-video-title-card.spec.ts
+++ b/tests/tool-page-video-title-card.spec.ts
@@ -48,6 +48,21 @@ async function frameStats(page: Page, dataUrl: string, time: number): Promise<St
       await new Promise<void>((res) => {
         v.onseeked = () => res();
       });
+      // onseeked can fire before the seeked frame has actually been painted, and
+      // drawImage then captures an unpainted (black) canvas. That is the flake
+      // that made video-aspect-pad report r=0 on bar pixels in one nightly and
+      // pass unchanged in the next. Wait for a presented frame, fall back to a
+      // rAF pair where requestVideoFrameCallback is unavailable, and always time
+      // out so a stalled decode fails the assertion rather than hanging.
+      await new Promise<void>((res) => {
+        const anyV = v as any;
+        if (typeof anyV.requestVideoFrameCallback === 'function') {
+          anyV.requestVideoFrameCallback(() => res());
+        } else {
+          requestAnimationFrame(() => requestAnimationFrame(() => res()));
+        }
+        setTimeout(() => res(), 2000);
+      });
       const c = document.createElement('canvas');
       c.width = v.videoWidth;
       c.height = v.videoHeight;


### PR DESCRIPTION
The nightly has failed **every night for at least 8 days**. All 10 `block-tests`
shards pass; all 8 `tool-pages-playwright` shards die on:

```
gizza-tool-pages: missing ./node_modules/@huggingface/transformers/dist/transformers.min.js
(run `npm install --no-audit --no-fund` before generating model pages)
```

The job installs `tests/package.json` — a different dependency set — and does it
*after* the generator has already run. This adds the root install before the
generator call.

### Also in here

**Network hardening**, matching `test.yml`. This job runs unattended at 03:00, so
a stalled mirror burns runner-hours before anyone looks — on PR runs this week
five shards sat in `playwright install --with-deps` for over three hours each.
Installs retry, the browser install is bounded and falls back to the
browser-only path when apt is unreachable, and both jobs get a `timeout-minutes`
so nothing can run to the 6h default.

**Four stale specs.** With the generator running again, the suite got far enough
to reveal specs calling `page.fill()` on fields rendered as `<select>` or a
checkbox. These are stale, not a regression: #151 ("fix text-box inputs", 1 Jul)
gave `mode`/`format`/`order`/`sort_keys` an enum or boolean schema, which is
exactly what turns them into a select or checkbox, and the specs predate it.
They have failed ever since unnoticed — the nightly sweep was broken, and the PR
path only runs specs for blocks a PR touches, which none of these have been.

Found by matching every `.fill('#in-<param>')` against that param's schema across
the whole suite: **10 calls in 4 specs**, two more than the nightly had got far
enough to report.

`seconds-to-hms` also asserted `format=bogus` yields "invalid format", which is
now unreachable from the page — `applyField()` assigns `el.value`, and a
`<select>` drops a value with no matching option. Dropped it, noting that
core's `rejects_unknown_format` covers the path where it can actually be driven.

### Verification

Dispatched this branch's nightly (run 32306043213): the generator now runs and
**399–434 specs execute per shard** where previously zero did. The four fixed
specs were additionally run against production with the real suite
(`baseURL=https://gizza.ai`): **10 passed**, and their pre-fix versions fail
there with the same `page.fill` error.

---

### Validation (4 nightly dispatches on this branch)

| run | contents | tool-page shards |
|---|---|---|
| 1 | workflow fix only | 5 of 8 failed — 4 stale specs, 1 timezone race, 1 video flake |
| 2 | + spec fixes | **8 of 8 pass** |
| 3 | + presented-frame wait | 1 failure: `audio-waveform-video` gradient (new, unrelated) |
| 4 | unchanged from 3 | **18 of 18 jobs pass** |

Run 4 is green end to end. The nightly went from every tool-page shard failing
for 8+ days to a clean sweep.

### Known flaky (reported, not patched)

`audio-waveform-video gradient wave fades red-left to blue-right` failed once in
run 3 (`leftRed` 0) and passed in runs 1, 2 and 4 with identical code — so
roughly 1 in 4. It is not the decode race this PR fixes: the test immediately
before it decodes the same output at the same timestamp and passed, and shard
timing was unchanged (1.0m) across runs, showing requestVideoFrameCallback fires
promptly rather than burning its timeout. Its own comment says it exercises the
`gradients/alphaextract/alphamerge` chain, so the intermittent part is most
likely that render. Left alone deliberately — a blind retry would mask what may
be a real intermittent ffmpeg bug, and I have not root-caused it.